### PR TITLE
Zip.php, add file exists check to prevent stat failed error warnings in the log 

### DIFF
--- a/system/libraries/Zip.php
+++ b/system/libraries/Zip.php
@@ -100,8 +100,8 @@ class CI_Zip  {
 	function _get_mod_time($dir)
 	{
 		// filemtime() may return false, but raises an error for non-existing files
-		$date = (file_exists($dir) && $filemtime = filemtime($dir)) ? $filemtime : getdate($this->now);
-
+		$date = (file_exists($dir)) ? filemtime($dir): getdate($this->now);
+		
 		$time['file_mtime'] = ($date['hours'] << 11) + ($date['minutes'] << 5) + $date['seconds'] / 2;
 		$time['file_mdate'] = (($date['year'] - 1980) << 9) + ($date['mon'] << 5) + $date['mday'];
 


### PR DESCRIPTION
These occur when creating .zips by passing data and creating an artificial fs structure inside the .zip
