### PR TITLE
Added unprefixed css property to welcome view

### DIFF
--- a/application/views/welcome_message.php
+++ b/application/views/welcome_message.php
@@ -89,6 +89,8 @@
 		margin: 10px;
 		border: 1px solid #D0D0D0;
 		-webkit-box-shadow: 0 0 8px #D0D0D0;
+		-moz-box-shadow: 0 0 8px #D0D0D0;
+		box-shadow: 0 0 8px #D0D0D0;
 	}
 	</style>
 </head>


### PR DESCRIPTION
With all the discussion about this lately, we really shouldn't have the webkit prefixed version, and not the standard version. 
