### PR TITLE
Changes "ie" to "e.g." 

### DIFF
--- a/application/config/database.php
+++ b/application/config/database.php
@@ -41,7 +41,7 @@
 |	['username'] The username used to connect to the database
 |	['password'] The password used to connect to the database
 |	['database'] The name of the database you want to connect to
-|	['dbdriver'] The database type. ie: mysql.  Currently supported:
+|	['dbdriver'] The database type. e.g.: mysql.  Currently supported:
 				 mysql, mysqli, pdo, postgre, odbc, mssql, sqlite, oci8
 |	['dbprefix'] You can add an optional prefix, which will be added
 |				 to the table name when using the  Active Record class


### PR DESCRIPTION
The instruction is followed by an example database type, not a clarification of what database types in general are, so it should use "e.g."
