### PR TITLE
Corrected Form Validation class errors in user guide

### DIFF
--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -63,6 +63,7 @@ Release Date: Not Released
    -  Modified valid_ip() to use PHP's filter_var() when possible (>= PHP 5.2) in the <a href="libraries/form_validation.html">Form Validation</a> library.
    -  Added $config['use_page_numbers'] to the :doc:`Pagination library <libraries/pagination>`, which enables real page numbers in the URI.
    -  Added TLS and SSL Encryption for SMTP.
+   - Fixed documentation error in Form Validation that stated set_checkbox() utilizes the array form (i.e. colors[])for the field name instead of the straight form (i.e. colors).
 
 -  Core
 

--- a/user_guide_src/source/libraries/form_validation.rst
+++ b/user_guide_src/source/libraries/form_validation.rst
@@ -998,8 +998,8 @@ first parameter must contain the name of the checkbox, the second
 parameter must contain its value, and the third (optional) parameter
 lets you set an item as the default (use boolean TRUE/FALSE). Example::
 
-	<input type="checkbox" name="mycheck[]" value="1" <?php echo set_checkbox('mycheck[]', '1'); ?> />
-	<input type="checkbox" name="mycheck[]" value="2" <?php echo set_checkbox('mycheck[]', '2'); ?> />
+	<input type="checkbox" name="mycheck[]" value="1" <?php echo set_checkbox('mycheck', '1'); ?> />
+	<input type="checkbox" name="mycheck[]" value="2" <?php echo set_checkbox('mycheck', '2'); ?> />
 
 set_radio()
 ============


### PR DESCRIPTION
Fixed documentation error in Form Validation that stated set_checkbox() utilizes the array form (i.e. colors[])for the field name instead of the straight form (i.e. colors).
