### PR TITLE
Added HTTP status code 422 (Unprocessable Entity) to set_status_header()

### DIFF
--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -419,6 +419,7 @@ if ( ! function_exists('set_status_header'))
 							415	=> 'Unsupported Media Type',
 							416	=> 'Requested Range Not Satisfiable',
 							417	=> 'Expectation Failed',
+							422	=> 'Unprocessable Entity',
 
 							500	=> 'Internal Server Error',
 							501	=> 'Not Implemented',


### PR DESCRIPTION
Some other frameworks (notably Rails) use a 422 Unprocessable Entity status when returning a model with validation errors. I was recently writing an API using CodeIgniter and wanted to use a 422 for this purpose, but set_status_header complained of "No status text available". This is a commonly used status code when building RESTful APIs and it'd be great if CodeIgniter recognised it by default.

<blockquote>"The 422 (Unprocessable Entity) status code means the server understands the content type of the request entity (hence a 415(Unsupported Media Type) status code is inappropriate), and the syntax of the request entity is correct (thus a 400 (Bad Request) status code is inappropriate) but was unable to process the contained instructions. For example, this error condition may occur if an XML request body contains well-formed (i.e., syntactically correct), but semantically erroneous XML instructions."</blockquote> - http://www.ruby-forum.com/topic/98002#207059
