### PR TITLE
Fixes issue #150, field_data() now returns the actual column length

### DIFF
--- a/system/database/drivers/mysql/mysql_driver.php
+++ b/system/database/drivers/mysql/mysql_driver.php
@@ -441,7 +441,7 @@ class CI_DB_mysql_driver extends CI_DB {
 	 */
 	function _field_data($table)
 	{
-		return "SELECT * FROM ".$table." LIMIT 1";
+		return "DESCRIBE ".$table;
 	}
 
 	// --------------------------------------------------------------------

--- a/system/database/drivers/mysql/mysql_result.php
+++ b/system/database/drivers/mysql/mysql_result.php
@@ -84,14 +84,19 @@ class CI_DB_mysql_result extends CI_DB_result {
 	function field_data()
 	{
 		$retval = array();
-		while ($field = mysql_fetch_field($this->result_id))
+		while ($field = mysql_fetch_object($this->result_id))
 		{
+			preg_match('/([a-zA-Z]+)\((\d+)\)/', $field->Type, $matches);
+
+			$type = $matches[1];
+			$length = (int)$matches[2];
+
 			$F				= new stdClass();
-			$F->name		= $field->name;
-			$F->type		= $field->type;
-			$F->default		= $field->def;
-			$F->max_length	= $field->max_length;
-			$F->primary_key = $field->primary_key;
+			$F->name		= $field->Field;
+			$F->type		= $type;
+			$F->default		= $field->Default;
+			$F->max_length	= $length;
+			$F->primary_key = ( $field->Key == 'PRI' ? 1 : 0 );
 
 			$retval[] = $F;
 		}

--- a/system/database/drivers/mysqli/mysqli_driver.php
+++ b/system/database/drivers/mysqli/mysqli_driver.php
@@ -442,7 +442,7 @@ class CI_DB_mysqli_driver extends CI_DB {
 	 */
 	function _field_data($table)
 	{
-		return "SELECT * FROM ".$table." LIMIT 1";
+		return "DESCRIBE ".$table;
 	}
 
 	// --------------------------------------------------------------------

--- a/system/database/drivers/mysqli/mysqli_result.php
+++ b/system/database/drivers/mysqli/mysqli_result.php
@@ -84,21 +84,26 @@ class CI_DB_mysqli_result extends CI_DB_result {
 	function field_data()
 	{
 		$retval = array();
-		while ($field = mysqli_fetch_field($this->result_id))
+		while ($field = mysqli_fetch_object($this->result_id))
 		{
+			preg_match('/([a-zA-Z]+)\((\d+)\)/', $field->Type, $matches);
+
+			$type = $matches[1];
+			$length = (int)$matches[2];
+
 			$F				= new stdClass();
-			$F->name		= $field->name;
-			$F->type		= $field->type;
-			$F->default		= $field->def;
-			$F->max_length	= $field->max_length;
-			$F->primary_key = ($field->flags & MYSQLI_PRI_KEY_FLAG) ? 1 : 0;
+			$F->name		= $field->Field;
+			$F->type		= $type;
+			$F->default		= $field->Default;
+			$F->max_length	= $length;
+			$F->primary_key = ( $field->Key == 'PRI' ? 1 : 0 );
 
 			$retval[] = $F;
 		}
 
 		return $retval;
 	}
-
+	
 	// --------------------------------------------------------------------
 
 	/**

--- a/user_guide/changelog.html
+++ b/user_guide/changelog.html
@@ -99,6 +99,7 @@ Change Log
     <li class="reactor">Fixed a bug (#200) where MySQL queries would be malformed after calling <samp>count_all()</samp> then <samp>db->get()</samp></li>
     <li>Fixed a bug (#181) where a mis-spelling was in the form validation language file.</li>
 	<li>Fixed a bug (#160) - Removed unneeded array copy in the file cache driver.</li>
+	<li>Fixed a bug (#150) - <samp>field_data()</samp> now correctly returns column length.</li>
 </ul>
 
 <h2>Version 2.0.3</h2>


### PR DESCRIPTION
Fixes issue #150

With mysql_fetch_field(), the 'max_length' that is returned is actually the length of the longest data in the column, not the maximum length defined in the column. This fix solves that problem by switching mysql_fetch_field()/mysqli_fetch_field() out for DESCRIBE.
