### PR TITLE
result_array(), result_object() to accept a field name to use as key of returned array

### DIFF
--- a/user_guide/changelog.html
+++ b/user_guide/changelog.html
@@ -91,6 +91,11 @@ Change Log
 			<li>
 				Added additional option 'none' for the optional third argument for  <kbd>$this->db->like()</kbd> in the <a href="database/active_record.html">Database Driver</a>.
 			</li>
+			<li>
+				<kbd>result_array()</kbd> and <kbd>result_object()</kbd> now accepts an optional argument to specify which field in the query result to use as array key.<br />
+				One generally specifies the primary key field because it contains unique values.<br />
+				<kbd>result()</kbd> also accepts this value, but as a second argument.
+			</li>
 		</ul>
 	</li>
 	<li>Libraries

--- a/user_guide/database/results.html
+++ b/user_guide/database/results.html
@@ -109,6 +109,27 @@ Query Results
 	&nbsp;&nbsp;&nbsp;echo $user->reverse_name(); // or methods defined on the 'User' class<br />
 	}
 	</code>
+	
+	<p>You can specify a field name from your results in the second parameter to use as the array key.</p>
+	<p>Usually you would use the primary key field of the table so that you won't lose any data because of duplicate keys.</p>
+	<p>Consider the following database data:</p>
+	<code>
+	mysql> select * from users;<br />
+	+----+------+<br />
+	| id | name |<br />
+	+----+------+<br />
+	|&nbsp;  1 | John |<br />
+	|&nbsp;  3 | Jane |<br />
+	|&nbsp;  4 | Joe&nbsp;  |<br />
+	+----+------+<br />
+	</code>
+	<p>In your application, you run the following code:</p>
+	<code>
+	$query = $this->db->query("SELECT id, name FROM users;");<br />
+	$results = $query->result('User','id');<br />
+	<br />
+	echo $results[3]->name; //prints Jane
+	</code>
 
 	<h2>result_array()</h2>
 
@@ -122,6 +143,36 @@ Query Results
 	&nbsp;&nbsp;&nbsp;echo $row['name'];<br />
 	&nbsp;&nbsp;&nbsp;echo $row['body'];<br />
 	}</code>
+	
+	<p>You can specify a field name from your results to use as the array key, similar to the previous example in result()</p>
+	<code>
+	$query = $this->db->query("SELECT id, name FROM users");<br />
+	$results = $query->result_array('id');<br />
+	print_r($results);</code>
+	
+	<p>Output:</p>
+	
+	<code>
+	Array<br />
+	(<br />
+	&nbsp;&nbsp;&nbsp;[1] => Array<br />
+	&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(<br />
+	&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[id] => 1<br />
+	&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[name] => John<br />
+	&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;)<br />
+	<br />
+	&nbsp;&nbsp;&nbsp;[3] => Array<br />
+	&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(<br />
+	&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[id] => 3<br />
+	&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[name] => Jane<br />
+	&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;)<br />
+	<br />
+	&nbsp;&nbsp;&nbsp;[4] => Array<br />
+	&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(<br />
+	&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[id] => 4<br />
+	&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[name] => Joe<br />
+	&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;)<br />
+	)</code>
 
 
 	<h2>row()</h2>


### PR DESCRIPTION
http://codeigniter.com/forums/viewthread/193209/

http://codeigniter.uservoice.com/forums/40508-codeigniter-reactor/suggestions/1561893-pass-column-name-into-active-record-result-to-be

Example use:
In my users database table, I have:

<pre>
id  - name - email
1 - Preston - preston@libria.com
3 - Seamus - seamus@libria.com
4 - Dupont - dupont@libria.com
</pre>


In my app, I do:

<pre>
$rs = $this->db->select('id, name')->get('users');
$users = $rs->result_array('id');
</pre>


$users will be:

<pre>
Array
(
    [1] => Array
        (
            [id] => 1
            [name] => Preston
        )

    [3] => Array
        (
            [id] => 3
            [name] => Seamus
        )

    [4] => Array
        (
            [id] => 4
            [name] => Dupont
        )
)
</pre>
