### PR TITLE
Add id= to form elements by default to aid usability with labels

### DIFF
--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -339,7 +339,7 @@ if ( ! function_exists('form_dropdown'))
 
 		$multiple = (count($selected) > 1 && strpos($extra, 'multiple') === FALSE) ? ' multiple="multiple"' : '';
 
-		$form = '<select id="'.$name,'" name="'.$name.'"'.$extra.$multiple.">\n";
+		$form = '<select id="'.$name.'" name="'.$name.'"'.$extra.$multiple.">\n";
 
 		foreach ($options as $key => $val)
 		{


### PR DESCRIPTION
Issue: EllisLab/CodeIgniter#336

Summary: Add ids to form elements using their name.  This allows the label elements to select the related form element on click.

Items included:
- form_input
- form_password
- form_upload
- form_checkbox
- form_dropdown
