### PR TITLE
session_data profiler sections is missing from user guide

### DIFF
--- a/user_guide/general/profiling.html
+++ b/user_guide/general/profiling.html
@@ -155,6 +155,11 @@ This information can be useful during development in order to help with debuggin
 			<td class="td">TRUE</td>
 		</tr>
 		<tr>
+			<td class="td"><strong>session_data</strong></td>
+			<td class="td">Data stored in current session</td>
+			<td class="td">TRUE</td>
+		</tr>
+		<tr>
 			<td class="td"><strong>query_toggle_count</strong></td>
 			<td class="td">The number of queries after which the query block will default to hidden.</td>
 			<td class="td">25</td>


### PR DESCRIPTION
There is no information about the session profiler section in the user guide in spite of it seems to be already implemented
