### PR TITLE
Fix for issue #693

### DIFF
--- a/application/config/mimes.php
+++ b/application/config/mimes.php
@@ -160,8 +160,6 @@ $mimes = array('hqx'	=>	array('application/mac-binhex40', 'application/mac-binhe
 				'ac3'   =>	'audio/ac3',
 				'flac'  =>	'audio/x-flac',
 				'ogg'   =>	'audio/ogg',
-                'kml'   =>  'application/vnd.google-earth.kml+xml',
-                'kmz'   =>  'application/vnd.google-earth.kmz'
 			);
 
 


### PR DESCRIPTION
Just added a dummy method (hacky but simple) to CI_DB_Driver class so that _reset_select() method is not undefined when AR class is disabled (not loaded).
