### PR TITLE
Edited system/helpers/date_helper.php to have a default id

### DIFF
--- a/system/helpers/date_helper.php
+++ b/system/helpers/date_helper.php
@@ -582,7 +582,7 @@ if ( ! function_exists('nice_date'))
  */
 if ( ! function_exists('timezone_menu'))
 {
-	function timezone_menu($default = 'UTC', $class = "", $id = "timezones", $name = 'timezones')
+	function timezone_menu($default = 'UTC', $class = "", $name = 'timezones', $id = "timezones")
 	{
 		$CI =& get_instance();
 		$CI->lang->load('date');


### PR DESCRIPTION
Using the date helper timezone_menu() I needed the drop down to have an id to utilize a javaScript function.  I edited the timezone_menu() to have the default id "timezones" identical to the default class name.
