### PR TITLE
Allow objects assigned to config vars to be printed in Profiler output

### DIFF
--- a/system/libraries/Profiler.php
+++ b/system/libraries/Profiler.php
@@ -472,7 +472,7 @@ class CI_Profiler {
 
 		foreach ($this->CI->config->config as $config=>$val)
 		{
-			if (is_array($val))
+			if (is_array($val) || is_object($val))
 			{
 				$val = print_r($val, TRUE);
 			}


### PR DESCRIPTION
Eliminates PHP Warning message: htmlspecialchars() expects parameter 1 to be string, object given
