### PR TITLE
Fixing TLS issue for sending email to exchange server

### DIFF
--- a/system/libraries/Email.php
+++ b/system/libraries/Email.php
@@ -64,7 +64,6 @@ class CI_Email {
 	public $send_multipart	= TRUE;		// TRUE/FALSE - Yahoo does not like multipart alternative, so this is an override.  Set to FALSE for Yahoo.
 	public $bcc_batch_mode	= FALSE;	// TRUE/FALSE  Turns on/off Bcc batch feature
 	public $bcc_batch_size	= 200;		// If bcc_batch_mode = TRUE, sets max number of Bccs in each batch
-	public $starttls        = FALSE;
 	private $_safe_mode		= FALSE;
 	private $_subject		= "";
 	private $_body			= "";
@@ -1498,7 +1497,7 @@ class CI_Email {
 
 		$this->_smtp_connect();
 
-		if ($this->starttls) 
+		if ($this->smtp_crypto == "tls") 
 		{
       if (! $this->_send_command('starttls')) 
       {
@@ -1506,7 +1505,7 @@ class CI_Email {
           return FALSE;
       }
       stream_socket_enable_crypto($this->_smtp_connect, true, STREAM_CRYPTO_METHOD_TLS_CLIENT);
-      // Re-issue hello to get updated service list (RFC 3207 section 4.2)
+      
       $this->_send_command('hello');
     }
 
@@ -1589,20 +1588,6 @@ class CI_Email {
 
 		$this->_set_error_message($this->_get_smtp_data());
 
-		if ($this->smtp_crypto == 'tls')
-		{
-			$this->_send_command('hello');
-			$this->_send_command('starttls');
-
-			$crypto = stream_socket_enable_crypto($this->_smtp_connect, TRUE, STREAM_CRYPTO_METHOD_TLS_CLIENT);
-
-			if ($crypto !== TRUE)
-			{
-				$this->_set_error_message('lang:email_smtp_error', $this->_get_smtp_data());
-				return FALSE;
-			}
-		}
-
 		return $this->_send_command('hello');
 	}
 
@@ -1659,12 +1644,6 @@ class CI_Email {
 
 						$resp = 221;
 			break;
-			case 'starttls'    :
-
-	          $this->_send_data('STARTTLS');
-
-	          $resp = 220;
-	     break;
 		}
 
 		$reply = $this->_get_smtp_data();

--- a/system/libraries/Email.php
+++ b/system/libraries/Email.php
@@ -64,6 +64,7 @@ class CI_Email {
 	public $send_multipart	= TRUE;		// TRUE/FALSE - Yahoo does not like multipart alternative, so this is an override.  Set to FALSE for Yahoo.
 	public $bcc_batch_mode	= FALSE;	// TRUE/FALSE  Turns on/off Bcc batch feature
 	public $bcc_batch_size	= 200;		// If bcc_batch_mode = TRUE, sets max number of Bccs in each batch
+	public $starttls        = FALSE;
 	private $_safe_mode		= FALSE;
 	private $_subject		= "";
 	private $_body			= "";
@@ -1496,6 +1497,19 @@ class CI_Email {
 		}
 
 		$this->_smtp_connect();
+
+		if ($this->starttls) 
+		{
+      if (! $this->_send_command('starttls')) 
+      {
+          $this->_set_error_message('email_starttls_failed');
+          return FALSE;
+      }
+      stream_socket_enable_crypto($this->_smtp_connect, true, STREAM_CRYPTO_METHOD_TLS_CLIENT);
+      // Re-issue hello to get updated service list (RFC 3207 section 4.2)
+      $this->_send_command('hello');
+    }
+
 		$this->_smtp_authenticate();
 
 		$this->_send_command('from', $this->clean_email($this->_headers['From']));
@@ -1645,6 +1659,12 @@ class CI_Email {
 
 						$resp = 221;
 			break;
+			case 'starttls'    :
+
+	          $this->_send_data('STARTTLS');
+
+	          $resp = 220;
+	     break;
 		}
 
 		$reply = $this->_get_smtp_data();


### PR DESCRIPTION
Slight tweak to the TLS config parameter.  I moved the TLS checking and stream_socket_enable_crypto into the _send_with_smtp method and removed from the _smtp_connect method.

I started with a fresh fork of codeigniter and tested locally on my machine for version differences before making the update.  Using the pre-existing smtp_crypto = "tls" didn't work for me.  Hence, this patch.  This is my first ever pull request so be gentle if I did something wrong in the process.

Best regards
