### PR TITLE
Refixed Old-style pdo connection string

### DIFF
--- a/system/database/drivers/pdo/pdo_driver.php
+++ b/system/database/drivers/pdo/pdo_driver.php
@@ -121,7 +121,7 @@ class CI_DB_pdo_driver extends CI_DB {
 
 			// End dsn with a semicolon for extra backward compability
 			// if database property was not empty.
-			if( ! empty($this->database))
+			if ( ! empty($this->database))
 			{
 				$this->dsn .= rtrim($this->hostname, ';').';';
 			}


### PR DESCRIPTION
Sorry @philsturgeon...looks like there was another issue.

I personally use the pdo driver, with pgsql on my website, so I know, as is, this works. 

The previous fix gave me a dsn like this `localhostpgsql:host=localhost`. 
