### PR TITLE
Fix for #36 and #199, -1 value and int check for db->limit()

### DIFF
--- a/system/database/DB_active_rec.php
+++ b/system/database/DB_active_rec.php
@@ -874,11 +874,22 @@ class CI_DB_active_record extends CI_DB_driver {
 	 */
 	public function limit($value, $offset = '')
 	{
-		$this->ar_limit = (int) $value;
-
-		if ($offset != '')
+		if(is_int($value) && $value >= 0)
 		{
-			$this->ar_offset = (int) $offset;
+			$this->ar_limit = $value;
+		}
+		else
+		{
+			$this->ar_limit = 1000000;
+		}
+
+		if ($offset != '' && is_int($offset) && $offset >= 0)
+		{
+			$this->ar_offset = $offset;
+		}
+		else if ($offset != '' && !is_int($offset) || $offset < 0)
+		{
+			$this->ar_offset = '';
 		}
 
 		return $this;


### PR DESCRIPTION
If the limit value is not a valid number or is negative, it sets a value of 1000000. This so we still can use the offset option. If I set the limit value to NULL or '' the offset value break.

If the offset value is not a valid number or is negative it is set to an empty value.

My first git pull request so be nice :)
