### PR TITLE
Fix issue #713 - Pagination lacks of anchor_target 

### DIFF
--- a/system/libraries/Pagination.php
+++ b/system/libraries/Pagination.php
@@ -70,6 +70,7 @@ class CI_Pagination {
 	protected $query_string_segment = 'per_page';
 	protected $display_pages		= TRUE;
 	protected $anchor_class			= '';
+	protected $anchor_attributes	= array(); // attribute/value pairs array for very anchors
 
 	/**
 	 * Constructor
@@ -268,13 +269,13 @@ class CI_Pagination {
 
 						if ($n == '' && $this->first_url != '')
 						{
-							$output .= $this->num_tag_open.'<a '.$this->anchor_class.'href="'.$this->first_url.'">'.$loop.'</a>'.$this->num_tag_close;
+							$output .= $this->num_tag_open.'<a '.$this->anchor_class.'href="'.$this->first_url.'"'.$this->_format_anchor_attributes($loop).'>'.$loop.'</a>'.$this->num_tag_close;
 						}
 						else
 						{
 							$n = ($n == '') ? '' : $this->prefix.$n.$this->suffix;
 
-							$output .= $this->num_tag_open.'<a '.$this->anchor_class.'href="'.$this->base_url.$n.'">'.$loop.'</a>'.$this->num_tag_close;
+							$output .= $this->num_tag_open.'<a '.$this->anchor_class.'href="'.$this->base_url.$n.'"'.$this->_format_anchor_attributes($loop).'>'.$loop.'</a>'.$this->num_tag_close;
 						}
 					}
 				}
@@ -286,7 +287,7 @@ class CI_Pagination {
 		{
 			$i = ($this->use_page_numbers) ? $this->cur_page + 1 : $this->cur_page * $this->per_page;
 
-			$output .= $this->next_tag_open.'<a '.$this->anchor_class.'href="'.$this->base_url.$this->prefix.$i.$this->suffix.'">'.$this->next_link.'</a>'.$this->next_tag_close;
+			$output .= $this->next_tag_open.'<a '.$this->anchor_class.'href="'.$this->base_url.$this->prefix.$i.$this->suffix.'"'.$this->_format_anchor_attributes($this->next_link).'>'.$this->next_link.'</a>'.$this->next_tag_close;
 		}
 
 		// Render the "Last" link
@@ -294,7 +295,7 @@ class CI_Pagination {
 		{
 			$i = ($this->use_page_numbers) ? $num_pages : ($num_pages * $this->per_page) - $this->per_page;
 
-			$output .= $this->last_tag_open.'<a '.$this->anchor_class.'href="'.$this->base_url.$this->prefix.$i.$this->suffix.'">'.$this->last_link.'</a>'.$this->last_tag_close;
+			$output .= $this->last_tag_open.'<a '.$this->anchor_class.'href="'.$this->base_url.$this->prefix.$i.$this->suffix.'"'.$this->_format_anchor_attributes($this->last_link).'>'.$this->last_link.'</a>'.$this->last_tag_close;
 		}
 
 		// Kill double slashes. Note: Sometimes we can end up with a double slash
@@ -305,6 +306,30 @@ class CI_Pagination {
 		$output = $this->full_tag_open.$output.$this->full_tag_close;
 
 		return $output;
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Gets a string representation of anchor_attributes, the class attribute/value pairs array for anchors
+	 * 
+	 * Example : array('target' => 'top', id => 'myAnchor') gives target="top" id="myAnchor"
+	 *
+	 * @access	private
+	 * @param	string	any string for macro replacement, if a macro %s is provided in the option value
+	 * @return	string a string representation of anchor_attributes, the class attribute/value pairs array for anchors
+	 */
+	private function _format_anchor_attributes($str = '')
+	{
+		$attributes = '';
+		if (is_array($this->anchor_attributes) === TRUE)
+		{
+			foreach ($this->anchor_attributes as $attribute=>$value)
+			{
+				$attributes .= ' '.$attribute.'="'.preg_replace('/(.*)%s(.*)/', '${1}'.$str.'$2', $value).'"';
+			}
+		}
+		return $attributes;
 	}
 }
 // END Pagination Class

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -124,6 +124,7 @@ Release Date: Not Released
       library <libraries/form_validation>`.
    -  Added $config['use_page_numbers'] to the :doc:`Pagination library <libraries/pagination>`, which enables real page numbers in the URI.
    -  Added TLS and SSL Encryption for SMTP.
+   -  Added $config['anchor_attributes'] to the :doc:`Pagination library <libraries/pagination>`, which enables the ability to add attributes to every anchor.
 
 -  Core
 

--- a/user_guide_src/source/libraries/pagination.rst
+++ b/user_guide_src/source/libraries/pagination.rst
@@ -254,3 +254,17 @@ Adding a class to every anchor
 If you want to add a class attribute to every link rendered by the
 pagination class, you can set the config "anchor_class" equal to the
 classname you want.
+
+*********************************
+Adding attributes to every anchor
+*********************************
+
+If you want to add attributes to every link rendered by the
+pagination class, you can set the config "anchor_attributes" equal to the
+array of attribute/value pairs you want. Placing a %s within an attribute value
+will be patched by the link's text as shown below::
+
+	 	$config['anchor_attributes']['target'] = '_top';
+		$config['anchor_attributes']['id'] = 'mylink%s';
+		
+		// Produces: <a href="http://example.com/index.php/test/page/20" target="_top" id="mylink2">2</a>


### PR DESCRIPTION
- Enables ability to add attributes to every anchor in Pagination library
- Updated doc and changelog with the possibly new feature

---

Adding attributes to every anchor

---

If you want to add attributes to every link rendered by the
pagination class, you can set the config "anchor_attributes" equal to the
array of attribute/value pairs you want. Placing a %s within an attribute value
will be patched by the link's text as shown below::

```
    $config['anchor_attributes']['target'] = '_top';
    $config['anchor_attributes']['id'] = 'mylink%s';

    // Produces: <a href="http://example.com/index.php/test/page/20" target="_top" id="mylink2">2</a>
```
