### PR TITLE
Input key check regex is incorrect. \/ is the invalid portion. Backslash...

### DIFF
--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -585,7 +585,7 @@ class CI_Input {
 	*/
 	protected function _clean_input_keys($str)
 	{
-		if ( ! preg_match('/^[a-z0-9:_\/-]+$/i', $str))
+		if ( ! preg_match('/^[a-z0-9:_\\/-]+$/i', $str))
 		{
 			set_status_header(503);
 			exit('Disallowed Key Characters.');


### PR DESCRIPTION
... must be escaped, forward slash does not need to be escaped as part of the regex. I believe this is a long standing latent bug in CI.
