### PR TITLE
A few small tweaks to CI_Email

### DIFF
--- a/system/libraries/Email.php
+++ b/system/libraries/Email.php
@@ -477,12 +477,12 @@ class CI_Email {
 	 * Set Wordwrap
 	 *
 	 * @access	public
-	 * @param	string
+	 * @param	bool
 	 * @return	void
 	 */
 	public function set_wordwrap($wordwrap = TRUE)
 	{
-		$this->wordwrap = ($wordwrap === FALSE) ? FALSE : TRUE;
+		$this->wordwrap = (bool) $wordwrap;
 		return $this;
 	}
 


### PR DESCRIPTION
- Changed set_alt_message() to cast the message a string to prevent possible issues when sending NULL or FALSE.
- Changed set_wordwrap() to cast the parameter as a boolean instead of using a ternary. Also fixed the doc block.
