### PR TITLE
Fixed #56:_compile_session_data() should be 'protected'

### DIFF
--- a/system/libraries/Profiler.php
+++ b/system/libraries/Profiler.php
@@ -493,7 +493,7 @@ class CI_Profiler {
 	 *
 	 * @return 	string
 	 */
-	private function _compile_session_data()
+	protected function _compile_session_data()
 	{
 		if ( ! isset($this->CI->session))
 		{


### PR DESCRIPTION
_compile_session_data() is 'protected' to be able to extend MY_Profiler.
