### PR TITLE
Fix news item href

### DIFF
--- a/user_guide_src/source/tutorial/news_section.rst
+++ b/user_guide_src/source/tutorial/news_section.rst
@@ -149,7 +149,7 @@ and add the next piece of code.
         <div id="main">
             <?php echo $news_item['text'] ?>
         </div>
-        <p><a href="news/<?php echo $news_item['slug'] ?>">View article</a></p>
+        <p><a href="<?php echo $news_item['slug'] ?>">View article</a></p>
 
     <?php endforeach ?>
 


### PR DESCRIPTION
News index page already has 'news' in its URL, so including it again in the news item href results in a 404
