### PR TITLE
Database Driver's save queries property explained in documentation and few other fixes

### DIFF
--- a/user_guide/database/configuration.html
+++ b/user_guide/database/configuration.html
@@ -79,7 +79,9 @@ $db['default']['char_set'] = "utf8";<br />
 $db['default']['dbcollat'] = "utf8_general_ci";<br />
 $db['default']['swap_pre'] = "";<br />
 $db['default']['autoinit'] = TRUE;<br />
-$db['default']['stricton'] = FALSE;</code>
+$db['default']['stricton'] = FALSE;<br />
+$db['default']['save_queries'] = TRUE;
+</code>
 
 <p>The reason we use a multi-dimensional array rather than a more simple one is to permit you to optionally store
 multiple sets of connection values.  If, for example,  you run multiple environments (development, production, test, etc.)
@@ -100,7 +102,9 @@ $db['test']['char_set'] = "utf8";<br />
 $db['test']['dbcollat'] = "utf8_general_ci";<br />
 $db['test']['swap_pre'] = "";<br />
 $db['test']['autoinit'] = TRUE;<br />
-$db['test']['stricton'] = FALSE;</code>
+$db['test']['stricton'] = FALSE;<br />
+$db['test']['save_queries'] = TRUE;
+</code>
 
 
 <p>Then, to globally tell the system to use that group you would set this variable located in the config file:</p>
@@ -134,9 +138,10 @@ for the primary connection, but it too can be renamed to something more relevant
 <li><strong>char_set</strong> - The character set used in communicating with the database.</li>
 <li><strong>dbcollat</strong> - The character collation used in communicating with the database. <p class="important"><strong>Note:</strong> For MySQL and MySQLi databases, this setting is only used as a backup if your server is running PHP &lt; 5.2.3 or MySQL &lt; 5.0.7 (and in table creation queries made with DB Forge). There is an incompatibility in PHP with mysql_real_escape_string() which can make your site vulnerable to SQL injection if you are using a multi-byte character set and are running versions lower than these. Sites using Latin-1 or UTF-8 database character set and collation are unaffected.</p></li>
 <li><strong>swap_pre</strong> - A default table prefix that should be swapped with <var>dbprefix</var>. This is useful for distributed applications where you might run manually written queries, and need the prefix to still be customizable by the end user.</li>
-<li><strong>autoinit</strong> - Whether or not to automatically connect to the database when the library loads. If set to false, the connection will take place prior to executing the first query.</li>
+<li><strong>autoinit</strong> - TRUE/FALSE (boolean) - Whether or not to automatically connect to the database when the library loads. If set to false, the connection will take place prior to executing the first query.</li>
 <li><strong>stricton</strong> - TRUE/FALSE (boolean) - Whether to force "Strict Mode" connections, good for ensuring strict SQL while developing an application.</li>
-<li><strong>port</strong> - The database port number.  To use this value you have to add a line to the database config array.<code>$db['default']['port'] =  5432;</code>
+<li><strong>port</strong> - The database port number.  To use this value you have to add a line to the database config array.<code>$db['default']['port'] =  5432;</code></li>
+<li><strong>save_queries</strong> - TRUE/FALSE (boolean) - Whether or not to save all queries to ease up debugging. Can consume memory, if queries are big or they are many.</li>
 </ul>
 
 <p class="important"><strong>Note:</strong> Depending on what database platform you are using (MySQL, Postgres, etc.)


### PR DESCRIPTION
Added database class property save_queries to the documentation. Potential memory eater, so good to point it out in documentation. Also added TRUE/FALSE description for autoinit for consistency. Added ending markup for one list item, since it was missing.
