### PR TITLE
nice_date() Example error

### DIFF
--- a/user_guide/helpers/date_helper.html
+++ b/user_guide/helpers/date_helper.html
@@ -239,12 +239,12 @@ $unix = human_to_unix($human);</code>
 <p>This function can take a number poorly-formed date formats and convert them into something useful. It also accepts well-formed dates.</p> 
 <p>The function will return a Unix timestamp by default. You can, optionally, pass a format string (the same type as the PHP date function accepts) as the second parameter. Example:</p>
 
-<code>$bad_time = 199605<br />
+<code>$bad_time = 199605;<br />
 <br />
 // Should Produce: 1996-05-01<br />
 $better_time = nice_date($bad_time,'Y-m-d');<br />
 <br />
-$bad_time = 9-11-2001<br />
+$human = '9-11-2001';<br />
 // Should Produce: 2001-09-11<br />
 $better_time = nice_date($human,'Y-m-d');</code>
 


### PR DESCRIPTION
# before

$bad_time = 199605

// Should Produce: 1996-05-01
$better_time = nice_date($bad_time,'Y-m-d');

$bad_time = 9-11-2001
// Should Produce: 2001-09-11
$better_time = nice_date($human,'Y-m-d');
# after

$bad_time = 199605;

// Should Produce: 1996-05-01
$better_time = nice_date($bad_time,'Y-m-d');

$human = '9-11-2001';
// Should Produce: 2001-09-11
$better_time = nice_date($human,'Y-m-d');
