### PR TITLE
Fixed a bug in CI_Lang::load()

### DIFF
--- a/system/core/Lang.php
+++ b/system/core/Lang.php
@@ -130,7 +130,7 @@ class CI_Lang {
 		}
 
 		$this->is_loaded[] = $langfile;
-		$this->language = $this->language + $lang;
+		$this->language = array_merge($this->language, $lang);
 		unset($lang);
 
 		log_message('debug', 'Language file loaded: language/'.$idiom.'/'.$langfile);


### PR DESCRIPTION
The bug has been introduced at some point after the 2.1 release and only exists in the develop tree.

The old line seems valid at first, but it will only append elements with keys that don't already exist in `$this->language`.
Example:

```
php > $a1 = array('test');
php > $a2 = array('test2', 'test3');
php > $test = $a1 + $a2;
php > var_dump($test);
array(2) {
  [0]=>
  string(4) "test"
  [1]=>
  string(5) "test3"
}
php > var_dump(array_merge($a1, $a2));
array(3) {
  [0]=>
  string(4) "test"
  [1]=>
  string(5) "test2"
  [2]=>
  string(5) "test3"
}
```
