### PR TITLE
APC Validate apc_store TTL

### DIFF
--- a/system/libraries/Cache/drivers/Cache_apc.php
+++ b/system/libraries/Cache/drivers/Cache_apc.php
@@ -68,6 +68,7 @@ class CI_Cache_apc extends CI_Driver {
 	 */
 	public function save($id, $data, $ttl = 60)
 	{
+		$ttl = (int) $ttl;
 		return apc_store($id, array($data, time(), $ttl), $ttl);
 	}
 


### PR DESCRIPTION
APC throws "apc_store() expects parameter 3 to be long, string given". Validates the TTL to an integer.
