### PR TITLE
Added 'opera mobi' to user agents making it identified as 'Opera Mini'. ...

### DIFF
--- a/application/config/user_agents.php
+++ b/application/config/user_agents.php
@@ -174,6 +174,7 @@ $mobiles = array(
 	'mobilexplorer'	=> "Mobile Explorer",
 	'operamini'		=> "Opera Mini",
 	'opera mini'	=> "Opera Mini",
+	'opera mobi'	=> "Opera Mini",
 
 	// Other
 	'digital paths'	=> "Digital Paths",


### PR DESCRIPTION
...Fixes issue #683

The user agent string for Opera Mini since version 9.80 has added 'opera mobi' for some devices:
http://www.useragentstring.com/pages/Opera%20Mini/
