### PR TITLE
Crypt isn't set and it causes extensive script time when specifying a cus

### DIFF
--- a/system/libraries/Email.php
+++ b/system/libraries/Email.php
@@ -1718,12 +1718,12 @@ class CI_Email {
 			$this->_send_command('hello');
 			$this->_send_command('starttls');
 			$crypto = stream_socket_enable_crypto($this->_smtp_connect, TRUE, STREAM_CRYPTO_METHOD_TLS_CLIENT);
-		}
 
-		if ($crypto !== TRUE)
-		{
-			$this->_set_error_message('lang:email_smtp_error', $this->_get_smtp_data());
-			return FALSE;
+			if ($crypto !== TRUE)
+			{
+				$this->_set_error_message('lang:email_smtp_error', $this->_get_smtp_data());
+				return FALSE;
+			}
 		}
 
 		return $this->_send_command('hello');


### PR DESCRIPTION
Crypt isn't set and it causes extensive script time when specifying a custom SMTP server
