### PR TITLE
url_helper: redirect() - HTTP/1.1 compliance for redirect after post.

### DIFF
--- a/system/helpers/url_helper.php
+++ b/system/helpers/url_helper.php
@@ -534,8 +534,8 @@ if ( ! function_exists('redirect'))
 {
 	function redirect($uri = '', $method = 'location', $http_response_code = NULL)
 	{
-	    	if (NULL === $http_response_code)
-	    	{
+		if (NULL === $http_response_code)
+		{
 			$is_http11_post =
 			(
 				isset ($_SERVER['REQUEST_METHOD'])
@@ -545,7 +545,7 @@ if ( ! function_exists('redirect'))
 			);
 
 			$http_response_code = $is_http11_post ? 303 : 302;
-	    	}
+		}
 
 		if ( ! preg_match('#^https?://#i', $uri))
 		{


### PR DESCRIPTION
For a more seamless integration with the Post/Redirect/Get (PRG) pattern in CI, see http://en.wikipedia.org/wiki/Post/Redirect/Get .

In HTTP/1.1 on a post request it should be opted for the 303 redirect code.

To have this easily available, the `redirect()` function inside the `url_helper` could just take care of that.
