### PR TITLE
Fix #109: Implementing atomic increment / decrement in cache library

### DIFF
--- a/system/libraries/Cache/Cache.php
+++ b/system/libraries/Cache/Cache.php
@@ -79,7 +79,7 @@ class CI_Cache extends CI_Driver_Library {
 	 */
 	public function save($id, $data, $ttl = 60, $raw = FALSE)
 	{
-                return $this->{$this->_adapter}->save($id, $data, $ttl, $raw);
+		return $this->{$this->_adapter}->save($id, $data, $ttl, $raw);
 	}
 
 	// ------------------------------------------------------------------------
@@ -95,35 +95,35 @@ class CI_Cache extends CI_Driver_Library {
 		return $this->{$this->_adapter}->delete($id);
 	}
 
-        // ------------------------------------------------------------------------
+	// ------------------------------------------------------------------------
 
-        /**
-         * Perform increment on key.
-         * 
-         * @param       key             unique identifier of the item in the cache
-         * @param       offset          offset increment to perform
-         * @return      boolean         new value on success/false on failure
-         */
-        public function increment($id, $offset = 1)
-        {
-                return $this->{$this->_adapter}->increment($id, $offset);
-        }
+	/**
+ 	* Perform increment on key.
+ 	* 
+ 	* @param       key             unique identifier of the item in the cache
+ 	* @param       offset          offset increment to perform
+ 	* @return      boolean         new value on success/false on failure
+ 	*/
+	public function increment($id, $offset = 1)
+	{
+		return $this->{$this->_adapter}->increment($id, $offset);
+	}
 
-        // ------------------------------------------------------------------------
+	// ------------------------------------------------------------------------
 
-        /**
-         * Perform decrement on key.
-         * 
-         * @param       key             unique identifier of the item in the cache
-         * @param       offset          offset decrement to perform
-         * @return      boolean         new value on success/false on failure
-         */
-        public function decrement($id, $offset = 1)
-        {
-                return $this->{$this->_adapter}->decrement($id, $offset);
-        }
+	/**
+ 	* Perform decrement on key.
+ 	* 
+ 	* @param       key             unique identifier of the item in the cache
+ 	* @param       offset          offset decrement to perform
+ 	* @return      boolean         new value on success/false on failure
+ 	*/
+	public function decrement($id, $offset = 1)
+	{
+		return $this->{$this->_adapter}->decrement($id, $offset);
+	}
 
-        // ------------------------------------------------------------------------
+	// ------------------------------------------------------------------------
 
 	/**
 	 * Clean the cache

--- a/system/libraries/Cache/drivers/Cache_apc.php
+++ b/system/libraries/Cache/drivers/Cache_apc.php
@@ -78,35 +78,35 @@ class CI_Cache_apc extends CI_Driver {
 		return apc_delete($id);
 	}
 
-        // ------------------------------------------------------------------------
+    // ------------------------------------------------------------------------
 
-        /**
-         * Perform increment on key.
-         * 
-         * @param       key             unique identifier of the item in the cache
-         * @param       offset          offset increment to perform
-         * @return      boolean         new value on success/false on failure
-         */
-        public function increment($id, $offset)
-        {
-                return apc_inc($id, $offset);
-        }
+    /**
+     * Perform increment on key.
+     * 
+     * @param       key             unique identifier of the item in the cache
+     * @param       offset          offset increment to perform
+     * @return      boolean         new value on success/false on failure
+     */
+    public function increment($id, $offset)
+    {
+            return apc_inc($id, $offset);
+    }
 
-        // ------------------------------------------------------------------------
+    // ------------------------------------------------------------------------
 
-        /**
-         * Perform decrement on key.
-         * 
-         * @param       key             unique identifier of the item in the cache
-         * @param       offset          offset decrement to perform
-         * @return      boolean         new value on success/false on failure
-         */
-        public function decrement($id, $offset)
-        {
-                return apc_dec($id, $offset);
-        }
+    /**
+     * Perform decrement on key.
+     * 
+     * @param       key             unique identifier of the item in the cache
+     * @param       offset          offset decrement to perform
+     * @return      boolean         new value on success/false on failure
+     */
+    public function decrement($id, $offset)
+    {
+            return apc_dec($id, $offset);
+    }
 
-        // ------------------------------------------------------------------------
+    // ------------------------------------------------------------------------
 
 	/**
 	 * Clean the cache

--- a/system/libraries/Cache/drivers/Cache_dummy.php
+++ b/system/libraries/Cache/drivers/Cache_dummy.php
@@ -70,35 +70,35 @@ class CI_Cache_dummy extends CI_Driver {
 		return TRUE;
 	}
 
-        // ------------------------------------------------------------------------
+    // ------------------------------------------------------------------------
 
-        /**
-         * Perform increment on key.
-         * 
-         * @param       key             unique identifier of the item in the cache
-         * @param       offset          offset increment to perform
-         * @return      boolean         FALSE
-         */
-        public function increment($id, $offset)
-        {
-                return FALSE;
-        }
+    /**
+     * Perform increment on key.
+     * 
+     * @param       key             unique identifier of the item in the cache
+     * @param       offset          offset increment to perform
+     * @return      boolean         FALSE
+     */
+    public function increment($id, $offset)
+    {
+        return FALSE;
+    }
 
-        // ------------------------------------------------------------------------
+    // ------------------------------------------------------------------------
 
-        /**
-         * Perform decrement on key.
-         * 
-         * @param       key             unique identifier of the item in the cache
-         * @param       offset          offset decrement to perform
-         * @return      boolean         FALSE
-         */
-        public function decrement($id, $offset)
-        {
-                return FALSE;
-        }
+    /**
+     * Perform decrement on key.
+     * 
+     * @param       key             unique identifier of the item in the cache
+     * @param       offset          offset decrement to perform
+     * @return      boolean         FALSE
+     */
+    public function decrement($id, $offset)
+    {
+        return FALSE;
+    }
 
-        // ------------------------------------------------------------------------
+    // ------------------------------------------------------------------------
 
 	/**
 	 * Clean the cache

--- a/system/libraries/Cache/drivers/Cache_file.php
+++ b/system/libraries/Cache/drivers/Cache_file.php
@@ -98,39 +98,39 @@ class CI_Cache_file extends CI_Driver {
 		return FALSE;
 	}
 
-        // ------------------------------------------------------------------------
+    // ------------------------------------------------------------------------
 
-        /**
-         * Perform increment on key.
-         * 
-         * @param       key             unique identifier of the item in the cache
-         * @param       offset          offset increment to perform
-         * @return      boolean         FALSE
-         */
-        public function increment($id, $offset)
-        {
-                $data = $this->get($id);
+    /**
+     * Perform increment on key.
+     * 
+     * @param       key             unique identifier of the item in the cache
+     * @param       offset          offset increment to perform
+     * @return      boolean         FALSE
+     */
+    public function increment($id, $offset)
+    {
+        $data = $this->get($id);
 
-                return (is_array($data)) ? FALSE : ($data + $offset);
-        }
+        return (is_array($data)) ? FALSE : ($data + $offset);
+    }
 
-        // ------------------------------------------------------------------------
+    // ------------------------------------------------------------------------
 
-        /**
-         * Perform decrement on key.
-         * 
-         * @param       key             unique identifier of the item in the cache
-         * @param       offset          offset decrement to perform
-         * @return      boolean         FALSE
-         */
-        public function decrement($id, $offset)
-        {
-                $data = $this->get($id);
+    /**
+     * Perform decrement on key.
+     * 
+     * @param       key             unique identifier of the item in the cache
+     * @param       offset          offset decrement to perform
+     * @return      boolean         FALSE
+     */
+    public function decrement($id, $offset)
+    {
+    	$data = $this->get($id);
 
-                return (is_array($data)) ? FALSE : ($data - $offset);
-        }
+        return (is_array($data)) ? FALSE : ($data - $offset);
+    }
 
-        // ------------------------------------------------------------------------
+    // ------------------------------------------------------------------------
 
 	/**
 	 * Delete from Cache

--- a/system/libraries/Cache/drivers/Cache_memcached.php
+++ b/system/libraries/Cache/drivers/Cache_memcached.php
@@ -88,31 +88,31 @@ class CI_Cache_memcached extends CI_Driver {
 
 	// ------------------------------------------------------------------------
 
-        /**
-         * Perform increment on key.
-         * 
-         * @param       key             unique identifier of the item in the cache
-         * @param       offset          offset increment to perform
-         * @return      boolean         new value on success/false on failure
-         */
-        public function increment($id, $offset)
-        {
-                 return $this->_memcached->increment($id, $offset);
-        }
+    /**
+     * Perform increment on key.
+     * 
+     * @param       key             unique identifier of the item in the cache
+     * @param       offset          offset increment to perform
+     * @return      boolean         new value on success/false on failure
+     */
+    public function increment($id, $offset)
+    {
+        return $this->_memcached->increment($id, $offset);
+    }
 
 	// ------------------------------------------------------------------------
 
-        /**
-         * Perform decrement on key.
-         * 
-         * @param       key             unique identifier of the item in the cache
-         * @param       offset          offset decrement to perform
-         * @return      boolean         new value on success/false on failure
-         */
-        public function decrement($id, $offset)
-        {
-                return $this->_memcached->decrement($id, $offset);
-        }
+    /**
+     * Perform decrement on key.
+     * 
+     * @param       key             unique identifier of the item in the cache
+     * @param       offset          offset decrement to perform
+     * @return      boolean         new value on success/false on failure
+     */
+    public function decrement($id, $offset)
+    {
+    	return $this->_memcached->decrement($id, $offset);
+    }
 
 	// ------------------------------------------------------------------------
 	

--- a/user_guide/changelog.html
+++ b/user_guide/changelog.html
@@ -108,6 +108,7 @@ Change Log
 	<li class="reactor">Fixed a bug where not setting 'null' when adding fields in db_forge for mysql and mysqli drivers would default to NULL instead of NOT NULL as the docs suggest.</li>
 	<li class="reactor">Fixed a bug where using <kbd>$this->db->select_max()</kdb>, <kbd>$this->db->select_min()</kdb>, etc could throw notices. Thanks to w43l for the patch.</li>
 	<li class="reactor">Replace checks for STDIN with php_sapi_name() == 'cli' which on the whole is more reliable. This should get parameters in crontab working.</li>
+	<li class="reactor">Fixed issue #109: Adding increment and decrement operations to Cache::Memcache and Cache::APC, stubbed out in Cache::Dummy and emulated operation in Cache::File</li>
 </ul>
 
 <h2>Version 2.0.2</h2>


### PR DESCRIPTION
This required an additional parameter to be added to save that allows for the raw value to be stored. The only side effect is that now get_metadata() will fail. 
