### PR TITLE
Add new feature: Output class support delete cache file

### DIFF
--- a/system/core/Output.php
+++ b/system/core/Output.php
@@ -321,14 +321,12 @@ class CI_Output {
 	 *
 	 * @access	public
 	 * @param	string
-	 * @return	void
+	 * @return	bool
 	 */
 	public function delete_cache($url = "")
 	{
 		$url = trim($url, "/");
 		$this->_delete_cache($url);
-
-		return TRUE;
 	}
 
 	// --------------------------------------------------------------------
@@ -533,7 +531,7 @@ class CI_Output {
 	 *
 	 * @access	public
 	 * @param 	string
-	 * @return	void
+	 * @return	bool
 	 */
 	public function _delete_cache($url)
 	{


### PR DESCRIPTION
Hi,

I add new function of output class. We can delete cache file from application/cache directory anytime.

Example: 

If you load welcome controller http://localhost/welcome/index

``` php
public function index()
{
    $this->output->cache(60);
    $this->load->view('welcome_message');
}
```

If the file doesn't expired, we can use the following way to delete it according to URL you load.

``` php
public function delete()
{
    $this->output->delete_cache('/welcome/index');
}
```
