### PR TITLE
Improve the core Loader library

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -1165,13 +1165,6 @@ class CI_Loader {
 			}
 		}
 
-		// A little tweak to remain backward compatible
-		// The $autoload['core'] item was deprecated
-		if ( ! isset($autoload['libraries']) AND isset($autoload['core']))
-		{
-			$autoload['libraries'] = $autoload['core'];
-		}
-
 		// Load libraries
 		if (isset($autoload['libraries']) AND count($autoload['libraries']) > 0)
 		{

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -31,6 +31,8 @@ Release Date: Not Released
    -  Added application/xml for xml and application/xml, text/xsl for xsl in mimes.php.
    -  Changed logger to only chmod when file is first created.
    -  Removed previously deprecated SHA1 Library.
+   -  Removed previously deprecated use of ``$autoload['core']`` in application/config/autoload.php.
+      Only entries in ``$autoload['libraries']`` are auto-loaded now.
 
 -  Helpers
 
@@ -66,10 +68,9 @@ Release Date: Not Released
 
 -  Core
 
-   -  Changed private functions in CI_URI to protected so MY_URI can
-      override them.
+   -  Changed private functions in CI_URI to protected so MY_URI can override them.
    -  Removed CI_CORE boolean constant from CodeIgniter.php (no longer Reactor and Core versions).
-   -  Added method get_vars() to CI_Loader to retrieve all variables loaded with $this->load->vars()
+   -  Added method get_vars() to CI_Loader to retrieve all variables loaded with $this->load->vars().
 
 Bug fixes for 3.0
 ------------------

--- a/user_guide_src/source/installation/upgrade_300.rst
+++ b/user_guide_src/source/installation/upgrade_300.rst
@@ -15,6 +15,9 @@ Replace all files and directories in your "system" folder and replace
 your index.php file. If any modifications were made to your index.php
 they will need to be made fresh in this new one.
 
+.. note:: If you have any custom developed files in these folders please
+	make copies of them first.
+
 Step 2: Change References to the SHA Library
 ============================================
 
@@ -23,6 +26,8 @@ Alter your code to use the native `sha1()` PHP function to generate a sha1 hash.
 
 Additionally, the `sha1()` method in the :doc:`Encryption Library <../libraries/encryption>` has been removed.
 
+Step 3: Remove $autoload['core'] from your config/autoload.php
+==============================================================
 
-.. note:: If you have any custom developed files in these folders please
-	make copies of them first.
+Use of the `$autoload['core']` config array has been deprecated as of CodeIgniter 1.4.1 and is now removed.
+Move any entries that you might have listed there to `$autoload['libraries']` instead.


### PR DESCRIPTION
Removed auto-loading libraries from `$autoload['core']` in application/config/autoload.php - this was deprecated as of 1.4.1.

Also cleaned up some spaces & comments.
