### PR TITLE
2.1.0 - Fatal error: Call to undefined method CI_DB_Driver::_reset_select()

### DIFF
--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -1381,7 +1381,21 @@ class CI_DB_driver {
 
 		return $item.$alias;
 	}
+	
+	// --------------------------------------------------------------------
 
+	/**
+	 * Dummy method that allows Active Record class to be disabled
+	 *
+	 * This function is used extensively by every db driver.
+	 *
+	 * @access	private
+	 * @return	void
+	 */
+	protected function _reset_select()
+	{
+	
+	}
 
 }
 


### PR DESCRIPTION
In CI 2.1.0 every database driver contains several calls to the method _reset_select(). However, the method _reset_select() is only available to the db drivers if the $active_record global variable in the database configuration file is set to TRUE since that method is inherited exclusively from the Active record class.

This means we're no longer able to disable the active record class because if we do so...database methods like count_all() will throw a fatal error since _reset_select() method is not defined.

This is a critical bug IMO. You should at least update the documentation stating the Active Record class cannot be disabled until this is fixed.

Hope you fix this soon.
