### PR TITLE
Adding in a few 503 status codes for common errors

### DIFF
--- a/index.php
+++ b/index.php
@@ -218,6 +218,7 @@ if (defined('ENVIRONMENT'))
 	{
 		if ( ! is_dir(BASEPATH.$application_folder.'/'))
 		{
+			header('HTTP/1.1 503 Service Unavailable.', TRUE, '503');
 			exit('Your application folder path does not appear to be set correctly. Please open the following file and correct this: '.SELF);
 		}
 
@@ -233,6 +234,7 @@ if (defined('ENVIRONMENT'))
 	{
 		if ( ! is_dir(APPPATH.'views/'))
 		{
+			header('HTTP/1.1 503 Service Unavailable.', TRUE, '503');
 			exit('Your view folder path does not appear to be set correctly. Please open the following file and correct this: '.SELF);
 		}
 

--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -177,6 +177,7 @@ if ( ! function_exists('load_class'))
 		{
 			// Note: We use exit() rather then show_error() in order to avoid a
 			// self-referencing loop with the Excptions class
+			set_status_header(503);
 			exit('Unable to locate the specified class: '.$class.'.php');
 		}
 
@@ -243,6 +244,7 @@ if ( ! function_exists('get_config'))
 		// Fetch the config file
 		if ( ! file_exists($file_path))
 		{
+			set_status_header(503);
 			exit('The configuration file does not exist.');
 		}
 
@@ -251,6 +253,7 @@ if ( ! function_exists('get_config'))
 		// Does the $config array exist in the file?
 		if ( ! isset($config) OR ! is_array($config))
 		{
+			set_status_header(503);
 			exit('Your config file does not appear to be formatted correctly.');
 		}
 

--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -592,6 +592,7 @@ class CI_Input {
 	{
 		if ( ! preg_match('/^[a-z0-9:_\/-]+$/i', $str))
 		{
+			set_status_header(503);
 			exit('Disallowed Key Characters.');
 		}
 


### PR DESCRIPTION
This is in response to an ExpressionEngine bug where reverse caching proxies would cache errors because they appeared to be normal 200 requests, so I've changed the status code to something more appropriate.

http://expressionengine.com/bug_tracker/bug/17420
