### PR TITLE
Fixed issue with sqlsrv and affected_rows()

### DIFF
--- a/system/database/drivers/sqlsrv/sqlsrv_driver.php
+++ b/system/database/drivers/sqlsrv/sqlsrv_driver.php
@@ -158,7 +158,8 @@ class CI_DB_sqlsrv_driver extends CI_DB {
 	function _execute($sql)
 	{
 		$sql = $this->_prep_query($sql);
-		if(stripos($sql,'UPDATE') !== FALSE || stripos($sql,'INSERT') !== FALSE) {
+		if (stripos($sql,'UPDATE') !== FALSE || stripos($sql,'INSERT') !== FALSE)
+		{
 			return sqlsrv_query($this->conn_id, $sql, null, array());
 		}
 		return sqlsrv_query($this->conn_id, $sql, null, array(


### PR DESCRIPTION
Code now does not use a scrollable cursor for UPDATE and INSERT statements. Previously would get "sqlsrv_rows_affected(): supplied resource is not a valid ss_sqlsrv_stmt resource" and "This function only works with statements that are not scrollable" when trying to use $this->db->affected_row() after running an UPDATE or INSERT statement. This has been tested by myself with a SQL Server 2005 database and the latest sqlsrv drivers.

First pull request on github ... go easy on me ;)
