### PR TITLE
Fixed issue #105 SQL log errors

### DIFF
--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -251,9 +251,10 @@ class CI_DB_driver {
 	{
 		if ($sql == '')
 		{
+			log_message('error', 'Invalid query: '.$sql);
+
 			if ($this->db_debug)
 			{
-				log_message('error', 'Invalid query: '.$sql);
 				return $this->display_error('db_invalid_query');
 			}
 			return FALSE;
@@ -306,21 +307,23 @@ class CI_DB_driver {
 			// This will trigger a rollback if transactions are being used
 			$this->_trans_status = FALSE;
 
+			// Grab the error number and message now, as we might run some
+			// additional queries before displaying the error
+			$error_no = $this->_error_number();
+			$error_msg = $this->_error_message();
+
+			// Log errors
+			log_message('error', 'Query error: '.$error_msg);
+
 			if ($this->db_debug)
 			{
-				// grab the error number and message now, as we might run some
-				// additional queries before displaying the error
-				$error_no = $this->_error_number();
-				$error_msg = $this->_error_message();
-
 				// We call this function in order to roll-back queries
 				// if transactions are enabled.  If we don't call this here
 				// the error message will trigger an exit, causing the
 				// transactions to remain in limbo.
 				$this->trans_complete();
 
-				// Log and display errors
-				log_message('error', 'Query error: '.$error_msg);
+				// Display errors
 				return $this->display_error(
 										array(
 												'Error Number: '.$error_no,

--- a/user_guide/changelog.html
+++ b/user_guide/changelog.html
@@ -112,6 +112,7 @@ Change Log
 	<li class="reactor">Fixed a bug (Reactor #19) where 1) the 404_override route was being ignored in some cases, and 2) auto-loaded libraries were not available to the 404_override controller when a controller existed but the requested method did not.</li>
 	<li class="rector">Fixed a bug (Reactor #89) where MySQL export would fail if the table had hyphens or other non alphanumeric/underscore characters.</li>
     <li class="reactor">Fixed a bug (#200) where MySQL queries would be malformed after calling <samp>count_all()</samp> then <samp>db->get()</samp></li>
+    <li class="reactor">Fixed bug #105 that stopped query errors from being logged unless database debugging was enabled</li>
     <li>Fixed a bug (#181) where a mis-spelling was in the form validation language file.</li>
 	<li>Fixed a bug (#160) - Removed unneeded array copy in the file cache driver.</li>
 	<li>Fixed a bug (#150) - <samp>field_data()</samp> now correctly returns column length.</li>


### PR DESCRIPTION
Enabled logging database query errors even if $db_debug is not enabled.
Seems even more important to log these when debugging is off since errors in production environment are bad enough as it is without having to rely on someone notifying you. 

Let me know if anything is off on coding standards etc, this is my first CI pull request :)
