### PR TITLE
Removed double slash in upload library

### DIFF
--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -34,7 +34,6 @@ Release Date: Not Released
    -  Removed previously deprecated SHA1 Library.
    -  Removed previously deprecated use of ``$autoload['core']`` in application/config/autoload.php.
       Only entries in ``$autoload['libraries']`` are auto-loaded now.
-   -  Removed a double slash in the function mimes_types() in the Upload library.
 
 -  Helpers
 


### PR DESCRIPTION
Removed a double slash in upload library, function mime_types()
