### PR TITLE
show_error() on undefined rules and callbacks

### DIFF
--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -586,7 +586,7 @@ class CI_Form_validation {
 			{
 				if ( ! method_exists($this->CI, $rule))
 				{
-					continue;
+					show_error("Undefined callback rule specified for field {$row['field']}: {$rule}");
 				}
 
 				// Run the function and grab the result
@@ -629,21 +629,21 @@ class CI_Form_validation {
 					}
 					else
 					{
-						log_message('debug', "Unable to find validation rule: ".$rule);
+						show_error("Undefined rule specified for field {$row['field']}: {$rule}");
 					}
-
-					continue;
-				}
-
-				$result = $this->$rule($postdata, $param);
-
-				if ($_in_array == TRUE)
-				{
-					$this->_field_data[$row['field']]['postdata'][$cycles] = (is_bool($result)) ? $postdata : $result;
 				}
 				else
 				{
-					$this->_field_data[$row['field']]['postdata'] = (is_bool($result)) ? $postdata : $result;
+					$result = $this->$rule($postdata, $param);
+	
+					if ($_in_array == TRUE)
+					{
+						$this->_field_data[$row['field']]['postdata'][$cycles] = (is_bool($result)) ? $postdata : $result;
+					}
+					else
+					{
+						$this->_field_data[$row['field']]['postdata'] = (is_bool($result)) ? $postdata : $result;
+					}
 				}
 			}
 

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -108,6 +108,7 @@ Bug fixes for 2.1.0
 -  Fixed a bug (#484) - First time _csrf_set_hash() is called, hash is never set to the cookie (in Security.php).
 -  Fixed a bug (#60) - Added _file_mime_type() method to the `File Uploading Library <libraries/file_uploading>` in order to fix a possible MIME-type injection.
 -  Fixed a bug (#537) - Support for all wav type in browser.
+-  Fixed a bug (#11) - Form validation class was ignoring undefined rules and callbacks and allowing validation to pass successfully.
 
 Version 2.0.3
 =============


### PR DESCRIPTION
If a rule/callback is undefined the Form_validation class no longer
ignores this and instead calls show_error(). Also, if using a global function
for validation (such as is_string) the result was being ignored thanks to
an ill-placed continue statement. Fixes GH-11.
