### PR TITLE
Fix #227: Fall through allows for spoofing of ip_address()

### DIFF
--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -287,7 +287,7 @@ class CI_Input {
 
 			$this->ip_address = in_array($_SERVER['REMOTE_ADDR'], $proxies) ? $_SERVER['HTTP_X_FORWARDED_FOR'] : $_SERVER['REMOTE_ADDR'];
 		}
-		elseif ($this->server('REMOTE_ADDR') AND ! $this->server('HTTP_CLIENT_IP'))
+		elseif (! $this->server('HTTP_CLIENT_IP') AND $this->server('REMOTE_ADDR'))
 		{
 			$this->ip_address = $_SERVER['REMOTE_ADDR'];
 		}


### PR DESCRIPTION
This is explained in the issue quite well. I changed the order of the if-check for short-circuit. 
