### PR TITLE
Default migration path not set correctly

### DIFF
--- a/system/libraries/Migration.php
+++ b/system/libraries/Migration.php
@@ -57,7 +57,7 @@ class CI_Migration {
 		}
 
 		// If not set, set it
-		$this->_migration_path == '' OR $this->_migration_path = APPPATH . 'migrations/';
+		$this->_migration_path == '' AND $this->_migration_path = APPPATH . 'migrations/';
 
 		// Add trailing slash if not set
 		$this->_migration_path = rtrim($this->_migration_path, '/').'/';


### PR DESCRIPTION
Ran in to this bug trying to move the migrations folder outside of the application folder. The migrations path is overridden to be APPPATH/migrations unless it is the empty string but it should be the other way around.
