### PR TITLE
2.1 stable: Fix for issue #183: Form validation class bug.

### DIFF
--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -622,22 +622,22 @@ class CI_Form_validation {
 					{
 						log_message('debug', "Unable to find validation rule: ".$rule);
 
-                        continue;
+						continue;
 					}
 				}
-                else
-                {
-                    $result = $this->$rule($postdata, $param);
-                }
+				else
+				{
+					$result = $this->$rule($postdata, $param);
+				}
 
-                if ($_in_array == TRUE)
-                {
-                    $this->_field_data[$row['field']]['postdata'][$cycles] = (is_bool($result)) ? $postdata : $result;
-                }
-                else
-                {
-                    $this->_field_data[$row['field']]['postdata'] = (is_bool($result)) ? $postdata : $result;
-                }
+				if ($_in_array == TRUE)
+				{
+					$this->_field_data[$row['field']]['postdata'][$cycles] = (is_bool($result)) ? $postdata : $result;
+				}
+				else
+				{
+					$this->_field_data[$row['field']]['postdata'] = (is_bool($result)) ? $postdata : $result;
+				}
 			}
 
 			// Did the rule test negatively?  If so, grab the error.


### PR DESCRIPTION
Today I noticed this bug and fixed it so I could continue developing an app for one of my clients. 
It's an important bug in my opinion.

This bug caused native PHP functions (and user defined global functions) to be ignored when used as a validation or prepping rule.

I've tested my fix in a real scenario (the app I'm building) and it's working properly.

BTW, sorry for the 5 commits...I had an issue with spaces vs tabs.
