### PR TITLE
Fixed old-style pdo connection string

### DIFF
--- a/system/database/drivers/pdo/pdo_driver.php
+++ b/system/database/drivers/pdo/pdo_driver.php
@@ -117,7 +117,7 @@ class CI_DB_pdo_driver extends CI_DB {
 			// $db['hostname'] = 'pdodriver:host(/Server(/DSN))=hostname(/DSN);';
 			// We need to get the prefix (pdodriver used by PDO).
 			$this->dsn = $this->hostname;
-			$split_dsn = explode(":", $this->hostname);
+			$split_dsn = explode(':', $this->hostname);
 			$this->pdodriver = $split_dsn[0];
 			
 			// End this part of the dsn with a semicolon


### PR DESCRIPTION
The overhaul of the PDO driver broke the old kind of connection string. This fixes that by appending a semicolon to the hostname.
