### PR TITLE
User guide formatting

### DIFF
--- a/user_guide_src/source/database/utilities.rst
+++ b/user_guide_src/source/database/utilities.rst
@@ -153,37 +153,16 @@ parameter of the backup function. Example::
 Description of Backup Preferences
 ---------------------------------
 
-Preference
-Default Value
-Options
-Description
-**tables**
-empty array
-None
-An array of tables you want backed up. If left blank all tables will be
-exported.
-**ignore**
-empty array
-None
-An array of tables you want the backup routine to ignore.
-**format**
-gzip
-gzip, zip, txt
-The file format of the export file.
-**filename**
-the current date/time
-None
-The name of the backed-up file. The name is needed only if you are using
-zip compression.
-**add_drop**
-TRUE
-TRUE/FALSE
-Whether to include DROP TABLE statements in your SQL export file.
-**add_insert**
-TRUE
-TRUE/FALSE
-Whether to include INSERT statements in your SQL export file.
-**newline**
-"\\n"
-"\\n", "\\r", "\\r\\n"
-Type of newline to use in your SQL export file.
+=============== ======================= ======================= ========================================================================
+Preference      Default Value           Options                 Description
+=============== ======================= ======================= ========================================================================
+**tables**      empty array             None                    An array of tables you want backed up. If left blank all tables will be
+                                                                exported.
+**ignore**      empty array             None                    An array of tables you want the backup routine to ignore.
+**format**      gzip                    gzip, zip, txt          The file format of the export file.
+**filename**    the current date/time   None                    The name of the backed-up file. The name is needed only if you are using
+                                                                zip compression.
+**add_drop**    TRUE                    TRUE/FALSE              Whether to include DROP TABLE statements in your SQL export file.
+**add_insert**  TRUE                    TRUE/FALSE              Whether to include INSERT statements in your SQL export file.
+**newline**     "\\n"                   "\\n", "\\r", "\\r\\n"  Type of newline to use in your SQL export file.
+=============== ======================= ======================= ========================================================================

--- a/user_guide_src/source/general/cli.rst
+++ b/user_guide_src/source/general/cli.rst
@@ -6,9 +6,7 @@ As well as calling an applications :doc:`Controllers <./controllers>`
 via the URL in a browser they can also be loaded via the command-line
 interface (CLI).
 
--  `What is the CLI? <#what>`_
--  `Why use this method? <#why>`_
--  `How does it work? <#how>`_
+.. contents:: Page Contents
 
 What is the CLI?
 ================

--- a/user_guide_src/source/general/controllers.rst
+++ b/user_guide_src/source/general/controllers.rst
@@ -5,17 +5,7 @@ Controllers
 Controllers are the heart of your application, as they determine how
 HTTP requests should be handled.
 
--  `What is a Controller? <#what>`_
--  `Hello World <#hello>`_
--  `Functions <#functions>`_
--  `Passing URI Segments to Your Functions <#passinguri>`_
--  `Defining a Default Controller <#default>`_
--  `Remapping Function Calls <#remapping>`_
--  `Controlling Output Data <#output>`_
--  `Private Functions <#private>`_
--  `Organizing Controllers into Sub-folders <#subfolders>`_
--  `Class Constructors <#constructors>`_
--  `Reserved Function Names <#reserved>`_
+.. contents:: Page Contents
 
 What is a Controller?
 =====================

--- a/user_guide_src/source/general/models.rst
+++ b/user_guide_src/source/general/models.rst
@@ -5,11 +5,7 @@ Models
 Models are **optionally** available for those who want to use a more
 traditional MVC approach.
 
--  `What is a Model? <#what>`_
--  `Anatomy of a Model <#anatomy>`_
--  `Loading a Model <#loading>`_
--  `Auto-Loading a Model <#auto_load_model>`_
--  `Connecting to your Database <#conn>`_
+.. contents:: Page Contents
 
 What is a Model?
 ================

--- a/user_guide_src/source/general/profiling.rst
+++ b/user_guide_src/source/general/profiling.rst
@@ -65,40 +65,19 @@ class <../libraries/output>`::
 Available sections and the array key used to access them are described
 in the table below.
 
-Key
-Description
-Default
-**benchmarks**
-Elapsed time of Benchmark points and total execution time
-TRUE
-**config**
-CodeIgniter Config variables
-TRUE
-**controller_info**
-The Controller class and method requested
-TRUE
-**get**
-Any GET data passed in the request
-TRUE
-**http_headers**
-The HTTP headers for the current request
-TRUE
-**memory_usage**
-Amount of memory consumed by the current request, in bytes
-TRUE
-**post**
-Any POST data passed in the request
-TRUE
-**queries**
-Listing of all database queries executed, including execution time
-TRUE
-**uri_string**
-The URI of the current request
-TRUE
-**session_data**
-Data stored in the current session
-TRUE
-**query_toggle_count**
-The number of queries after which the query block will default to
-hidden.
-25
+======================= =================================================================== ========
+Key                     Description                                                         Default
+======================= =================================================================== ========
+**benchmarks**          Elapsed time of Benchmark points and total execution time           TRUE
+**config**              CodeIgniter Config variables                                        TRUE
+**controller_info**     The Controller class and method requested                           TRUE
+**get**                 Any GET data passed in the request                                  TRUE
+**http_headers**        The HTTP headers for the current request                            TRUE
+**memory_usage**        Amount of memory consumed by the current request, in bytes          TRUE
+**post**                Any POST data passed in the request                                 TRUE
+**queries**             Listing of all database queries executed, including execution time  TRUE
+**uri_string**          The URI of the current request                                      TRUE
+**session_data**        Data stored in the current session                                  TRUE
+**query_toggle_count**  The number of queries after which the query block will default to   25
+                        hidden.
+======================= =================================================================== ========

--- a/user_guide_src/source/libraries/form_validation.rst
+++ b/user_guide_src/source/libraries/form_validation.rst
@@ -5,31 +5,7 @@ Form Validation
 CodeIgniter provides a comprehensive form validation and data prepping
 class that helps minimize the amount of code you'll write.
 
--  `Overview <#overview>`_
--  `Form Validation Tutorial <#tutorial>`_
-
-   -  `The Form <#theform>`_
-   -  `The Success Page <#thesuccesspage>`_
-   -  `The Controller <#thecontroller>`_
-   -  `Setting Validation Rules <#validationrules>`_
-   -  `Setting Validation Rules Using an
-      Array <#validationrulesasarray>`_
-   -  `Cascading Rules <#cascadingrules>`_
-   -  `Prepping Data <#preppingdata>`_
-   -  `Re-populating the Form <#repopulatingform>`_
-   -  `Callbacks <#callbacks>`_
-   -  `Setting Error Messages <#settingerrors>`_
-   -  `Changing the Error Delimiters <#errordelimiters>`_
-   -  `Translating Field Names <#translatingfn>`_
-   -  `Showing Errors Individually <#individualerrors>`_
-   -  `Saving Sets of Validation Rules to a Config
-      File <#savingtoconfig>`_
-   -  `Using Arrays as Field Names <#arraysasfields>`_
-
--  `Rule Reference <#rulereference>`_
--  `Prepping Reference <#preppingreference>`_
--  `Function Reference <#functionreference>`_
--  `Helper Reference <#helperreference>`_
+.. contents:: Page Contents
 
 ********
 Overview
@@ -888,7 +864,7 @@ Name                 Parameter Description
 ==================== ========= ===================================================================================================
 **xss_clean**        No        Runs the data through the XSS filtering function, described in the :doc:`Input Class <input>` page.
 **prep_for_form**    No        Converts special characters so that HTML data can be shown in a form field without breaking it.
-**prep_url**         No        Adds "http://" to URLs if missing.
+**prep_url**         No        Adds "\http://" to URLs if missing.
 **strip_image_tags** No        Strips the HTML from image tags leaving the raw URL.
 **encode_php_tags**  No        Converts PHP tags to entities.
 ==================== ========= ===================================================================================================

--- a/user_guide_src/source/libraries/sessions.rst
+++ b/user_guide_src/source/libraries/sessions.rst
@@ -284,50 +284,23 @@ Session Preferences
 You'll find the following Session related preferences in your
 application/config/config.php file:
 
-Preference
-Default
-Options
-Description
-**sess_cookie_name**
-ci_session
-None
-The name you want the session cookie saved as.
-**sess_expiration**
-7200
-None
-The number of seconds you would like the session to last. The default
-value is 2 hours (7200 seconds). If you would like a non-expiring
-session set the value to zero: 0
-**sess_expire_on_close**
-FALSE
-TRUE/FALSE (boolean)
-Whether to cause the session to expire automatically when the browser
-window is closed.
-**sess_encrypt_cookie**
-FALSE
-TRUE/FALSE (boolean)
-Whether to encrypt the session data.
-**sess_use_database**
-FALSE
-TRUE/FALSE (boolean)
-Whether to save the session data to a database. You must create the
-table before enabling this option.
-**sess_table_name**
-ci_sessions
-Any valid SQL table name
-The name of the session database table.
-**sess_time_to_update**
-300
-Time in seconds
-This options controls how often the session class will regenerate itself
-and create a new session id.
-**sess_match_ip**
-FALSE
-TRUE/FALSE (boolean)
-Whether to match the user's IP address when reading the session data.
-Note that some ISPs dynamically changes the IP, so if you want a
-non-expiring session you will likely set this to FALSE.
-**sess_match_useragent**
-TRUE
-TRUE/FALSE (boolean)
-Whether to match the User Agent when reading the session data.
+=========================== =============== =========================== ==========================================================================
+Preference                  Default         Options                     Description
+=========================== =============== =========================== ==========================================================================
+**sess_cookie_name**        ci_session      None                        The name you want the session cookie saved as.
+**sess_expiration**         7200            None                        The number of seconds you would like the session to last. The default
+                                                                        value is 2 hours (7200 seconds). If you would like a non-expiring
+                                                                        session set the value to zero: 0
+**sess_expire_on_close**    FALSE           TRUE/FALSE (boolean)        Whether to cause the session to expire automatically when the browser
+                                                                        window is closed.
+**sess_encrypt_cookie**     FALSE           TRUE/FALSE (boolean)        Whether to encrypt the session data.
+**sess_use_database**       FALSE           TRUE/FALSE (boolean)        Whether to save the session data to a database. You must create the
+                                                                        table before enabling this option.
+**sess_table_name**         ci_sessions     Any valid SQL table name    The name of the session database table.
+**sess_time_to_update**     300             Time in seconds             This options controls how often the session class will regenerate itself
+                                                                        and create a new session id.
+**sess_match_ip**           FALSE           TRUE/FALSE (boolean)        Whether to match the user's IP address when reading the session data.
+                                                                        Note that some ISPs dynamically changes the IP, so if you want a
+                                                                        non-expiring session you will likely set this to FALSE.
+**sess_match_useragent**    TRUE            TRUE/FALSE (boolean)        Whether to match the User Agent when reading the session data.
+=========================== =============== =========================== ==========================================================================


### PR DESCRIPTION
change hardcoded page docs to use generated ones
escape "http://" that was getting linked
formatting some tables
