### PR TITLE
Added ability to extend Driver library

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -622,16 +622,16 @@ class CI_Loader {
 	 */
 	public function driver($library = '', $params = NULL, $object_name = NULL)
 	{
-		$prefix = config_item('subclass_prefix');
-		
-		if ( ! class_exists('CI_Driver_Library') || !class_exists($prefix.'Driver_Library'))
+		if ( ! class_exists('CI_Driver_Library'))
 		{
 			// we aren't instantiating an object here, that'll be done by the Library itself
 			require BASEPATH.'libraries/Driver.php';
 			
+			$prefix = config_item('subclass_prefix');
+			
 			// Driver library extending implementation.
 			// If there is a Driver library extending, we call this file.
-			if (file_exists(APPPATH.'libraries/' . $prefix . 'Driver.php'))
+			if (file_exists(APPPATH.'libraries/' . $prefix . 'Driver.php') && !class_exists($prefix.'Driver_Library'))
 			{
 				require APPPATH.'libraries/' . $prefix . 'Driver.php';
 			}


### PR DESCRIPTION
CI_Loader::driver() method updated to check for subclass in ./application/libraries folder.

There could be some times that user wants to implement a method to the all drivers like a method that enables/disables the drivers.
