### PR TITLE
oci8 driver escape string quotes fix

### DIFF
--- a/system/database/drivers/oci8/oci8_driver.php
+++ b/system/database/drivers/oci8/oci8_driver.php
@@ -404,6 +404,7 @@ class CI_DB_oci8_driver extends CI_DB {
 		}
 
 		$str = remove_invisible_characters($str);
+		$str = str_replace("'", "''", $str);
 
 		// escape LIKE condition wildcards
 		if ($like === TRUE)

--- a/user_guide/changelog.html
+++ b/user_guide/changelog.html
@@ -108,6 +108,7 @@ Change Log
 	<li>Fixed a bug (#160) - Removed unneeded array copy in the file cache driver.</li>
 	<li>Fixed a bug (#150) - <samp>field_data()</samp> now correctly returns column length.</li>
 	<li>Fixed a bug (#8) - <samp>load_class()</samp> now looks for core classes in <samp>APPPATH</samp> first, allowing them to be replaced.</li>
+	<li>Fixed a bug (#85) - OCI8 (Oracle) database escape_str() function did not escape correct.</li>
 </ul>
 
 <h2>Version 2.0.3</h2>


### PR DESCRIPTION
fix for issue #85 - OCI8 (Oracle) database escape_str() function did not escape correct.
