### PR TITLE
Changed the 'development' environment default error reporting.

### DIFF
--- a/index.php
+++ b/index.php
@@ -33,7 +33,7 @@ if (defined('ENVIRONMENT'))
 	switch (ENVIRONMENT)
 	{
 		case 'development':
-			error_reporting(E_ALL | E_STRICT);
+			error_reporting(-1);
 		break;
 	
 		case 'testing':


### PR DESCRIPTION
Changed the 'development' environment default error reporting to included E_STRICT errors.  E_ALL does not include these errors.  See http://php.net/manual/en/migrating5.errorrep.php for more details.
