### PR TITLE
add method get_vars() to CI_Loader

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -495,6 +495,20 @@ class CI_Loader {
 	// --------------------------------------------------------------------
 
 	/**
+	 * Get Variables
+	 *
+	 * Retrieve all loaded variables
+	 *
+	 * @return	array
+	 */
+	public function get_vars()
+	{
+		return $this->_ci_cached_vars;
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
 	 * Load Helper
 	 *
 	 * This function loads the specified helper file.

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -50,6 +50,7 @@ Release Date: Not Released
    -  Changed private functions in CI_URI to protected so MY_URI can
       override them.
    -  Removed CI_CORE boolean constant from CodeIgniter.php (no longer Reactor and Core versions).
+   -  Added method get_vars() to CI_Loader to retrieve all variables loaded with $this->load->vars()
 
 Bug fixes for 3.0
 ------------------

--- a/user_guide_src/source/libraries/loader.rst
+++ b/user_guide_src/source/libraries/loader.rst
@@ -165,6 +165,12 @@ This function checks the associative array of variables available to
 your views. This is useful if for any reason a var is set in a library
 or another controller method using $this->load->vars().
 
+$this->load->get_vars()
+===========================
+
+This function retrieves all variables available to
+your views.
+
 $this->load->helper('file_name')
 =================================
 


### PR DESCRIPTION
this allows you to retrieve all loaded variables without having to know the variable's name
