### PR TITLE
Removed uses of =& for object assignment from the user guide

### DIFF
--- a/user_guide/general/creating_libraries.html
+++ b/user_guide/general/creating_libraries.html
@@ -178,26 +178,18 @@ If you would like to use CodeIgniter's classes from within your own custom class
 
 <p>First, assign the CodeIgniter object to a variable:</p>
 
-<code>$CI =&amp; get_instance();</code>
+<code>$CI = get_instance();</code>
 
 <p>Once you've assigned the object to a variable, you'll use that variable <em>instead</em> of <kbd>$this</kbd>:</p>
 
 <code>
-$CI =&amp; get_instance();<br />
+$CI = get_instance();<br />
 <br />
 $CI->load->helper('url');<br />
 $CI->load->library('session');<br />
 $CI->config->item('base_url');<br />
 etc.
 </code>
-
-<p class="important"><strong>Note:</strong> You'll notice that the above get_instance() function is being passed by reference:
-<br /><br />
-<var>$CI =&amp; get_instance();</var>
-<br />
-<br />
-<kbd>This is very important.</kbd> Assigning by reference allows you to use the original CodeIgniter object rather than creating a copy of it.</p>
-
 
 <h2>Replacing Native Libraries with Your Versions</h2>
 

--- a/user_guide/general/hooks.html
+++ b/user_guide/general/hooks.html
@@ -140,7 +140,7 @@ $hook['pre_controller']<kbd>[]</kbd> = array(<br />
 			Called immediately after your controller is fully executed.</li>
 		<li><strong>display_override</strong><br />
 			Overrides the <dfn>_display()</dfn> function, used to send the finalized page to the web browser at the end of system execution.  This permits you to
-			use your own display methodology.  Note that you will need to reference the CI superobject with <dfn>$this->CI =&amp; get_instance()</dfn> and then the finalized data will be available by calling <dfn>$this->CI->output->get_output()</dfn></li>
+			use your own display methodology.  Note that you will need to reference the CI superobject with <dfn>$this->CI = get_instance()</dfn> and then the finalized data will be available by calling <dfn>$this->CI->output->get_output()</dfn></li>
 		<li><strong>cache_override</strong><br />
 			Enables you to call your own function instead of the <dfn>_display_cache()</dfn> function in the output class.  This permits you to use your own cache display mechanism.</li>
 		<li><strong>post_system</strong><br />


### PR DESCRIPTION
Removed uses of =& for object assignment from the user guide files creating_libraries.html and hooks.html. Reference assignment of objects is an obsolete PHP4ism.
According to a quick grep of the user guide, all such uses should now be removed.
