### PR TITLE
PDO sqlite generates incorrect DSN, add check for empty db name

### DIFF
--- a/system/database/drivers/pdo/pdo_driver.php
+++ b/system/database/drivers/pdo/pdo_driver.php
@@ -90,7 +90,7 @@ class CI_DB_pdo_driver extends CI_DB {
 			$this->_like_escape_chr = '!';
 		}
 		
-		if (!empty($this->database))
+		if ( ! empty($this->database))
 		{
 			$this->hostname .= ";dbname=".$this->database;
 		}


### PR DESCRIPTION
Please see Issue #726 for discussion
