### PR TITLE
HMVC lite typo in Hooks initializer

### DIFF
--- a/system/core/Hooks.php
+++ b/system/core/Hooks.php
@@ -79,7 +79,7 @@ class CI_Hooks {
 
 		// Grab the "hooks" definition file.
 		// If there are no hooks, we're done.
-		$hook = $CI->config->get('hooks.php', 'hooks');
+		$hook = $CI->config->get('hooks.php', 'hook');
 		if (is_array($hook))
 		{
 			$this->hooks =& $hook;


### PR DESCRIPTION
The variable name in the config load call was wrong (was hooks instead of hook).
