### PR TITLE
Changed form_open() to compare $action against base_url()

### DIFF
--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -65,7 +65,7 @@ if ( ! function_exists('form_open'))
 		$form .= '>';
 
 		// Add CSRF field if enabled, but leave it out for GET requests and requests to external websites	
-		if ($CI->config->item('csrf_protection') === TRUE AND ! (strpos($action, $CI->config->site_url()) === FALSE OR strpos($form, 'method="get"')))	
+		if ($CI->config->item('csrf_protection') === TRUE AND ! (strpos($action, $CI->config->base_url()) === FALSE OR strpos($form, 'method="get"')))	
 		{
 			$hidden[$CI->security->get_csrf_token_name()] = $CI->security->get_csrf_hash();
 		}

--- a/user_guide/changelog.html
+++ b/user_guide/changelog.html
@@ -71,6 +71,7 @@ Change Log
 <h3>Bug fixes for 2.1.1</h3>
 <ul>
 	<li>Fixed a bug (#697) - A wrong array key was used in the Upload library to check for mime-types.</li>
+	<li>Fixed a bug - form_open() compared $action against site_url() instead of base_url()</li>
 </ul>
 
 


### PR DESCRIPTION
Checking for `strpos($action, $CI->config->site_url()) === FALSE` in `form_open()` causes the CSRF token to not be added in `form_open()` output. When the first parameter (`$uri`) of `site_url()` is empty, site_url's return value is the base URL plus the return value of  `$CI->config->item('index_page')`. `form_open()` and CodeIgniter's URI routing do not require index.php to be in the URL, so any call to `form_open()` in which the `$action` parameter does not have 'index.php' will always return false for the `strpos()` call.
