### PR TITLE
Output class sends HTTP headers to match file caching settings

### DIFF
--- a/system/core/Output.php
+++ b/system/core/Output.php
@@ -466,6 +466,9 @@ class CI_Output {
 		@chmod($cache_path, FILE_WRITE_MODE);
 
 		log_message('debug', 'Cache file written: '.$cache_path);
+		
+		// Send HTTP cache-control headers to browser to match file cache settings.
+		$this->set_cache_header($_SERVER['REQUEST_TIME'],$expire);
 	}
 
 	// --------------------------------------------------------------------
@@ -503,12 +506,21 @@ class CI_Output {
 			return FALSE;
 		}
 
-		// Has the file expired? If so we'll delete it.
-		if (time() >= trim(str_replace('TS--->', '', $match[1])) && is_really_writable($cache_path))
+		$last_modified = filemtime($cache_path);
+		$expire = trim(str_replace('TS--->', '', $match[1]));
+
+		// Has the file expired?
+		if ($_SERVER['REQUEST_TIME'] >= $expire && is_really_writable($cache_path))
 		{
+			// If so we'll delete it.
 			@unlink($filepath);
 			log_message('debug', 'Cache file has expired. File deleted.');
 			return FALSE;
+		}
+		else
+		{	
+			// Or else send the HTTP cache control headers.
+			$this->set_cache_header($last_modified,$expire);
 		}
 
 		// Display the cache
@@ -516,6 +528,35 @@ class CI_Output {
 		log_message('debug', 'Cache file is current. Sending it to browser.');
 		return TRUE;
 	}
+
+
+	// --------------------------------------------------------------------
+	/**
+	 * Set the HTTP headers to match the server-side file cache settings
+	 * in order to reduce bandwidth.
+	 *
+	 * @param 	int		timestamp of when the page was last modified
+	 * @param 	int		timestamp of when should the requested page expire from cache
+	 * @return	void
+	 */
+	public function set_cache_header($last_modified,$expiration)
+	{		
+        $max_age = $expiration - $_SERVER['REQUEST_TIME'];
+
+		if (isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) && ($last_modified <= strtotime($_SERVER['HTTP_IF_MODIFIED_SINCE'])))
+		{
+			$this->set_status_header(304);
+			exit;
+		}
+		else
+		{
+			header('Pragma: public'); 
+			header('Cache-Control: max-age=' . $max_age . ', public');
+			header('Expires: '.gmdate('D, d M Y H:i:s', $expiration).' GMT');
+			header('Last-modified: '.gmdate('D, d M Y H:i:s', $last_modified).' GMT');
+		}
+	}
+
 
 }
 


### PR DESCRIPTION
Employs both "Last-modified" and "Expires"/"Max-age" types of http headers for browser-side caching.

Browsers will now check with a "if-modified-since" header whether the version of the page in the browser cache is stale.  CodeIgniter will check the last-modified date of the cache file and respond with a "304/Not modified" header instead of resending the exact same content.  This results in faster page loads and less bandwidth consumption.  Search engines also adhere to this rule, and so a site with a large amount of cached content can save considerably on bandwidth costs.

Still, this first method requires a response from the server before the cached page is rerendered by the browser.

The "expires"/"max-age" http headers avoid even this.  All the checks are internally.  The only possible issue is if a developer had manually flushed the file cache (or has written some routine that does this), the browser cache will have no way of knowing and will continue to serve of stale content until the original expiration or until they "refresh" the page.  This is an edge case, but if it's an issue perhaps it might make sense to have a config setting so developers can choose whether they prefer this behavior or not.
