### PR TITLE
Add Security class to list of core classes in docs

### DIFF
--- a/user_guide_src/source/general/core_classes.rst
+++ b/user_guide_src/source/general/core_classes.rst
@@ -31,6 +31,7 @@ time CodeIgniter runs:
 -  Log
 -  Output
 -  Router
+-  Security
 -  URI
 -  Utf8
 


### PR DESCRIPTION
It appears the Security class has been added to the system/core folder and is loaded automatically as well.

Using $this->load->library('security'); in controllers currently returns FALSE, yet you might not notice because the Security class is already loaded.
I discovered this because of a custom Loader class I was using returned an error when loading the Security class.
