### PR TITLE
In case we call a stored procedure with $this->db->query("call store proc

### DIFF
--- a/system/database/drivers/mysql/mysql_result.php
+++ b/system/database/drivers/mysql/mysql_result.php
@@ -34,8 +34,10 @@ class CI_DB_mysql_result extends CI_DB_result {
 	 */
 	function num_rows()
 	{
-		if(!is_resource($this->result_id))
-			return false;
+		if ( ! is_resource($this->result_id))
+		{
+		    return false;
+		}
 		return @mysql_num_rows($this->result_id);
 	}
 


### PR DESCRIPTION
In case we call a stored procedure with $this->db->query("call store procedure") and it does not return any row we get a warning:  Severity: Warning  --> mysql_num_rows() expects parameter 1 to be resource, boolean given /system/database/drivers/mysql/mysql_result.php 37

This little fix keep logs clean...
