### PR TITLE
Added multiple sub folder support for controllers.

### DIFF
--- a/application/config/routes.php
+++ b/application/config/routes.php
@@ -68,5 +68,12 @@ $route['default_controller'] = "welcome";
 $route['404_override'] = '';
 
 
+/**
+ * To allow controller files to be stored in multiple subfolders,
+ * such as "controllers/sub1/sub2/controller_here.php",
+ * set allow_multiple_subfolders to TRUE
+ **/
+$route['allow_multiple_subfolders'] = FALSE;
+
 /* End of file routes.php */
 /* Location: ./application/config/routes.php */

--- a/system/core/Router.php
+++ b/system/core/Router.php
@@ -274,14 +274,16 @@ class CI_Router {
 			$this->set_directory($segments[0]);
 			$segments = array_slice($segments, 1);
 			
-         // Check for subfolders
-         while(count($segments) > 0 && is_dir(APPPATH.'controllers/'.$this->fetch_directory().$segments[0]))
-         {
-                 // Set the directory and remove it from the segment array
-                 $this->set_directory($this->fetch_directory().$segments[0]);
-                 $segments = array_slice($segments, 1);
-         }
-
+			if($this->routes['allow_multiple_subfolders'] === TRUE)
+			{
+				// Check for subfolders
+				while(count($segments) > 0 && is_dir(APPPATH.'controllers/'.$this->fetch_directory().$segments[0]))
+				{
+					// Set the directory and remove it from the segment array
+					$this->set_directory($this->fetch_directory().$segments[0]);
+					$segments = array_slice($segments, 1);
+				}
+			}
 			if (count($segments) > 0)
 			{
 				// Does the requested controller exist in the sub-folder?


### PR DESCRIPTION
Controllers can be stored in sub folders so as to allow for better organisation of controller files if needed.

It is optional and set off by default, since not everyone needs this and it could slow down the system.

To switch it on, set <code>$routes['allow_multiple_subfolders']</code> in <code>application/config/routes.php</code> to <code>TRUE</code>.
