### PR TITLE
Hotfix for broken _remove_evil_attributes() in XSS Security

### DIFF
--- a/system/core/Security.php
+++ b/system/core/Security.php
@@ -615,13 +615,13 @@ class CI_Security {
 		}
 		
 		// Parse tags, stripping evil attributes
-		// The subpattern (?:([\'"]).*?\2|[^>]) matches everything but >, unless it's in quotes
+		// The subpattern (?:([\'"]).*?\2|[^\'">]) matches everything but >, unless it's in quotes
 		// After the tag open, use this non-greedily (+?) to capture the tag name and non-evil attributes
 		// Then swallow as many evil attributes are found in a row
 		// Finally, use the special subpattern to capture any remaining attributes up to the end of the tag
-		$regex = '/<(\/?(?:([\'"]).*?\2|[^>])+?)'.	// Start open or close tag and capture safe attributes
-			'(?:\s+(?:'.implode('|', $evil_attributes).')\s*=\s*(?:([\'"]).*?\3|[^\s>]*))*'.	// Eat evil attributes
-			'((?:([\'"]).*?\5|[^>])*)>/';			// Capture remaining attributes until end of tag
+		$regex = '/<(\/?(?:([\'"]).*?\2|[^\'">])+?)'.	// Start open or close tag and capture safe attributes
+			'(?:\s+(?:'.implode('|', $evil_attributes).')\s*=\s*(?:([\'"]).*?\3|[^\s>]*))+'.	// Eat evil attributes
+			'((?:([\'"]).*?\5|[^\'">])*)>/';			// Capture remaining attributes until end of tag
 		// Wash, rinse, repeat...
 		do {
 			$str = preg_replace($regex, '<$1$4>', $str, -1, $count);


### PR DESCRIPTION
A recent change to the _remove_evil_attributes() function - part of the xss_clean() suite in Security.php - left it broken, or at least differently broken than it may have been before. I ran across the following string to be cleaned:

`<span style="color:#ff0000;">This is a test</span>`

Which got converted into:

`<span  is a test</span>`

The first regex pattern inside the loop eats everything that's not a space after an evil attribute. At very least, it needs to stop at a > character. While debugging and testing, I also noticed that the second regex pattern used duplicates the work of the first, in that the first is already picking up quoted attributes.

Thus, I worked out a replacement regex that analyzes each tag, stripping out evil attributes as it goes. This one will recognize attributes with single, double, or no quotes and accurately detect the end of each value. The pattern represents one full open or close tag - start to end - and will not get tripped up on '>' characters within valid quoted attributes. That is, if you tested this silly but technically valid string:

`<span id="foo" onclick="action()" customattr=">.<" style="color:#ff0000;">This is a test</span>`

...it would parse the entire span open tag, recognizing it with four attributes, and successfully remove the two evil ones. The regex also happens to be pretty about eating the preceding whitespace with each evil attribute it removes.

Finally, for a little bit of extra efficiency, the expression is assembled once outside the while loop to avoid implode() and string concatenation on each iteration, as this loop will run at least twice for any string containing an evil attribute.
