### PR TITLE
Fixed multiple column non-primary keys in DB_forge.

### DIFF
--- a/system/database/DB_forge.php
+++ b/system/database/DB_forge.php
@@ -97,16 +97,6 @@ class CI_DB_forge {
 	 */
 	function add_key($key = '', $primary = FALSE)
 	{
-		if (is_array($key))
-		{
-			foreach ($key as $one)
-			{
-				$this->add_key($one, $primary);
-			}
-
-			return;
-		}
-
 		if ($key == '')
 		{
 			show_error('Key information is required for that operation.');


### PR DESCRIPTION
According to the User guide below code will generate a compound index.

```
$this->dbforge->add_key(array('blog_name', 'blog_label')); 
```

But it generate two individual indexes.

This issue was also found in 2010.

http://codeigniter.com/forums/viewthread/175805/
