### PR TITLE
Optimized Sessions database in documentation

### DIFF
--- a/user_guide/libraries/sessions.html
+++ b/user_guide/libraries/sessions.html
@@ -219,15 +219,15 @@ be updated, they can only be generated when a new session is created.</p>
 prototype (for MySQL) required by the session class:</p>
 
 <textarea class="textarea" style="width:100%" cols="50" rows="10">
-CREATE TABLE IF NOT EXISTS  `ci_sessions` (
-	session_id varchar(40) DEFAULT '0' NOT NULL,
-	ip_address varchar(16) DEFAULT '0' NOT NULL,
+CREATE TABLE IF NOT EXISTS ci_sessions (
+	session_id char(32) NOT NULL DEFAULT '0',
+	ip_address varchar(15) NOT NULL DEFAULT '0',
 	user_agent varchar(120) NOT NULL,
-	last_activity int(10) unsigned DEFAULT 0 NOT NULL,
-	user_data text NOT NULL,
+	last_activity int(10) unsigned NOT NULL DEFAULT '0',
+	user_data text,
 	PRIMARY KEY (session_id),
-	KEY `last_activity_idx` (`last_activity`)
-);
+	KEY last_activity_idx (last_activity)
+) DEFAULT CHARSET=utf8;
 </textarea>
 
 <p><strong>Note:</strong> By default the table is called <dfn>ci_sessions</dfn>, but you can name it anything you want


### PR DESCRIPTION
I have fixed the bug in documentation that would cause a database error when creating sessions. Also changed default charset and ip_address now is varchar(15).
