### PR TITLE
Fix #31: Changing to set as add will not save over existing value

### DIFF
--- a/system/libraries/Cache/drivers/Cache_memcached.php
+++ b/system/libraries/Cache/drivers/Cache_memcached.php
@@ -64,7 +64,7 @@ class CI_Cache_memcached extends CI_Driver {
 	 */
 	public function save($id, $data, $ttl = 60)
 	{
-		return $this->_memcached->add($id, array($data, time(), $ttl), $ttl);
+		return $this->_memcached->set($id, array($data, time(), $ttl), $ttl);
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
This is fixing issue 31 - the add() method does not write over an existing key, set() does, and will add a key if it does not exist.
