### PR TITLE
site_url() improvement

### DIFF
--- a/system/core/Config.php
+++ b/system/core/Config.php
@@ -245,8 +245,7 @@ class CI_Config {
 
 		if ($this->item('enable_query_strings') == FALSE)
 		{
-			$suffix = ($this->item('url_suffix') == FALSE) ? '' : $this->item('url_suffix');
-			return $this->slash_item('base_url').$this->slash_item('index_page').$this->_uri_string($uri).$suffix;
+			return $this->slash_item('base_url').$this->slash_item('index_page').$this->_uri_string($uri);
 		}
 		else
 		{
@@ -284,19 +283,21 @@ class CI_Config {
 			{
 				$uri = implode('/', $uri);
 			}
-			return trim($uri, '/');
+			$suffix = ($this->item('url_suffix') == FALSE) ? '' : $this->item('url_suffix');
+			if (strpos($uri, '?') === FALSE)
+			{
+				return trim($uri, '/').$suffix;
+			}
+			else
+			{
+				// There is a query string in uri, add suffix before parameters
+				list($uri_seg, $uri_qry) = explode('?', $uri);
+				return trim($uri_seg, '/').$suffix.'?'.$uri_qry;
+			}
 		}
 		elseif (is_array($uri))
 		{
-			$i = 0;
-			$str = '';
-			foreach ($uri as $key => $val)
-			{
-				$prefix = ($i === 0) ? '' : '&';
-				$str .= $prefix.$key.'='.$val;
-				$i++;
-			}
-			return $str;
+			return http_build_query($uri);
 		}
 
 		return $uri;


### PR DESCRIPTION
Fixed url suffix position in site_url() result string if argument $uri contains query string. In some cases it might be useful to have query string in uri (example: JavaScript URI parsers etc). But my problem is that I am using additionally url suffix (Ex. ".html") and in case of the following call:  site_url('controller/method/argument?myvar=1&other=2') - i am getting "http://www.example.com/controller/method/argument?myvar=1&other=2.html which is wrong as you understand. So I decided to fix this issue. Please check my change.

Another thing I've found is that there was used $uri (if array) iteration for building query string. There is php function to do the same - http_build_query().
