### PR TITLE
Allow NULL to be passed as value to Active Record limit() method

### DIFF
--- a/system/database/DB_active_rec.php
+++ b/system/database/DB_active_rec.php
@@ -988,7 +988,10 @@ class CI_DB_active_record extends CI_DB_driver {
 	 */
 	public function limit($value, $offset = NULL)
 	{
-		$this->ar_limit = (int) $value;
+		if ( ! is_null($value)
+		{
+			$this->ar_limit = (int) $value;
+		}
 
 		if ( ! is_null($offset))
 		{


### PR DESCRIPTION
The current implementation in master and develop will typecast $value to an int, which means passing NULL causes limit to be set to 0. This pull request only sets ar_value if the value passed is not NULL, similar to how the same function handles offset.
