### PR TITLE
Fixed problem with needless seperator at begin/end of string

### DIFF
--- a/system/helpers/url_helper.php
+++ b/system/helpers/url_helper.php
@@ -50,7 +50,7 @@ if ( ! function_exists('site_url'))
 
 /**
  * Base URL
- * 
+ *
  * Create a local URL based on your basepath.
  * Segments can be passed in as a string or an array, same as site_url
  * or a URL to a file can be passed in, e.g. to an image file.
@@ -512,7 +512,7 @@ if ( ! function_exists('url_title'))
 			$str = strtolower($str);
 		}
 
-		return trim(stripslashes($str));
+		return trim(trim(stripslashes($str)), $replace);
 	}
 }
 


### PR DESCRIPTION
If you use url_title on strings with special characters at the begin/end, you end up with a needless seperator.

``` php
url_title('%&/ fu bar', 'dash', TRUE); // would become -fu-bar
url_title('fu bar %&/', 'dash', TRUE); // would become fu-bar-
```
