### PR TITLE
Make the session library function names shorter - they're unnecessarily long! 

### DIFF
--- a/system/libraries/Cart.php
+++ b/system/libraries/Cart.php
@@ -59,9 +59,9 @@ class CI_Cart {
 		$this->CI->load->library('session', $config);
 
 		// Grab the shopping cart array from the session table, if it exists
-		if ($this->CI->session->userdata('cart_contents') !== FALSE)
+		if ($this->CI->session->get('cart_contents') !== FALSE)
 		{
-			$this->_cart_contents = $this->CI->session->userdata('cart_contents');
+			$this->_cart_contents = $this->CI->session->get('cart_contents');
 		}
 		else
 		{
@@ -397,7 +397,7 @@ class CI_Cart {
 		// Is our cart empty?  If so we delete it from the session
 		if (count($this->_cart_contents) <= 2)
 		{
-			$this->CI->session->unset_userdata('cart_contents');
+			$this->CI->session->rm('cart_contents');
 
 			// Nothing more to do... coffee time!
 			return FALSE;
@@ -405,7 +405,7 @@ class CI_Cart {
 
 		// If we made it this far it means that our cart has data.
 		// Let's pass it to the Session class so it can be stored
-		$this->CI->session->set_userdata(array('cart_contents' => $this->_cart_contents));
+		$this->CI->session->set(array('cart_contents' => $this->_cart_contents));
 
 		// Woot!
 		return TRUE;
@@ -541,7 +541,7 @@ class CI_Cart {
 		$this->_cart_contents['cart_total'] = 0;
 		$this->_cart_contents['total_items'] = 0;
 
-		$this->CI->session->unset_userdata('cart_contents');
+		$this->CI->session->rm('cart_contents');
 	}
 
 

--- a/system/libraries/Session.php
+++ b/system/libraries/Session.php
@@ -395,7 +395,7 @@ class CI_Session {
 	 * @access	public
 	 * @return	void
 	 */
-	function sess_destroy()
+	function destroy()
 	{
 		// Kill the session DB row
 		if ($this->sess_use_database === TRUE AND isset($this->userdata['session_id']))
@@ -424,7 +424,7 @@ class CI_Session {
 	 * @param	string
 	 * @return	string
 	 */
-	function userdata($item)
+	function get($item)
 	{
 		return ( ! isset($this->userdata[$item])) ? FALSE : $this->userdata[$item];
 	}
@@ -437,7 +437,7 @@ class CI_Session {
 	 * @access	public
 	 * @return	array
 	 */
-	function all_userdata()
+	function get_all()
 	{
 		return $this->userdata;
 	}
@@ -452,7 +452,7 @@ class CI_Session {
 	 * @param	string
 	 * @return	void
 	 */
-	function set_userdata($newdata = array(), $newval = '')
+	function set($newdata = array(), $newval = '')
 	{
 		if (is_string($newdata))
 		{
@@ -478,7 +478,7 @@ class CI_Session {
 	 * @access	array
 	 * @return	void
 	 */
-	function unset_userdata($newdata = array())
+	function rm($newdata = array())
 	{
 		if (is_string($newdata))
 		{
@@ -519,7 +519,7 @@ class CI_Session {
 			foreach ($newdata as $key => $val)
 			{
 				$flashdata_key = $this->flashdata_key.':new:'.$key;
-				$this->set_userdata($flashdata_key, $val);
+				$this->set($flashdata_key, $val);
 			}
 		}
 	}
@@ -540,10 +540,10 @@ class CI_Session {
 		// Note the function will return FALSE if the $key
 		// provided cannot be found
 		$old_flashdata_key = $this->flashdata_key.':old:'.$key;
-		$value = $this->userdata($old_flashdata_key);
+		$value = $this->get($old_flashdata_key);
 
 		$new_flashdata_key = $this->flashdata_key.':new:'.$key;
-		$this->set_userdata($new_flashdata_key, $value);
+		$this->set($new_flashdata_key, $value);
 	}
 
 	// ------------------------------------------------------------------------
@@ -558,7 +558,7 @@ class CI_Session {
 	function flashdata($key)
 	{
 		$flashdata_key = $this->flashdata_key.':old:'.$key;
-		return $this->userdata($flashdata_key);
+		return $this->get($flashdata_key);
 	}
 
 	// ------------------------------------------------------------------------
@@ -572,15 +572,15 @@ class CI_Session {
 	 */
 	function _flashdata_mark()
 	{
-		$userdata = $this->all_userdata();
+		$userdata = $this->get_all();
 		foreach ($userdata as $name => $value)
 		{
 			$parts = explode(':new:', $name);
 			if (is_array($parts) && count($parts) === 2)
 			{
 				$new_name = $this->flashdata_key.':old:'.$parts[1];
-				$this->set_userdata($new_name, $value);
-				$this->unset_userdata($name);
+				$this->set($new_name, $value);
+				$this->unset($name);
 			}
 		}
 	}
@@ -596,12 +596,12 @@ class CI_Session {
 
 	function _flashdata_sweep()
 	{
-		$userdata = $this->all_userdata();
+		$userdata = $this->get_all();
 		foreach ($userdata as $key => $value)
 		{
 			if (strpos($key, ':old:'))
 			{
-				$this->unset_userdata($key);
+				$this->unset($key);
 			}
 		}
 
@@ -767,6 +767,37 @@ class CI_Session {
 			log_message('debug', 'Session garbage collection performed.');
 		}
 	}
+	
+	// --------------------------------------------------------------------
+	
+	/**
+	 * Backwards compatible functions
+	 */
+	 
+	 function userdata($item)
+	 {
+	 	return $this->get($item);
+	 }
+	 
+	 function all_userdata()
+	 {
+	 	return $this->get_all();
+	 }
+	 
+	 function set_userdata($newdata)
+	 {
+	 	$this->set($newdata);
+	 }
+	 
+	 function unset_userdata($newdata)
+	 {
+	 	$this->rm($newdata);
+	 }
+	 
+	 function sess_destroy()
+	 {
+	 	$this->destroy(); 
+	 }
 
 
 }


### PR DESCRIPTION
I've renamed some of the session functions to make them much shorter because I think they're too long.

$this->session->userdata($item) becomes $this->session->get($item)

$this->session->set_userdata($data) becomes $this->session->set($data)

$this->session->unset_userdata($data) becomes $this->session->rm($data)

I've included the original functions at the bottom which call the new ones (instead of repeating code).
I've also updated the cart library to use the new functions.
