### PR TITLE
Removed blue background from code examples to improve readability

### DIFF
--- a/user_guide_src/source/_themes/eldocs/static/asset/css/common.css
+++ b/user_guide_src/source/_themes/eldocs/static/asset/css/common.css
@@ -134,6 +134,10 @@ fieldset{ border: 0; }
 	padding: 10px 10px 8px; 
 }
 
+.highlight-ci{
+	background:none;
+}
+
 	.highlight-ci,
 	.highlight-ee,
 	.highlight-rst,


### PR DESCRIPTION
Since the blues and greens of the highlighted code areas are difficult to read because of the blue background, I removed this blue background, but left the "box" around the code examples. 
