### PR TITLE
Changed session table user_agent field to 255 to accommodate long strings

### DIFF
--- a/user_guide_src/source/libraries/sessions.rst
+++ b/user_guide_src/source/libraries/sessions.rst
@@ -242,7 +242,7 @@ session class::
 	CREATE TABLE IF NOT EXISTS  `ci_sessions` (
 		session_id varchar(40) DEFAULT '0' NOT NULL,
 		ip_address varchar(16) DEFAULT '0' NOT NULL,
-		user_agent varchar(120) NOT NULL,
+		user_agent varchar(255) NOT NULL,
 		last_activity int(10) unsigned DEFAULT 0 NOT NULL,
 		user_data text NOT NULL,
 		PRIMARY KEY (session_id),


### PR DESCRIPTION
Changed session table user_agent field to 255 to accommodate long agent strings. Truncation of this data would cause the session to not match when the "sess_match_useragent" config option was set to TRUE.
