### PR TITLE
Changelog HTML fix

### DIFF
--- a/user_guide/changelog.html
+++ b/user_guide/changelog.html
@@ -64,7 +64,7 @@ Change Log
 	<li>General Changes
 		<ul>
 			<li>Callback validation rules can now accept parameters like any other validation rule.</li>
-			<li class="reactor">Added html_escape() to the <a href="general/common_functions.html">Common functions<a> to escape HTML output for preventing XSS easliy.</li>
+			<li class="reactor">Added html_escape() to the <a href="general/common_functions.html">Common functions</a> to escape HTML output for preventing XSS easliy.</li>
 		</ul>
 	</li>
 	<li>Helpers


### PR DESCRIPTION
The link to common functions wasn't closed properly under the 'Added html_escape() to the Common functions' change.
