### PR TITLE
newline character ending for link_tag() function result

### DIFF
--- a/system/helpers/html_helper.php
+++ b/system/helpers/html_helper.php
@@ -365,7 +365,7 @@ if ( ! function_exists('link_tag'))
 
 			$link .= '/>';
 		}
-
+		$link .= "\n";
 
 		return $link;
 	}


### PR DESCRIPTION
make code generated by link_tag() cleaner
