### PR TITLE
Shorthand syntax for Form Validation set_rules()

### DIFF
--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -97,9 +97,13 @@ class CI_Form_validation {
 		{
 			foreach ($field as $row)
 			{
-				// Houston, we have a problem...
+				// Houston, we (might) have a problem...
 				if ( ! isset($row['field']) OR ! isset($row['rules']))
 				{
+					if (count($row) === 3)
+					{
+						call_user_func_array(array($this, 'set_rules'), $row);
+					}
 					continue;
 				}
 

--- a/user_guide_src/source/libraries/form_validation.rst
+++ b/user_guide_src/source/libraries/form_validation.rst
@@ -254,7 +254,7 @@ Setting Rules Using an Array
 
 Before moving on it should be noted that the rule setting function can
 be passed an array if you prefer to set all your rules in one action. If
-you use this approach you must name your array keys as indicated::
+you use this approach you can structure your array in one of two ways indicated below::
 
 	$config = array(
 	               array(
@@ -277,6 +277,18 @@ you use this approach you must name your array keys as indicated::
 	                     'label'   => 'Email', 
 	                     'rules'   => 'required'
 	                  )
+	            );
+
+	$this->form_validation->set_rules($config);
+
+Or by using a group of shorthand arrays, each with **three** parameters. 
+The syntax is identical to setting an individual rule::
+
+	$config = array(
+	               array('username', 'Username', 'required'),
+	               array('password', 'Password', 'required'),
+	               array('passconf', 'Password Confirmation', 'required'),
+	               array('email', 'Email', 'required')
 	            );
 
 	$this->form_validation->set_rules($config);


### PR DESCRIPTION
Allows shorthand syntax for the array of rules passed into set_rules,
matching the syntax of setting an individual rule. Includes proposed
documentation update.

The following two methods for setting validation groups can be used:

```
$config = array(
               array('username', 'Username', 'required'),
               array('password', 'Password', 'required'),
               array('passconf', 'Password Confirmation', 'required'),
               array('email', 'Email', 'required')
            );

$this->form_validation->set_rules($config);
```

or the usual:

```
$config = array(
               array(
                     'field'   => 'username', 
                     'label'   => 'Username', 
                     'rules'   => 'required'
                  ),
               array(
                     'field'   => 'password', 
                     'label'   => 'Password', 
                     'rules'   => 'required'
                  ),
               array(
                     'field'   => 'passconf', 
                     'label'   => 'Password Confirmation', 
                     'rules'   => 'required'
                  ),   
               array(
                     'field'   => 'email', 
                     'label'   => 'Email', 
                     'rules'   => 'required'
                  )
            );

$this->form_validation->set_rules($config);
```
