### PR TITLE
Fix for PDO driver, exception for sqlite in DSN spec

### DIFF
--- a/system/database/drivers/pdo/pdo_driver.php
+++ b/system/database/drivers/pdo/pdo_driver.php
@@ -90,7 +90,10 @@ class CI_DB_pdo_driver extends CI_DB {
 			$this->_like_escape_chr = '!';
 		}
 		
-		$this->hostname .= ";dbname=".$this->database;
+		if (strpos($this->hostname, 'sqlite') === FALSE)
+		{
+			$this->hostname .= ";dbname=".$this->database;
+		}
 		
 		$this->trans_enabled = FALSE;
 


### PR DESCRIPTION
Previously, the pdo driver constructor will generate the first parameter for PDO as follow

`"sqlite:/test.sqlite;dbname="`

This wont work for sqlite. The typical DSN for sqlite was something like

`"sqlite:/test.sqlite"`
