### PR TITLE
fix to issue #696

### DIFF
--- a/system/database/drivers/oci8/oci8_result.php
+++ b/system/database/drivers/oci8/oci8_result.php
@@ -57,11 +57,11 @@ class CI_DB_oci8_result extends CI_DB_result {
 		if ($this->num_rows === 0 && count($this->result_array()) > 0)
 		{
 			$this->num_rows = count($this->result_array());
-			@oci_execute($this->stmt_id);
+			@oci_execute($this->stmt_id, OCI_DEFAULT);
 
 			if ($this->curs_id)
 			{
-				@oci_execute($this->curs_id);
+				@oci_execute($this->curs_id, OCI_DEFAULT);
 			}
 		}
 


### PR DESCRIPTION
Was doing a small project with oracle and noticed transactions were not working. Followed the bug back to the way rows are counted in the oci driver. Iterating through the oci result set and building an array of result objects while also counting rows works, but running the query a second time to reset the oci cursor breaks transactions (since the query is committed, even though it's only a select). Running the second query in non-commit mode is a workable fix, see the notes I've made on the issue page for more in-depth discussion.
