### PR TITLE
function total_qty() added to Cart.php

### DIFF
--- a/system/libraries/Cart.php
+++ b/system/libraries/Cart.php
@@ -440,6 +440,28 @@ class CI_Cart {
 	}
 
 	// --------------------------------------------------------------------
+	
+	/**
+	 * Total Quantity
+	 *
+	 * Returns the total quantity count
+	 *
+	 * @access	public
+	 * @return	integer
+	 */
+	function total_qty()
+	{
+		$total=0;
+		
+		foreach($this->contents() as $item)
+		{	
+			$total+=$item['qty'];
+		}
+		
+		return $total;
+	}
+
+	// --------------------------------------------------------------------
 
 	/**
 	 * Cart Contents


### PR DESCRIPTION
total_items() returns total items in the cart. For example we have 2 items in the cart Apple and Orange, and there 2(qty) Apples and 1(qty) Orange. total_items() returns 2, because there are 2 items. But there should be a method which should return 2(qty). I have added this method to Cart.php

```
function total_qty()
{
    $total=0;

    foreach($this->contents() as $item)
    {   
        $total+=$item['qty'];
    }

    return $total;
}
```
