### PR TITLE
Changed form_open() to compare $action against base_url()

### DIFF
--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -77,7 +77,7 @@ if ( ! function_exists('form_open'))
 		$form .= '>';
 
 		// Add CSRF field if enabled, but leave it out for GET requests and requests to external websites	
-		if ($CI->config->item('csrf_protection') === TRUE AND ! (strpos($action, $CI->config->site_url()) === FALSE OR strpos($form, 'method="get"')))	
+		if ($CI->config->item('csrf_protection') === TRUE AND ! (strpos($action, $CI->config->base_url()) === FALSE OR strpos($form, 'method="get"')))	
 		{
 			$hidden[$CI->security->get_csrf_token_name()] = $CI->security->get_csrf_hash();
 		}


### PR DESCRIPTION
Checking for strpos($action, $CI->config->site_url()) === FALSE causes CSRF token to not be added in form_open() output. When site_url()'s first parameter ($uri) is empty, site_url's return value is the base URL plus the $CI->config->item('index_page') value.  form_open() and CodeIgniter's URI routing do not require index.php to be in the URL, so any call to form_open() in which the $action parameter does not have index.php will always return false for the strpos() call.
