### PR TITLE
Loader class throws a notice.

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -127,7 +127,7 @@ class CI_Loader {
 		$this->_ci_library_paths = array(APPPATH, BASEPATH);
 		$this->_ci_helper_paths = array(APPPATH, BASEPATH);
 		$this->_ci_model_paths = array(APPPATH);
-		$this->_ci_view_paths = array(VIEWPATH	=> TRUE);
+		$this->_ci_view_paths = array('VIEWPATH' => TRUE);
 
 		log_message('debug', "Loader Class Initialized");
 	}


### PR DESCRIPTION
Constants used as array keys must have quotes! Otherwise it throws a notice. Fixed this issue in constructor of Loader class.
