### PR TITLE
Stop CI overriding the set config value for Maximum Execution Time, when running from CLI

### DIFF
--- a/system/core/CodeIgniter.php
+++ b/system/core/CodeIgniter.php
@@ -109,7 +109,7 @@
 	if (function_exists("set_time_limit") AND @ini_get("safe_mode") == 0)
 	{
 		// Do not override the Time Limit value if running from Command Line
-		if(php_sapi_name() != 'cli' && ! empty($_SERVER['REMOTE_ADDR']))
+		if(php_sapi_name() != 'cli')
 		{
 			@set_time_limit(300);
 		}


### PR DESCRIPTION
CI overrides the PHP Maximum Execution Time value to 300 seconds. Whilst this is sensible in the vast majority of situations (browsers), when running a script from CLI, it is likely that execution times may need to be longer. Therefore, don't override the time limit if being run from the CLI - instead default back to PHP's own configuration.

I have been writing an extensive database migration script (copying over GBs of data from an old structure to a totally new one). I'm using CI to format the data and handle the SQL. When performing a very large `batch_insert()` the execution timed out, even though I'd set `php.ini` to 3000 seconds rather than 300. I found the culprit to be CodeIgniter setting this value itself.
