### PR TITLE
Fix for Hmvc lite subfolder late loading controller

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -341,7 +341,7 @@ class CI_Loader {
 			}
 
 			// Include source and instantiate object
-			include($path.'controllers/'.$subdir.strtolower($class).'.php');
+			include($path.'controllers/'.$subdir.'/'.strtolower($class).'.php');
 			$classnm = ucfirst($class);
 			$this->CI->$name = new $classnm();
 


### PR DESCRIPTION
Loader.php: Add a slash after the subfolder name.

The bug occured when trying to load a controller from a subfolder as 404 override
