### PR TITLE
Fix for Issue #63

### DIFF
--- a/system/database/DB_active_rec.php
+++ b/system/database/DB_active_rec.php
@@ -1930,7 +1930,7 @@ class CI_DB_active_record extends CI_DB_driver {
 			}
 			else
 			{
-				// remove the first 'AND' or 'OR' if there isn't any other where statements
+				// Remove the first 'AND' or 'OR' if there isn't any other where statements before
 				$like_part = preg_replace('/AND|OR/', '', $like_part, 1);
 			}
 		


### PR DESCRIPTION
This patch fixes the [issue #63](https://github.com/EllisLab/CodeIgniter/issues/63)

``` php

$this->db->where('CustomerId', $searchString);
$this->db->or_where('TaxId', $searchString);
$this->db->or_like('CompanyName ', $searchString, 'both');
$this->db->or_like('Contact ', $searchString, 'both');
$this->db->or_like('ba.City ', $searchString, 'both');

produces:

WHERE CustomerId = 'SONAE'
OR TaxId = 'SONAE'
AND CompanyName LIKE '%SONAE%'
OR Contact LIKE '%SONAE%'
OR ba.City LIKE '%SONAE%'
```

The method CI_DB_active_record::_like disregards the given type parameter ('AND' or 'OR') of the first like statement and if there is any prior where statement, it is binded with an 'AND' in CI_DB_active_record::_compile_select.

I made quick and a little dirty fix; 
- removed the line which disregards the first type parameter given, 
- made a string replace if there isn't any prior where statements (this is the dirty part :) )
