### PR TITLE
Update of `anchor_popup` function to let it build some accessible links ...

### DIFF
--- a/system/helpers/url_helper.php
+++ b/system/helpers/url_helper.php
@@ -207,7 +207,7 @@ if ( ! function_exists('anchor_popup'))
 
 		if ($attributes === FALSE)
 		{
-			return "<a href='javascript:void(0);' onclick=\"window.open('".$site_url."', '_blank');\">".$title."</a>";
+			return "<a href='".$site_url."' target='_blank' onclick=\"window.open('".$site_url."', '_blank'); return false;\">".$title."</a>";
 		}
 
 		if ( ! is_array($attributes))
@@ -226,7 +226,7 @@ if ( ! function_exists('anchor_popup'))
 			$attributes = _parse_attributes($attributes);
 		}
 
-		return "<a href='javascript:void(0);' onclick=\"window.open('".$site_url."', '_blank', '"._parse_attributes($atts, TRUE)."');\"$attributes>".$title."</a>";
+		return "<a href='".$site_url."' target='_blank' onclick=\"window.open('".$site_url."', '_blank', '"._parse_attributes($atts, TRUE)."'); return false;\"$attributes>".$title."</a>";
 	}
 }
 


### PR DESCRIPTION
Just some few changes:
-   replace the `javascript:void(0)` instruction by the URL for the `href` attribute,
-   add a `target=_blank` attribute,
-   add a `return false` instruction to the end of the `onclick` attribute.

This way, if the browser can execute JS the popup will be open just as usual, and if it doesn't a new window will be open ...
