### PR TITLE
Fixes an issue with the Image_lib class not clearing properties completely

### DIFF
--- a/system/libraries/Image_lib.php
+++ b/system/libraries/Image_lib.php
@@ -116,7 +116,7 @@ class CI_Image_lib {
 	 */
 	function clear()
 	{
-		$props = array('source_folder', 'dest_folder', 'source_image', 'full_src_path', 'full_dst_path', 'new_image', 'image_type', 'size_str', 'quality', 'orig_width', 'orig_height', 'rotation_angle', 'x_axis', 'y_axis', 'create_fnc', 'copy_fnc', 'wm_overlay_path', 'wm_use_truetype', 'dynamic_output', 'wm_font_size', 'wm_text', 'wm_vrt_alignment', 'wm_hor_alignment', 'wm_padding', 'wm_hor_offset', 'wm_vrt_offset', 'wm_font_color', 'wm_use_drop_shadow', 'wm_shadow_color', 'wm_shadow_distance', 'wm_opacity');
+		$props = array('source_folder', 'dest_folder', 'source_image', 'full_src_path', 'full_dst_path', 'new_image', 'image_type', 'size_str', 'quality', 'orig_width', 'orig_height', 'rotation_angle', 'x_axis', 'y_axis', 'create_fnc', 'copy_fnc', 'wm_overlay_path', 'wm_use_truetype', 'dynamic_output', 'wm_font_size', 'wm_text', 'wm_vrt_alignment', 'wm_hor_alignment', 'wm_padding', 'wm_hor_offset', 'wm_vrt_offset', 'wm_font_color', 'wm_use_drop_shadow', 'wm_shadow_color', 'wm_shadow_distance', 'wm_opacity', 'width', 'height');
 
 		foreach ($props as $val)
 		{
@@ -125,6 +125,9 @@ class CI_Image_lib {
 
 		// special consideration for master_dim
 		$this->master_dim = 'auto';
+		
+		// special consideration for create_thumb
+		$this->create_thumb = FALSE;
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
Encountered an issue in the Image_lib class when processing multiple images: Despite calling the clear() method between image operations, some settings were being persisted between calls, namely width, height and create_thumb. This update adds them to the list of properties reset in the clear() method.
