### PR TITLE
Fix issue #182: OCI8's num_rows() re-executing the statement

### DIFF
--- a/system/database/drivers/oci8/oci8_result.php
+++ b/system/database/drivers/oci8/oci8_result.php
@@ -42,15 +42,18 @@ class CI_DB_oci8_result extends CI_DB_result {
 	 */
 	function num_rows()
 	{
-		$rowcount = count($this->result_array());
-		@ociexecute($this->stmt_id);
-
-		if ($this->curs_id)
+		if ($this->num_rows === 0 && count($this->result_array()) > 0)
 		{
-			@ociexecute($this->curs_id);
+			$this->num_rows = count($this->result_array());
+			@ociexecute($this->stmt_id);
+
+			if ($this->curs_id)
+			{
+				@ociexecute($this->curs_id);
+			}
 		}
 
-		return $rowcount;
+		return $this->num_rows;
 	}
 
 	// --------------------------------------------------------------------

--- a/user_guide/changelog.html
+++ b/user_guide/changelog.html
@@ -129,6 +129,7 @@ Change Log
 	<li>Fixed a bug (#85) - OCI8 (Oracle) database escape_str() function did not escape correct.</li>
 	<li>Fixed a bug (#344) - Using schema found in <a href="libraries/sessions.html">Saving Session Data to a Database</a>, system would throw error "user_data does not have a default value" when deleting then creating a session.</li>
 	<li>Fixed a bug (#112) - OCI8 (Oracle) driver didn't pass the configured database character set when connecting.</li>
+	<li>Fixed a bug (#182) - OCI8 (Oracle) driver used to re-execute the statement whenever num_rows() is called.</li>
 </ul>
 
 <h2>Version 2.0.3</h2>


### PR DESCRIPTION
Fix issue #182 in system/database/drivers/oci8_result.php by caching the num_rows property after statement execution. Used to re-execute the statement each time the method was called.
