### PR TITLE
resolve a difference between the two memcache set method parameters

### DIFF
--- a/system/libraries/Cache/drivers/Cache_memcached.php
+++ b/system/libraries/Cache/drivers/Cache_memcached.php
@@ -64,7 +64,16 @@ class CI_Cache_memcached extends CI_Driver {
 	 */
 	public function save($id, $data, $ttl = 60)
 	{
-		return $this->_memcached->set($id, array($data, time(), $ttl), $ttl);
+		if (get_class($this->_memcached) == 'Memcached')
+		{
+			return $this->_memcached->set($id, array($data, time(), $ttl), $ttl);
+		}
+		else if (get_class($this->_memcached) == 'Memcache')
+		{
+			return $this->_memcached->set($id, array($data, time(), $ttl), 0, $ttl);
+		}
+		
+		return FALSE;
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
Hey guys, if you check:
- http://us3.php.net/manual/en/memcache.set.php
- http://us.php.net/manual/en/memcached.set.php

You'll notice that `Memcache::set` has an additional parameter `$flags`. I defaulted this to 0 (no compression) and everything seems to work. Not sure if you'd rather add a config item for this though…
