### PR TITLE
Output Cache: GZip Before Writing File and Save Mime-Type to Cache File.

### DIFF
--- a/system/core/Output.php
+++ b/system/core/Output.php
@@ -387,7 +387,7 @@ class CI_Output {
 				// If $CI doesn't exist then we know we're serving up
 				// a cached file.  Since cached files are already gzip
 				// encoded, 
-				ini_set('zlib.output_compression','Off');
+				ini_set('zlib.output_compression', 'Off');
 				header('Content-Encoding: gzip');
 				header('Content-Length: '.strlen($output));
 				
@@ -404,7 +404,7 @@ class CI_Output {
 			// If output compression is not enabled or supported
 			// yet we are serving up a compressed cached file, we need
 			// to decompress the file first before serving it.
-			echo gzinflate(substr($output,10,-8)); 
+			echo gzinflate(substr($output, 10, -8)); 
 			log_message('debug', 'Final (uncompressed) output sent to browser');
 			log_message('debug', 'Total execution time: '.$elapsed);
 			return TRUE;
@@ -483,7 +483,7 @@ class CI_Output {
 
 		if (flock($fp, LOCK_EX))
 		{
-			fwrite($fp, $expire.'TS--->'.$this->mime_type.'MT--->'.gzencode($output,6));
+			fwrite($fp, $expire.'TS--->'.$this->mime_type.'MT--->'.gzencode($output, 6));
 			flock($fp, LOCK_UN);
 		}
 		else


### PR DESCRIPTION
Applies two changes to the format of cached files:
1. The output is gzipped before it is written to disk, thus reducing the processing overhead associated with gzipping the same content repeatedly on every single page request while also reducing disk space consumption.  For the 10% (or probably much less these days) of cases where GZip is not supported by the browser, the cached content is uncompressed before being outputted.  This improves efficiency for sites that rely on heavy caching (less processing, less disk i/o, less disk consumption).
2. Mime-type (if it has been set via the set_content_type() function) is also saved in the new cache file format.  There are many cases where a developer would want CodeIgniter to spit out some cached CSS, JSON, JavaScript, XML, etc., but until now this has not been possible!

Due to the change in file format for the cached files, developers will need to clear the cache folder when upgrading.  
This is just one of many ideas for improvements to the output library that I proposed here:
http://codeigniter.uservoice.com/forums/40508-codeigniter-reactor/suggestions/2530591-cache-output-library-improvements-overhaul-?tracking_code=57a1219af213e7d050ef5dd9064ca9b7

(PS--ignore those first two commits, those were for a different pull request and I don't know enough about git to get them out of this one.)
