### PR TITLE
Added ability for db like param $side to use 'none'

### DIFF
--- a/system/database/DB_active_rec.php
+++ b/system/database/DB_active_rec.php
@@ -660,8 +660,12 @@ class CI_DB_active_record extends CI_DB_driver {
 			$prefix = (count($this->ar_like) == 0) ? '' : $type;
 
 			$v = $this->escape_like_str($v);
-
-			if ($side == 'before')
+			
+			if ($side == 'none')
+			{
+				$like_statement = $prefix." $k $not LIKE '{$v}'";
+			}
+			elseif ($side == 'before')
 			{
 				$like_statement = $prefix." $k $not LIKE '%{$v}'";
 			}


### PR DESCRIPTION
Added ability for _like param side to use 'none', in case one wants to query like instead of where without case being sensitive
