### PR TITLE
Fixes issue #150, field_data() now returns the actual column length

### DIFF
--- a/system/database/drivers/mysql/mysql_result.php
+++ b/system/database/drivers/mysql/mysql_result.php
@@ -86,10 +86,10 @@ class CI_DB_mysql_result extends CI_DB_result {
 		$retval = array();
 		while ($field = mysql_fetch_object($this->result_id))
 		{
-			preg_match('/([a-zA-Z]+)\((\d+)\)/', $field->Type, $matches);
+			preg_match('/([a-zA-Z]+)(\(\d+\))?/', $field->Type, $matches);
 
-			$type = $matches[1];
-			$length = (int)$matches[2];
+			$type = (array_key_exists(1, $matches)) ? $matches[1] : NULL;
+			$length = (array_key_exists(2, $matches)) ? preg_replace('/[^\d]/', '', $matches[2]) : NULL;
 
 			$F				= new stdClass();
 			$F->name		= $field->Field;

--- a/system/database/drivers/mysqli/mysqli_result.php
+++ b/system/database/drivers/mysqli/mysqli_result.php
@@ -86,10 +86,10 @@ class CI_DB_mysqli_result extends CI_DB_result {
 		$retval = array();
 		while ($field = mysqli_fetch_object($this->result_id))
 		{
-			preg_match('/([a-zA-Z]+)\((\d+)\)/', $field->Type, $matches);
+			preg_match('/([a-zA-Z]+)(\(\d+\))?/', $field->Type, $matches);
 
-			$type = $matches[1];
-			$length = (int)$matches[2];
+			$type = (array_key_exists(1, $matches)) ? $matches[1] : NULL;
+			$length = (array_key_exists(2, $matches)) ? preg_replace('/[^\d]/', '', $matches[2]) : NULL;
 
 			$F				= new stdClass();
 			$F->name		= $field->Field;
@@ -103,7 +103,7 @@ class CI_DB_mysqli_result extends CI_DB_result {
 
 		return $retval;
 	}
-	
+
 	// --------------------------------------------------------------------
 
 	/**


### PR DESCRIPTION
Fix for issue #150 which was failing on fields without length specified (text, timestamp, etc)
