### PR TITLE
error_array method in Form_validation library.

### DIFF
--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -228,6 +228,21 @@ class CI_Form_validation {
 	// --------------------------------------------------------------------
 
 	/**
+	 * Get Array of Error Messages
+	 *
+	 * Returns the error messages as an array
+	 *
+	 * @access	public
+	 * @return	array
+	 */
+	public function error_array()
+	{
+		return $this->_error_array; 
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
 	 * Error String
 	 *
 	 * Returns the error messages as a string, wrapped in the error delimiters


### PR DESCRIPTION
Added method for Form validation library to access the error array variable. I often have a need to access this information so I can convert it to json for XHR.
