### PR TITLE
Cleanup and switch oci8_driver and oci8_result to PHP5 functions

### DIFF
--- a/system/database/DB_result.php
+++ b/system/database/DB_result.php
@@ -45,7 +45,7 @@ class CI_DB_result {
 	 * @param	string	can be "object" or "array"
 	 * @return	mixed	either a result object or array
 	 */
-	function result($type = 'object')
+	public function result($type = 'object')
 	{
 		if ($type == 'array') return $this->result_array();
 		else if ($type == 'object') return $this->result_object();
@@ -60,7 +60,7 @@ class CI_DB_result {
 	 * @param class_name A string that represents the type of object you want back
 	 * @return array of objects
 	 */
-	function custom_result_object($class_name)
+	public function custom_result_object($class_name)
 	{
 		if (array_key_exists($class_name, $this->custom_result_object))
 		{
@@ -79,12 +79,12 @@ class CI_DB_result {
 		while ($row = $this->_fetch_object())
 		{
 			$object = new $class_name();
-			
+
 			foreach ($row as $key => $value)
 			{
 				$object->$key = $value;
 			}
-			
+
 			$result_object[] = $object;
 		}
 
@@ -100,7 +100,7 @@ class CI_DB_result {
 	 * @access	public
 	 * @return	object
 	 */
-	function result_object()
+	public function result_object()
 	{
 		if (count($this->result_object) > 0)
 		{
@@ -132,7 +132,7 @@ class CI_DB_result {
 	 * @access	public
 	 * @return	array
 	 */
-	function result_array()
+	public function result_array()
 	{
 		if (count($this->result_array) > 0)
 		{
@@ -166,7 +166,7 @@ class CI_DB_result {
 	 * @param	string	can be "object" or "array"
 	 * @return	mixed	either a result object or array
 	 */
-	function row($n = 0, $type = 'object')
+	public function row($n = 0, $type = 'object')
 	{
 		if ( ! is_numeric($n))
 		{
@@ -198,7 +198,7 @@ class CI_DB_result {
 	 * @access	public
 	 * @return	object
 	 */
-	function set_row($key, $value = NULL)
+	public function set_row($key, $value = NULL)
 	{
 		// We cache the row data for subsequent uses
 		if ( ! is_array($this->row_data))
@@ -230,7 +230,7 @@ class CI_DB_result {
 	 * @access	public
 	 * @return	object
 	 */
-	function custom_row_object($n, $type)
+	public function custom_row_object($n, $type)
 	{
 		$result = $this->custom_result_object($type);
 
@@ -253,7 +253,7 @@ class CI_DB_result {
 	 * @access	public
 	 * @return	object
 	 */
-	function row_object($n = 0)
+	public function row_object($n = 0)
 	{
 		$result = $this->result_object();
 
@@ -278,7 +278,7 @@ class CI_DB_result {
 	 * @access	public
 	 * @return	array
 	 */
-	function row_array($n = 0)
+	public function row_array($n = 0)
 	{
 		$result = $this->result_array();
 
@@ -304,7 +304,7 @@ class CI_DB_result {
 	 * @access	public
 	 * @return	object
 	 */
-	function first_row($type = 'object')
+	public function first_row($type = 'object')
 	{
 		$result = $this->result($type);
 
@@ -323,7 +323,7 @@ class CI_DB_result {
 	 * @access	public
 	 * @return	object
 	 */
-	function last_row($type = 'object')
+	public function last_row($type = 'object')
 	{
 		$result = $this->result($type);
 
@@ -342,7 +342,7 @@ class CI_DB_result {
 	 * @access	public
 	 * @return	object
 	 */
-	function next_row($type = 'object')
+	public function next_row($type = 'object')
 	{
 		$result = $this->result($type);
 
@@ -367,7 +367,7 @@ class CI_DB_result {
 	 * @access	public
 	 * @return	object
 	 */
-	function previous_row($type = 'object')
+	public function previous_row($type = 'object')
 	{
 		$result = $this->result($type);
 
@@ -394,14 +394,14 @@ class CI_DB_result {
 	 * operational due to the unavailability of the database resource IDs with
 	 * cached results.
 	 */
-	function num_rows() { return $this->num_rows; }
-	function num_fields() { return 0; }
-	function list_fields() { return array(); }
-	function field_data() { return array(); }
-	function free_result() { return TRUE; }
-	function _data_seek() { return TRUE; }
-	function _fetch_assoc() { return array(); }
-	function _fetch_object() { return array(); }
+	public function num_rows() { return $this->num_rows; }
+	public function num_fields() { return 0; }
+	public function list_fields() { return array(); }
+	public function field_data() { return array(); }
+	public function free_result() { return TRUE; }
+	protected function _data_seek() { return TRUE; }
+	protected function _fetch_assoc() { return array(); }
+	protected function _fetch_object() { return array(); }
 
 }
 // END DB_result class

--- a/system/database/drivers/oci8/oci8_driver.php
+++ b/system/database/drivers/oci8/oci8_driver.php
@@ -145,10 +145,10 @@ class CI_DB_oci8_driver extends CI_DB {
 	/**
 	 * Version number query string
 	 *
-	 * @access  public
+	 * @access  protected
 	 * @return  string
 	 */
-	public function _version()
+	protected function _version()
 	{
 		return oci_server_version($this->conn_id);
 	}
@@ -158,11 +158,11 @@ class CI_DB_oci8_driver extends CI_DB {
 	/**
 	 * Execute the query
 	 *
-	 * @access  public  called by the base class
+	 * @access  protected  called by the base class
 	 * @param   string  an SQL query
 	 * @return  resource
 	 */
-	public function _execute($sql)
+	protected function _execute($sql)
 	{
 		// oracle must parse the query before it is run. All of the actions with
 		// the query are based on the statement id returned by ociparse
@@ -482,11 +482,11 @@ class CI_DB_oci8_driver extends CI_DB {
 	 *
 	 * Generates a platform-specific query string so that the table names can be fetched
 	 *
-	 * @access	public
+	 * @access	protected
 	 * @param	boolean
 	 * @return	string
 	 */
-	public function _list_tables($prefix_limit = FALSE)
+	protected function _list_tables($prefix_limit = FALSE)
 	{
 		$sql = "SELECT TABLE_NAME FROM ALL_TABLES";
 
@@ -505,11 +505,11 @@ class CI_DB_oci8_driver extends CI_DB {
 	 *
 	 * Generates a platform-specific query string so that the column names can be fetched
 	 *
-	 * @access  public
+	 * @access  protected
 	 * @param   string  the table name
 	 * @return  string
 	 */
-	public function _list_columns($table = '')
+	protected function _list_columns($table = '')
 	{
 		return "SELECT COLUMN_NAME FROM all_tab_columns WHERE table_name = '$table'";
 	}
@@ -525,7 +525,7 @@ class CI_DB_oci8_driver extends CI_DB {
 	 * @param   string  the table name
 	 * @return  object
 	 */
-	public function _field_data($table)
+	protected function _field_data($table)
 	{
 		return "SELECT * FROM ".$table." where rownum = 1";
 	}
@@ -535,10 +535,10 @@ class CI_DB_oci8_driver extends CI_DB {
 	/**
 	 * The error message string
 	 *
-	 * @access  public
+	 * @access  protected
 	 * @return  string
 	 */
-	public function _error_message()
+	protected function _error_message()
 	{
 		// If the error was during connection, no conn_id should be passed
 		$error = is_resource($this->conn_id) ? oci_error($this->conn_id) : oci_error();
@@ -550,10 +550,10 @@ class CI_DB_oci8_driver extends CI_DB {
 	/**
 	 * The error message number
 	 *
-	 * @access  public
+	 * @access  protected
 	 * @return  integer
 	 */
-	public function _error_number()
+	protected function _error_number()
 	{
 		// Same as _error_message()
 		$error = is_resource($this->conn_id) ? oci_error($this->conn_id) : oci_error();
@@ -567,11 +567,11 @@ class CI_DB_oci8_driver extends CI_DB {
 	 *
 	 * This function escapes column and table names
 	 *
-	 * @access	public
+	 * @access	protected
 	 * @param	string
 	 * @return	string
 	 */
-	public function _escape_identifiers($item)
+	protected function _escape_identifiers($item)
 	{
 		if ($this->_escape_char == '')
 		{
@@ -610,11 +610,11 @@ class CI_DB_oci8_driver extends CI_DB {
 	 * This function implicitly groups FROM tables so there is no confusion
 	 * about operator precedence in harmony with SQL standards
 	 *
-	 * @access	public
+	 * @access	protected
 	 * @param	type
 	 * @return	type
 	 */
-	public function _from_tables($tables)
+	protected function _from_tables($tables)
 	{
 		if ( ! is_array($tables))
 		{
@@ -637,7 +637,7 @@ class CI_DB_oci8_driver extends CI_DB {
 	 * @param   array   the insert values
 	 * @return  string
 	 */
-	public function _insert($table, $keys, $values)
+	protected function _insert($table, $keys, $values)
 	{
 		return "INSERT INTO ".$table." (".implode(', ', $keys).") VALUES (".implode(', ', $values).")";
 	}
@@ -649,13 +649,13 @@ class CI_DB_oci8_driver extends CI_DB {
 	 *
 	 * Generates a platform-specific insert string from the supplied data
 	 *
-	 * @access      public
+	 * @access      protected
 	 * @param       string  the table name
 	 * @param       array   the insert keys
 	 * @param       array   the insert values
 	 * @return      string
 	 */
-	public function _insert_batch($table, $keys, $values)
+	protected function _insert_batch($table, $keys, $values)
 	{
 		$keys = implode(', ', $keys);
 		$sql = "INSERT ALL\n";
@@ -677,7 +677,7 @@ class CI_DB_oci8_driver extends CI_DB {
 	 *
 	 * Generates a platform-specific update string from the supplied data
 	 *
-	 * @access	public
+	 * @access	protected
 	 * @param	string	the table name
 	 * @param	array	the update data
 	 * @param	array	the where clause
@@ -685,7 +685,7 @@ class CI_DB_oci8_driver extends CI_DB {
 	 * @param	array	the limit clause
 	 * @return	string
 	 */
-	public function _update($table, $values, $where, $orderby = array(), $limit = FALSE)
+	protected function _update($table, $values, $where, $orderby = array(), $limit = FALSE)
 	{
 		foreach ($values as $key => $val)
 		{
@@ -714,11 +714,11 @@ class CI_DB_oci8_driver extends CI_DB {
 	 * If the database does not support the truncate() command
 	 * This function maps to "DELETE FROM table"
 	 *
-	 * @access	public
+	 * @access	protected
 	 * @param	string	the table name
 	 * @return	string
 	 */
-	public function _truncate($table)
+	protected function _truncate($table)
 	{
 		return "TRUNCATE TABLE ".$table;
 	}
@@ -730,13 +730,13 @@ class CI_DB_oci8_driver extends CI_DB {
 	 *
 	 * Generates a platform-specific delete string from the supplied data
 	 *
-	 * @access	public
+	 * @access	protected
 	 * @param	string	the table name
 	 * @param	array	the where clause
 	 * @param	string	the limit clause
 	 * @return	string
 	 */
-	public function _delete($table, $where = array(), $like = array(), $limit = FALSE)
+	protected function _delete($table, $where = array(), $like = array(), $limit = FALSE)
 	{
 		$conditions = '';
 
@@ -764,13 +764,13 @@ class CI_DB_oci8_driver extends CI_DB {
 	 *
 	 * Generates a platform-specific LIMIT clause
 	 *
-	 * @access  public
+	 * @access  protected
 	 * @param   string  the sql query string
 	 * @param   integer the number of rows to limit the query to
 	 * @param   integer the offset value
 	 * @return  string
 	 */
-	public function _limit($sql, $limit, $offset)
+	protected function _limit($sql, $limit, $offset)
 	{
 		$limit = $offset + $limit;
 		$newsql = "SELECT * FROM (select inner_query.*, rownum rnum FROM ($sql) inner_query WHERE rownum < $limit)";
@@ -791,11 +791,11 @@ class CI_DB_oci8_driver extends CI_DB {
 	/**
 	 * Close DB Connection
 	 *
-	 * @access  public
+	 * @access  protected
 	 * @param   resource
 	 * @return  void
 	 */
-	public function _close($conn_id)
+	protected function _close($conn_id)
 	{
 		@oci_close($conn_id);
 	}

--- a/system/database/drivers/oci8/oci8_result.php
+++ b/system/database/drivers/oci8/oci8_result.php
@@ -146,10 +146,10 @@ class CI_DB_oci8_result extends CI_DB_result {
 	 *
 	 * Returns the result set as an array
 	 *
-	 * @access  public
+	 * @access  protected
 	 * @return  array
 	 */
-	public function _fetch_assoc()
+	protected function _fetch_assoc()
 	{
 		$id = ($this->curs_id) ? $this->curs_id : $this->stmt_id;
 		return oci_fetch_assoc($id);
@@ -162,10 +162,10 @@ class CI_DB_oci8_result extends CI_DB_result {
 	 *
 	 * Returns the result set as an object
 	 *
-	 * @access  public
+	 * @access  protected
 	 * @return  object
 	 */
-	public function _fetch_object()
+	protected function _fetch_object()
 	{
 		$id = ($this->curs_id) ? $this->curs_id : $this->stmt_id;
 		return @oci_fetch_object($id);
@@ -204,10 +204,10 @@ class CI_DB_oci8_result extends CI_DB_result {
 	 * this internally before fetching results to make sure the
 	 * result set starts at zero
 	 *
-	 * @access	public
+	 * @access	protected
 	 * @return	array
 	 */
-	public function _data_seek($n = 0)
+	protected function _data_seek($n = 0)
 	{
 		return FALSE; // Not needed
 	}


### PR DESCRIPTION
- replaced all PHP4 / OCI8 PECL < 1.1.0 functions with those from PHP5 as they are no longer needed and are deprecated anyways
- removed a PHP4 backwards compatibility workaround for `_fetch_object()`
- fix `_error_message()` and `_error_code()` to work for connect-time generated errors
- method visibility declarations (not really needed, but still ... PHP4 no longer supported)
- miscellaneous clean-ups (spaces, comments, etc.)
