### PR TITLE
No need for eval to extend a class

### DIFF
--- a/system/database/DB.php
+++ b/system/database/DB.php
@@ -138,14 +138,14 @@ function &DB($params = '', $active_record_override = NULL)
 
 		if ( ! class_exists('CI_DB'))
 		{
-			eval('class CI_DB extends CI_DB_active_record { }');
+			class CI_DB extends CI_DB_active_record { }
 		}
 	}
 	else
 	{
 		if ( ! class_exists('CI_DB'))
 		{
-			eval('class CI_DB extends CI_DB_driver { }');
+			class CI_DB extends CI_DB_driver { }
 		}
 	}
 


### PR DESCRIPTION
Can you verify there would be a need to use eval to extend the CI_DB class?
