### PR TITLE
2.1-stable: bug fix: compile binds before caching the query…

### DIFF
--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -265,6 +265,12 @@ class CI_DB_driver {
 			$sql = preg_replace("/(\W)".$this->swap_pre."(\S+?)/", "\\1".$this->dbprefix."\\2", $sql);
 		}
 
+		// Compile binds if needed
+		if ($binds !== FALSE)
+		{
+			$sql = $this->compile_binds($sql, $binds);
+		}
+
 		// Is query caching enabled?  If the query is a "read type"
 		// we will load the caching class and return the previously
 		// cached query if it exists
@@ -278,12 +284,6 @@ class CI_DB_driver {
 					return $cache;
 				}
 			}
-		}
-
-		// Compile binds if needed
-		if ($binds !== FALSE)
-		{
-			$sql = $this->compile_binds($sql, $binds);
 		}
 
 		// Save the  query for debugging

--- a/user_guide/changelog.html
+++ b/user_guide/changelog.html
@@ -79,6 +79,7 @@ Change Log
 	<li>Fixed a bug - form_open() compared $action against site_url() instead of base_url()</li>
 	<li>Fixed a bug - CI_Upload::_file_mime_type() could've failed if mime_content_type() is used for the detection and returns FALSE.</li>
 	<li>Fixed a bug (#538) - Windows paths were ignored when using the <a href="libraries/image_lib.html">Image Manipulation Class</a> to create a new file.</li>
+	<li>Fixed a bug - When database caching was enabled, $this->db->query() checked the cache before binding variables which resulted in cached queries never being found.</li>
 </ul>
 
 


### PR DESCRIPTION
… otherwise the cached query will never match the unboud query
Currently, with database caching on, a query such as:

``` php
$this->db->query('SELECT `fields` FROM `table` WHERE `key` = ?', array('value'));
```

will check the cache for 

``` mysql
SELECT `fields` FROM `table` WHERE `key` = ?
```

then perform the bind, then cache the query as

``` mysql
SELECT `fields` FROM `table` WHERE `key` = 'value'
```

My change simply moves the bind above the cache check so the cached query is actually found.

see discussion on https://github.com/EllisLab/CodeIgniter/pull/1098 and https://github.com/EllisLab/CodeIgniter/pull/1099
