### PR TITLE
Changes in the UTF8 Class.

### DIFF
--- a/system/core/Utf8.php
+++ b/system/core/Utf8.php
@@ -44,19 +44,18 @@ class CI_Utf8 {
 	 * Constructor
 	 *
 	 * Determines if UTF-8 support is to be enabled
-	 *
 	 */
-	function __construct()
+	public function __construct()
 	{
 		log_message('debug', "Utf8 Class Initialized");
 
 		global $CFG;
 
 		if (
-			preg_match('/./u', 'é') === 1					// PCRE must support UTF-8
-			AND function_exists('iconv')					// iconv must be installed
-			AND ini_get('mbstring.func_overload') != 1		// Multibyte string function overloading cannot be enabled
-			AND $CFG->item('charset') == 'UTF-8'			// Application charset must be UTF-8
+			@preg_match('/./u', 'é') === 1		// PCRE must support UTF-8
+			&& function_exists('iconv')			// iconv must be installed
+			&& ini_get('mbstring.func_overload') !== 1	// Multibyte string function overloading cannot be enabled
+			&& $CFG->item('charset') == 'UTF-8'			// Application charset must be UTF-8
 			)
 		{
 			log_message('debug', "UTF-8 Support Enabled");
@@ -90,11 +89,10 @@ class CI_Utf8 {
 	 *
 	 * Ensures strings are UTF-8
 	 *
-	 * @access	public
 	 * @param	string
 	 * @return	string
 	 */
-	function clean_string($str)
+	public function clean_string($str)
 	{
 		if ($this->_is_ascii($str) === FALSE)
 		{
@@ -113,11 +111,10 @@ class CI_Utf8 {
 	 * line feeds, and carriage returns, as all others can cause
 	 * problems in XML
 	 *
-	 * @access	public
 	 * @param	string
 	 * @return	string
 	 */
-	function safe_ascii_for_xml($str)
+	public function safe_ascii_for_xml($str)
 	{
 		return remove_invisible_characters($str, FALSE);
 	}
@@ -129,12 +126,11 @@ class CI_Utf8 {
 	 *
 	 * Attempts to convert a string to UTF-8
 	 *
-	 * @access	public
 	 * @param	string
 	 * @param	string	- input encoding
 	 * @return	string
 	 */
-	function convert_to_utf8($str, $encoding)
+	public function convert_to_utf8($str, $encoding)
 	{
 		if (function_exists('iconv'))
 		{
@@ -159,13 +155,12 @@ class CI_Utf8 {
 	 *
 	 * Tests if a string is standard 7-bit ASCII or not
 	 *
-	 * @access	public
 	 * @param	string
 	 * @return	bool
 	 */
-	function _is_ascii($str)
+	protected function _is_ascii($str)
 	{
-		return (preg_match('/[^\x00-\x7F]/S', $str) == 0);
+		return (preg_match('/[^\x00-\x7F]/S', $str) === 0);
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
- Adding error suppression ("@") on the preg_match() in the constructor to help prevent errors if PCRE doesn't support Unicode
- Adding method visibility.
- Changed comparisons on integers/booleans to explicit.  eg:  !==/===
