### PR TITLE
get_magic_quotes_gpc() to be executed only if PHP version is 5.3 or lower

### DIFF
--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -554,8 +554,12 @@ class CI_Input {
 			return $new_array;
 		}
 
-		// We strip slashes if magic quotes is on to keep things consistent
-		if (function_exists('get_magic_quotes_gpc') AND @get_magic_quotes_gpc())
+		/* We strip slashes if magic quotes is on to keep things consistent
+
+		   NOTE: In PHP 5.4 get_magic_quotes_gpc() will always return 0 and
+			 it will probably not exist in future versions at all.
+		*/
+		if ( ! is_php('5.4') && get_magic_quotes_gpc())
 		{
 			$str = stripslashes($str);
 		}

--- a/system/libraries/Email.php
+++ b/system/libraries/Email.php
@@ -383,9 +383,13 @@ class CI_Email {
 	{
 		$this->_body = rtrim(str_replace("\r", "", $body));
 
-		//strip slashes only if magic quotes is ON
-		//if we do it with magic quotes OFF, it strips real, user-inputted chars.
-		if (get_magic_quotes_gpc())
+		/* strip slashes only if magic quotes is ON
+		   if we do it with magic quotes OFF, it strips real, user-inputted chars.
+
+		   NOTE: In PHP 5.4 get_magic_quotes_gpc() will always return 0 and
+			 it will probably not exist in future versions at all.
+		*/
+		if ( ! is_php('5.4') && get_magic_quotes_gpc())
 		{
 			$this->_body = stripslashes($this->_body);
 		}


### PR DESCRIPTION
In 5.4 and above, it will always return 0, if the function exists at all.
