### PR TITLE
Add method to parse a supplied User Agent string.

### DIFF
--- a/system/libraries/User_agent.php
+++ b/system/libraries/User_agent.php
@@ -522,6 +522,40 @@ class CI_User_agent {
 		return (in_array(strtolower($charset), $this->charsets(), TRUE));
 	}
 
+	/**
+	 * Parse a User Agent string that is not the current users
+	 * Note: is_referral() and referrer() methods will not work
+	 * 
+	 * @param string $agent_string User Agent string to parse,
+	 *        eg 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'
+	 */
+	public function parse_agent_string($agent_string = '')
+	{
+		//reset everything
+		$this->is_browser	= FALSE;
+		$this->is_robot		= FALSE;
+		$this->is_mobile	= FALSE;
+		$this->languages	= array();
+		$this->charsets		= array();
+		$this->platforms	= array();
+		$this->browsers		= array();
+		$this->mobiles		= array();
+		$this->robots		= array();
+		$this->platform		= '';
+		$this->browser		= '';
+		$this->version		= '';
+		$this->mobile		= '';
+		$this->robot		= '';
+		
+		//set the new agent string to parse
+		$this->agent = $agent_string;
+		
+		//do it!
+		if ($agent_string !== '' && $this->_load_agent_file())
+		{
+			$this->_compile_data();
+		}
+	}
 }
 
 /* End of file User_agent.php */


### PR DESCRIPTION
CI has a pretty good user agent parser, but, why limit it to only the current user?  There are times where it is useful to be able to parse a string, like processing log files or the user session table, and be able to use the goodness built into this class.
