### PR TITLE
CI_Loader::driver() processes empty library. Fixed.

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -616,6 +616,11 @@ class CI_Loader {
 			require BASEPATH.'libraries/Driver.php';
 		}
 
+		if ($library == '')
+		{
+			return FALSE;
+		}
+
 		// We can save the loader some time since Drivers will *always* be in a subfolder,
 		// and typically identically named to the library
 		if ( ! strpos($library, '/'))


### PR DESCRIPTION
This causes endless recursion calls _ci_load_class(), see #550
