### PR TITLE
Enable use of HTTPONLY cookies for session data when available

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -297,12 +297,15 @@ $config['sess_time_to_update']	= 300;
 | 'cookie_domain' = Set to .your-domain.com for site-wide cookies
 | 'cookie_path'   =  Typically will be a forward slash
 | 'cookie_secure' =  Cookies will only be set if a secure HTTPS connection exists.
+| 'cookie_httponly'			= Whether to mark the cookie as httponly. Httponly means javascript
+|   cannot access the cookie (not implemented in all browsers, most modern do)
 |
 */
 $config['cookie_prefix']	= "";
 $config['cookie_domain']	= "";
 $config['cookie_path']		= "/";
 $config['cookie_secure']	= FALSE;
+$config['cookie_httponly']	= FALSE;
 
 /*
 |--------------------------------------------------------------------------

--- a/system/libraries/Session.php
+++ b/system/libraries/Session.php
@@ -50,6 +50,7 @@ class CI_Session {
 	public $cookie_path			= '';
 	public $cookie_domain			= '';
 	public $cookie_secure			= FALSE;
+	public $cookie_httponly			= FALSE;
 	public $sess_time_to_update		= 300;
 	public $encryption_key			= '';
 	public $flashdata_key			= 'flash';
@@ -74,7 +75,7 @@ class CI_Session {
 
 		// Set all the session preferences, which can either be set
 		// manually via the $params array above or via the config file
-		foreach (array('sess_encrypt_cookie', 'sess_use_database', 'sess_table_name', 'sess_expiration', 'sess_expire_on_close', 'sess_match_ip', 'sess_match_useragent', 'sess_cookie_name', 'cookie_path', 'cookie_domain', 'cookie_secure', 'sess_time_to_update', 'time_reference', 'cookie_prefix', 'encryption_key') as $key)
+		foreach (array('sess_encrypt_cookie', 'sess_use_database', 'sess_table_name', 'sess_expiration', 'sess_expire_on_close', 'sess_match_ip', 'sess_match_useragent', 'sess_cookie_name', 'cookie_path', 'cookie_domain', 'cookie_secure', 'sess_time_to_update', 'time_reference', 'cookie_prefix', 'encryption_key', 'cookie_httponly') as $key)
 		{
 			$this->$key = (isset($params[$key])) ? $params[$key] : $this->CI->config->item($key);
 		}
@@ -648,14 +649,29 @@ class CI_Session {
 		$expire = ($this->sess_expire_on_close === TRUE) ? 0 : $this->sess_expiration + time();
 
 		// Set the cookie
-		setcookie(
-					$this->sess_cookie_name,
-					$cookie_data,
-					$expire,
-					$this->cookie_path,
-					$this->cookie_domain,
-					$this->cookie_secure
-				);
+		if( is_php('5.2.0') )
+		{
+			setcookie(
+						$this->sess_cookie_name,
+						$cookie_data,
+						$expire,
+						$this->cookie_path,
+						$this->cookie_domain,
+						$this->cookie_secure,
+						$this->cookie_httponly
+					);
+		}
+		else
+		{
+			setcookie(
+						$this->sess_cookie_name,
+						$cookie_data,
+						$expire,
+						$this->cookie_path,
+						$this->cookie_domain,
+						$this->cookie_secure
+					);
+		}
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
HTTPONLY enables one to hide cookies from the javascript code. This is useful to help prevent XSS attacks.

http://en.wikipedia.org/wiki/HTTP_cookie#HttpOnly_cookie
