### PR TITLE
Escape WHERE clause field names in the DB update_string() method (Issue #82)

### DIFF
--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -950,6 +950,7 @@ class CI_DB_driver {
 			foreach ($where as $key => $val)
 			{
 				$prefix = (count($dest) == 0) ? '' : ' AND ';
+				$key = $this->_protect_identifiers($key);
 
 				if ($val !== '')
 				{

--- a/user_guide/changelog.html
+++ b/user_guide/changelog.html
@@ -132,6 +132,7 @@ Change Log
 	<li>Fixed a bug (#344) - Using schema found in <a href="libraries/sessions.html">Saving Session Data to a Database</a>, system would throw error "user_data does not have a default value" when deleting then creating a session.</li>
 	<li>Fixed a bug (#112) - OCI8 (Oracle) driver didn't pass the configured database character set when connecting.</li>
 	<li>Fixed a bug (#182) - OCI8 (Oracle) driver used to re-execute the statement whenever num_rows() is called.</li>
+	<li>Fixed a bug (#82) - WHERE clause field names in the DB <samp>update_string()</samp> method were not escaped, resulting in failed queries in some cases.</li>
 </ul>
 
 <h2>Version 2.0.3</h2>


### PR DESCRIPTION
Used to cause failed queries in some cases when using the OCI8 (Oracle) driver and possibly others as well.
