### PR TITLE
fix a small bug in the migration library

### DIFF
--- a/system/libraries/Migration.php
+++ b/system/libraries/Migration.php
@@ -223,7 +223,7 @@ class CI_Migration {
 	{
 		if ( ! $migrations = $this->find_migrations())
 		{
-			$this->_error_string = $this->line->lang('migration_none_found');
+			$this->_error_string = $this->lang->line('migration_none_found');
 			return false;
 		}
 


### PR DESCRIPTION
Fixed a typo in the migration library. Does this need to go in the changelog? I didn't add a note yet since migrations are going to be new to 2.1 but I can add it if needed.
