### PR TITLE
Fixed syntax error in pdo driver

### DIFF
--- a/system/database/drivers/pdo/pdo_driver.php
+++ b/system/database/drivers/pdo/pdo_driver.php
@@ -255,11 +255,7 @@ class CI_DB_pdo_driver extends CI_DB {
 		// Reset the transaction failure flag.
 		// If the $test_mode flag is set to TRUE transactions will be rolled back
 		// even if the queries produce a successful result.
-<<<<<<< HEAD
-		$this->_trans_failure = ($test_mode === TRUE) ? TRUE : FALSE;
-=======
 		$this->_trans_failure = (bool) ($test_mode === TRUE);
->>>>>>> master
 
 		return $this->conn_id->beginTransaction();
 	}


### PR DESCRIPTION
Looks like some git data got pulled recently, causing a syntax error in the pdo_driver.php file. This corrects that.
