### PR TITLE
Fix a bug and put some comments describing changes from pull #818

### DIFF
--- a/system/libraries/Image_lib.php
+++ b/system/libraries/Image_lib.php
@@ -171,11 +171,7 @@ class CI_Image_lib {
 					{
 						if (preg_match('/^#?([0-9a-f]{3}|[0-9a-f]{6})$/i', $val, $matches))
 						{
-							/* This particular line has caused a lengthy discussion
-							 * (https://github.com/EllisLab/CodeIgniter/pull/818), so
-							 * just to clarify:
-							 *
-							 * $matches[1] contains our hex color value, but it might be
+							/* $matches[1] contains our hex color value, but it might be
 							 * both in the full 6-length format or the shortened 3-length
 							 * value.
 							 * We'll later need the full version, so we keep it if it's


### PR DESCRIPTION
We need to split `wm_font_color` and `wm_shadow_color` into 2 character chunks to get the proper hex RGB values. This bug was introduced yesterday in pull #818 (sorry about that), so no changelog entry should be needed.
The rest are just comments to describe code from the same pull request that turned out might be confusing.
