### PR TITLE
Fix #106: select_max() problem with Reserved Words

### DIFF
--- a/system/database/DB_active_rec.php
+++ b/system/database/DB_active_rec.php
@@ -196,7 +196,7 @@ class CI_DB_active_record extends CI_DB_driver {
 			$alias = $this->_create_alias_from_table(trim($select));
 		}
 
-		$sql = $type.'('.$this->_protect_identifiers(trim($select)).') AS '.$alias;
+		$sql = $type.'('.$this->_protect_identifiers(trim($select)).') AS '.$this->_protect_identifiers(trim($alias));
 
 		$this->ar_select[] = $sql;
 


### PR DESCRIPTION
Fix for issue #106

Fixes issue in select_max(), select_min(), select_avg() and select_sum() when trying to select a column with a reserved name, due to the alias not being escaped.
