### PR TITLE
Typo in "Watermarking Preferences". Configuration parameter is "wp_paddin

### DIFF
--- a/user_guide/libraries/image_lib.html
+++ b/user_guide/libraries/image_lib.html
@@ -509,7 +509,7 @@ will be positioned at the bottom/center of the image, 20 pixels from the bottom 
 </tr>
 
 <tr>
-<td class="td"><strong>padding</strong></td>
+<td class="td"><strong>wm_padding</strong></td>
 <td class="td">None</td>
 <td class="td">A number</td>
 <td class="td">The amount of padding, set in pixels, that will be applied to the watermark to set it away from the edge of your images.</td>


### PR DESCRIPTION
Typo in "Watermarking Preferences". Configuration parameter is "wp_padding", but it is listed as "padding".
