### PR TITLE
Fixed error when using MySQL stored procedures

### DIFF
--- a/system/database/drivers/mysqli/mysqli_driver.php
+++ b/system/database/drivers/mysqli/mysqli_driver.php
@@ -177,6 +177,11 @@ class CI_DB_mysqli_driver extends CI_DB {
 	{
 		$sql = $this->_prep_query($sql);
 		$result = @mysqli_query($this->conn_id, $sql);
+		while ( mysqli_more_results($this->conn_id) ) {
+			mysqli_next_result($this->conn_id);
+			$temp = mysqli_use_result($this->conn_id);
+			if ($temp) mysqli_free_result($temp);
+		}
 		return $result;
 	}
 


### PR DESCRIPTION
Added rudimentary support for stored procedures in the mysqli database driver.

Prevents "Commands out of sync; you can't run this command now" errors when running

    $this->db->query('call StoredProc(...)');