### PR TITLE
fixes potential SQL injection vector in Active Record offset()

### DIFF
--- a/system/database/DB_active_rec.php
+++ b/system/database/DB_active_rec.php
@@ -894,7 +894,7 @@ class CI_DB_active_record extends CI_DB_driver {
 	 */
 	public function offset($offset)
 	{
-		$this->ar_offset = $offset;
+		$this->ar_offset = (int) $offset;
 		return $this;
 	}
 


### PR DESCRIPTION
Fix in https://github.com/EllisLab/CodeIgniter/commit/b0eae5f81a4cb92911bb215ad814ae5caef4f61d is missing offset() fucntion.

Related: #36
