### PR TITLE
Fix error when update a object to database that contains null attributes.

### DIFF
--- a/system/database/DB_active_rec.php
+++ b/system/database/DB_active_rec.php
@@ -1825,7 +1825,10 @@ class CI_DB_active_record extends CI_DB_driver {
 			// There are some built in keys we need to ignore for this conversion
 			if ( ! is_object($val) && ! is_array($val) && $key != '_parent_name')
 			{
-				$array[$key] = $val;
+				if($val!==null){
+					$array[$key] = $val;
+				}
+				
 			}
 		}
 


### PR DESCRIPTION
Fix error when update a object to database that contains null attributes. This error occurs when I create a object just some atributes with value so, others attributes with null values will empty in database after update(db->update('table',$object)). Ex: If I Have object student with attributs, id=1,name='John' and age='21', and I update name='James' with id=1, so it will return id=1,name='James',age=null.
