### PR TITLE
Added a property_exists around the call to find the value of a property ...

### DIFF
--- a/system/core/Model.php
+++ b/system/core/Model.php
@@ -48,7 +48,12 @@ class CI_Model {
 	function __get($key)
 	{
 		$CI =& get_instance();
-		return $CI->$key;
+		if ( property_exists( $CI, $key ) )
+		{
+			return $CI->$key;
+		}
+
+		return;
 	}
 }
 // END Model Class


### PR DESCRIPTION
...in the base model in __get.

This will prevent notices being raised for properties that don't exist
in the model. This way, you can override the getter to access your own
properties, and still make a call to the base model as a final
fallback, and not get a notice.
