### PR TITLE
Fix language file names having to be unique on a project basis. 

### DIFF
--- a/system/core/Lang.php
+++ b/system/core/Lang.php
@@ -84,8 +84,9 @@ class CI_Lang {
 		}
 
 		$langfile .= '.php';
+		$langname  = "$idiom/$langfile";
 
-		if (in_array($langfile, $this->is_loaded, TRUE))
+		if (in_array($langname, $this->is_loaded, TRUE))
 		{
 			return;
 		}
@@ -135,7 +136,7 @@ class CI_Lang {
 			return $lang;
 		}
 
-		$this->is_loaded[] = $langfile;
+		$this->is_loaded[] = $langname;
 		$this->language = $this->language + $lang;
 		unset($lang);
 


### PR DESCRIPTION
Without this you would be unable to have two different languages with the same `_lang` files in them. For example:

If you had the following folder structure:

```
application/language
  en/general_lang.php
  de/general_lang.php
```

If you were to load the English `general_lang.php` file as default and then try to load the German one on a per-user basis the file wouldn't get loaded because the load function would only check the filename and ignore its `idiom`. This patch fixes that issue.
