### PR TITLE
Added a "break 2;", When overriding the Driver file

### DIFF
--- a/system/libraries/Driver.php
+++ b/system/libraries/Driver.php
@@ -76,7 +76,7 @@ class CI_Driver_Library {
 						if (file_exists($filepath))
 						{
 							include_once $filepath;
-							break;
+							break 2;
 						}
 					}
 				}


### PR DESCRIPTION
Added a "break 2;", When overriding the driver file in an other folder, it would try to load all files corresponding to this name and create an error because of a double file loading
