### PR TITLE
Undocumented result_to_csv() parameter

### DIFF
--- a/user_guide/database/utilities.html
+++ b/user_guide/database/utilities.html
@@ -184,7 +184,7 @@ echo $this->dbutil->csv_from_result($query);
 </code>
 
 <p>The second, third, and fourth parameters allow you to
-set the delimiter, newline, enclosure characters, respectively.  By default tabs are used as the delimiter, "\n" is used as a new line, and a double-quote is used as the enclosure.  Example:</p>
+set the delimiter, newline, and enclosure characters respectively.  By default tabs are used as the delimiter, "\n" is used as a new line, and a double-quote is used as the enclosure.  Example:</p>
 
 <code>
 $delimiter = ",";<br />


### PR DESCRIPTION
Documented an un-documented parameter of dbutil's `result_to_csv()` method. The user_guide was missing the documentation for the 'enclosure' parameter.
