### PR TITLE
- Stop logger from trying to chmod on each event 

### DIFF
--- a/system/libraries/Log.php
+++ b/system/libraries/Log.php
@@ -111,6 +111,7 @@ class CI_Log {
 
 		if ( ! file_exists($filepath))
 		{
+			$newfile = TRUE;
 			$message .= "<"."?php  if ( ! defined('BASEPATH')) exit('No direct script access allowed'); ?".">\n\n";
 		}
 
@@ -126,7 +127,10 @@ class CI_Log {
 		flock($fp, LOCK_UN);
 		fclose($fp);
 
-		@chmod($filepath, FILE_WRITE_MODE);
+		if (isset($newfile) AND $newfile === TRUE)
+		{
+			@chmod($filepath, FILE_WRITE_MODE);
+		}
 		return TRUE;
 	}
 


### PR DESCRIPTION
... to safe i/o and prevent error messages popping up when the user is different then the webserver.

We run cron jobs from the command line as user Foo, while the webserver runs as user Bar. We now get a race condition whichever user executes first has the right to chmod the file. Every additional chmod() by the other user results in an error:

ERROR - 2011-11-30 15:12:58 --> Severity: Warning  --> chmod(): Operation not permitted /var/websites/superawesomeproject/codeigniter/libraries/Log.php 106

This fix only sets chmod on the first write when the file is created. Since it sets permissions to 666, every other user can write to the file.

Is there a specific reason why chmod() is called on each write to the Log class? 
