### PR TITLE
Fixed issue 874

### DIFF
--- a/system/libraries/Image_lib.php
+++ b/system/libraries/Image_lib.php
@@ -408,7 +408,7 @@ class CI_Image_lib {
 	 */
 	public function crop()
 	{
-		$protocol = (strtolower(substr($this->image_library, 0, -3)) === 'gd2') ? 'image_process_gd' : 'image_process_'.$this->image_library;
+		$protocol = ($this->image_library === 'gd2') ? 'image_process_gd' : 'image_process_'.$this->image_library;
 		return $this->$protocol('crop');
 	}
 


### PR DESCRIPTION
The bug was introduced in one of my latest pull requests and the code was never released, so no changelog entry should be needed.

I remember specifically testing the result of `substr($string, 0, -$length)` prior to submitting it, but I guess ... well, I don't know how that happened. Anyways - it's better this way as neither `substr()` or `strtolower()` are required.
