### PR TITLE
Output cache now uses CodeIgniter caching library.

### DIFF
--- a/application/config/output.php
+++ b/application/config/output.php
@@ -1,0 +1,3 @@
+<?php
+
+$config['adapter'] = 'file';

--- a/system/core/CodeIgniter.php
+++ b/system/core/CodeIgniter.php
@@ -196,6 +196,25 @@
  * ------------------------------------------------------
  */
 	$OUT =& load_class('Output', 'core');
+	
+	
+/*
+ * ------------------------------------------------------
+ *  Load the app controller and local controller
+ * ------------------------------------------------------
+ *
+ */
+	// Load the base controller class
+	require BASEPATH.'core/Controller.php';
+
+	function &get_instance()
+	{
+		return CI_Controller::get_instance();
+	}
+	
+	
+	//dummy version
+	$CI = new CI_Controller();
 
 /*
  * ------------------------------------------------------
@@ -230,20 +249,6 @@
  * ------------------------------------------------------
  */
 	$LANG =& load_class('Lang', 'core');
-
-/*
- * ------------------------------------------------------
- *  Load the app controller and local controller
- * ------------------------------------------------------
- *
- */
-	// Load the base controller class
-	require BASEPATH.'core/Controller.php';
-
-	function &get_instance()
-	{
-		return CI_Controller::get_instance();
-	}
 
 
 	if (file_exists(APPPATH.'core/'.$CFG->config['subclass_prefix'].'Controller.php'))

--- a/system/libraries/Cache/drivers/Cache_memcached.php
+++ b/system/libraries/Cache/drivers/Cache_memcached.php
@@ -47,6 +47,8 @@ class CI_Cache_memcached extends CI_Driver {
 	 */
 	public function get($id)
 	{
+		if ($this->_memcached == null) $this->_setup_memcached();
+		
 		$data = $this->_memcached->get($id);
 
 		return (is_array($data)) ? $data[0] : FALSE;
@@ -64,6 +66,7 @@ class CI_Cache_memcached extends CI_Driver {
 	 */
 	public function save($id, $data, $ttl = 60)
 	{
+		if ($this->_memcached == null) $this->_setup_memcached();
 		return $this->_memcached->set($id, array($data, time(), $ttl), $ttl);
 	}
 
@@ -77,6 +80,7 @@ class CI_Cache_memcached extends CI_Driver {
 	 */
 	public function delete($id)
 	{
+		if ($this->_memcached == null) $this->_setup_memcached();
 		return $this->_memcached->delete($id);
 	}
 
@@ -89,6 +93,7 @@ class CI_Cache_memcached extends CI_Driver {
 	 */
 	public function clean()
 	{
+		if ($this->_memcached == null) $this->_setup_memcached();
 		return $this->_memcached->flush();
 	}
 
@@ -102,6 +107,7 @@ class CI_Cache_memcached extends CI_Driver {
 	 */
 	public function cache_info($type = NULL)
 	{
+		if ($this->_memcached == null) $this->_setup_memcached();
 		return $this->_memcached->getStats();
 	}
 
@@ -115,6 +121,8 @@ class CI_Cache_memcached extends CI_Driver {
 	 */
 	public function get_metadata($id)
 	{
+		if ($this->_memcached == null) $this->_setup_memcached();
+		
 		$stored = $this->_memcached->get($id);
 
 		if (count($stored) !== 3)


### PR DESCRIPTION
Updated the output library caching mechanism.  Now uses the Cache
library and associated drivers to do full page caching.  Given that
$_GET is no longer a leper in CI have added that to the cache key
generation.  Any headers set are also cached and resent on subsequent
requests for the cached page.

Have tested with APC, Memcached and file system caches.