### PR TITLE
Adding equal to greater than, equal to less than form validators.

### DIFF
--- a/system/language/english/form_validation_lang.php
+++ b/system/language/english/form_validation_lang.php
@@ -47,9 +47,9 @@ $lang['is_natural']				= "The %s field must contain only positive numbers.";
 $lang['is_natural_no_zero']		= "The %s field must contain a number greater than zero.";
 $lang['decimal']				= "The %s field must contain a decimal number.";
 $lang['less_than']				= "The %s field must contain a number less than %s.";
-$lang['less_than_equal_to']		= "The %s field must contain a number equal to or less than %s.";
+$lang['less_than_equal_to']		= "The %s field must contain a number less than or equal to %s.";
 $lang['greater_than']			= "The %s field must contain a number greater than %s.";
-$lang['greater_than_equal_to']	= "The %s field must contain a number equal to or greater than %s.";
+$lang['greater_than_equal_to']	= "The %s field must contain a number greater than or equal to %s.";
 
 
 /* End of file form_validation_lang.php */

--- a/user_guide_src/source/libraries/form_validation.rst
+++ b/user_guide_src/source/libraries/form_validation.rst
@@ -833,10 +833,10 @@ Rule                      Parameter  Description                                
 **max_length**            Yes        Returns FALSE if the form element is longer then the parameter value.                         max_length[12]         
 **exact_length**          Yes        Returns FALSE if the form element is not exactly the parameter value.                         exact_length[8]        
 **greater_than**          Yes        Returns FALSE if the form element is less than the parameter value or not numeric.            greater_than[8]        
-**greater_than_equal_to** Yes        Returns FALSE if the form element is not equal to or less than the parameter value,           greater_than[8]        
+**greater_than_equal_to** Yes        Returns FALSE if the form element is less than or not equal to the parameter value,           greater_than[8]        
                                      or not numeric.
 **less_than**             Yes        Returns FALSE if the form element is greater than the parameter value or not numeric.         less_than[8]           
-**less_than_equal_to**    Yes        Returns FALSE if the form element is not equal to or greater than the parameter value,        less_than[8]           
+**less_than_equal_to**    Yes        Returns FALSE if the form element is greater than or not equal to the parameter value,        less_than[8]           
                                      or not numeric.
 **alpha**                 No         Returns FALSE if the form element contains anything other than alphabetical characters.                              
 **alpha_numeric**         No         Returns FALSE if the form element contains anything other than alpha-numeric characters.                             


### PR DESCRIPTION
I think this is very useful.

I have seen some say this feature is unnecessary as you can just decrement the number in question. In other words, to make sure it's equal to or greater than 0, make the number -1.

This causes two problems, first and most importantly it's broken. -.5 would be valid in this case, which is clearly NOT equal to or greater than 0. 

Also, the error messaging is ugly. "The amount field must contain a number greater than -1" looks unprofessional and hacky, whereas  "The amount field must contain a number equal to or greater than 0." is far nicer and easier to understand.
