### PR TITLE
Fix issue #121 - DB result_object() to return an object instead of an array, if empty

### DIFF
--- a/system/database/DB_result.php
+++ b/system/database/DB_result.php
@@ -32,7 +32,7 @@ class CI_DB_result {
 	var $result_id				= NULL;
 	var $result_array			= array();
 	var $result_object			= array();
-	var $custom_result_object	= array();
+	var $custom_result_object		= array();
 	var $current_row			= 0;
 	var $num_rows				= 0;
 	var $row_data				= NULL;
@@ -79,12 +79,12 @@ class CI_DB_result {
 		while ($row = $this->_fetch_object())
 		{
 			$object = new $class_name();
-			
+
 			foreach ($row as $key => $value)
 			{
 				$object->$key = $value;
 			}
-			
+
 			$result_object[] = $object;
 		}
 
@@ -109,10 +109,10 @@ class CI_DB_result {
 
 		// In the event that query caching is on the result_id variable
 		// will return FALSE since there isn't a valid SQL resource so
-		// we'll simply return an empty array.
+		// we'll simply return an empty object.
 		if ($this->result_id === FALSE OR $this->num_rows() == 0)
 		{
-			return array();
+			return new stdClass();
 		}
 
 		$this->_data_seek(0);

--- a/user_guide/changelog.html
+++ b/user_guide/changelog.html
@@ -134,6 +134,7 @@ Change Log
 	<li>Fixed a bug (#182) - OCI8 (Oracle) driver used to re-execute the statement whenever num_rows() is called.</li>
 	<li>Fixed a bug (#82) - WHERE clause field names in the DB <samp>update_string()</samp> method were not escaped, resulting in failed queries in some cases.</li>
 	<li>Fixed a bug (#89) - Fix a variable type mismatch in DB <samp>display_error()</samp> where an array is expected, but a string could be set instead.</li>
+	<li>Fixed a bug (#121) - DB <samp>result_object()</samp> (and all result methods depending on it) used to return an empty array instead of object in case that there's no result.</li>
 </ul>
 
 <h2>Version 2.0.3</h2>


### PR DESCRIPTION
As a result of this, all result methods depending on it also returned array() when there's no actual result.
Also fixed some missing/extra tabs in system/database/DB_result.php.
