### PR TITLE
Changed up to down for down method error line

### DIFF
--- a/system/language/english/migration_lang.php
+++ b/system/language/english/migration_lang.php
@@ -5,7 +5,7 @@ $lang['migration_not_found']			= "This migration could not be found.";
 $lang['migration_multiple_version']		= "This are multiple migrations with the same version number: %d.";
 $lang['migration_class_doesnt_exist']	= "The migration class \"%s\" could not be found.";
 $lang['migration_missing_up_method']	= "The migration class \"%s\" is missing an 'up' method.";
-$lang['migration_missing_down_method']	= "The migration class \"%s\" is missing an 'up' method.";
+$lang['migration_missing_down_method']	= "The migration class \"%s\" is missing a 'down' method.";
 $lang['migration_invalid_filename']		= "Migration \"%s\" has an invalid filename.";
 
 


### PR DESCRIPTION
There'a a typo in in the migration_lang language file
