### PR TITLE
2.1 stable - Fix for issue #183: Form validation class bug.

### DIFF
--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -617,25 +617,18 @@ class CI_Form_validation {
 					if (function_exists($rule))
 					{
 						$result = $rule($postdata);
-
-						if ($_in_array == TRUE)
-						{
-							$this->_field_data[$row['field']]['postdata'][$cycles] = (is_bool($result)) ? $postdata : $result;
-						}
-						else
-						{
-							$this->_field_data[$row['field']]['postdata'] = (is_bool($result)) ? $postdata : $result;
-						}
 					}
 					else
 					{
 						log_message('debug', "Unable to find validation rule: ".$rule);
+
+						continue;
 					}
-
-					continue;
 				}
-
-				$result = $this->$rule($postdata, $param);
+				else
+				{
+					$result = $this->$rule($postdata, $param);
+				}
 
 				if ($_in_array == TRUE)
 				{

--- a/user_guide/changelog.html
+++ b/user_guide/changelog.html
@@ -80,6 +80,7 @@ Change Log
 	<li>Fixed a bug - CI_Upload::_file_mime_type() could've failed if mime_content_type() is used for the detection and returns FALSE.</li>
 	<li>Fixed a bug (#538) - Windows paths were ignored when using the <a href="libraries/image_lib.html">Image Manipulation Class</a> to create a new file.</li>
 	<li>Fixed a bug - When database caching was enabled, $this->db->query() checked the cache before binding variables which resulted in cached queries never being found.</li>
+	<li>Fixed a bug (#183) - PHP native and user defined functions were ignored if used as rules in Form Validation class</li>
 </ul>
 
 


### PR DESCRIPTION
Today I noticed this bug and fixed it so I could continue developing an app for one of my clients. 
It's an important bug in my opinion.

This bug caused native PHP functions (and user defined global functions) to be ignored when used as a validation or prepping rule.

I've tested my fix in a real scenario (the app I'm building) and it's working properly.
