### PR TITLE
Fix #178: Check if the file (directory) exists before deleting in Cache_file.php

### DIFF
--- a/system/libraries/Cache/drivers/Cache_file.php
+++ b/system/libraries/Cache/drivers/Cache_file.php
@@ -107,10 +107,10 @@ class CI_Cache_file extends CI_Driver {
 	 */
 	public function delete($id)
 	{
-                if ( ! file_exists($this->_cache_path.$id)) 
-                {
-                        return FALSE;
-                }
+		if ( ! file_exists($this->_cache_path.$id)) 
+		{
+			return FALSE;
+		}
 
 		return unlink($this->_cache_path.$id);
 	}

--- a/user_guide/changelog.html
+++ b/user_guide/changelog.html
@@ -108,6 +108,7 @@ Change Log
 	<li class="reactor">Fixed a bug where not setting 'null' when adding fields in db_forge for mysql and mysqli drivers would default to NULL instead of NOT NULL as the docs suggest.</li>
 	<li class="reactor">Fixed a bug where using <kbd>$this->db->select_max()</kdb>, <kbd>$this->db->select_min()</kdb>, etc could throw notices. Thanks to w43l for the patch.</li>
 	<li class="reactor">Replace checks for STDIN with php_sapi_name() == 'cli' which on the whole is more reliable. This should get parameters in crontab working.</li>
+	<li class="reactor">Fixed issue #178: Checking if file exists before performing unlink() operation to get rid of warning message.</li>
 </ul>
 
 <h2>Version 2.0.2</h2>


### PR DESCRIPTION
Question is should we return FALSE or TRUE is the directory does not exist? My suggestion is FALSE, as the operation was not performed.
