### PR TITLE
remove redundant 'if' in typography helper

### DIFF
--- a/system/helpers/typography_helper.php
+++ b/system/helpers/typography_helper.php
@@ -76,6 +76,7 @@ if ( ! function_exists('auto_typography'))
  *
  * @access	public
  * @param	string
+ * @param   string
  * @return	string
  */
 if ( ! function_exists('entity_decode'))


### PR DESCRIPTION
This removes a redundant if statement that appears in the called function $SEC->entity_decode()
