### PR TITLE
Fix for Hmvc lite subfolder default controller handling

### DIFF
--- a/system/core/Router.php
+++ b/system/core/Router.php
@@ -273,9 +273,14 @@ class CI_Router {
 						continue;
 					}
 
-					// Get class and method
-					$class = array_unshift($default);
-					$method = array_unshift($default);
+					// Get class and method:
+					// - index 0 and 1 are always present
+					// - since we are in a sub-folder the
+					//   first entry is now the directory
+					$directory = array_shift($default);
+					$class = array_shift($default);
+					// the $default route may not have the method set
+					$method = count($default) ? array_shift($default) : 'index';
 				}
 
 				// Does the requested controller exist in the sub-folder?
@@ -533,6 +538,8 @@ class CI_Router {
 
 	/**
 	 * Get segments of default controller
+	 *
+	 * Returns at least two segments
 	 *
 	 * @access	protected
 	 * @return	array	array of segments


### PR DESCRIPTION
When the URL would only contain the subfolder but not the controller
name, the used routine was wrong.

example URL: http://example.com/index.php/subfolder/
1. use of array_unshift instead of array_shift
2. since we're in a subfolder, the $default segments contain the directory as first segment
