### PR TITLE
2.1 stable - CI_Upload::_file_mime_type() could've failed if popen() is used for the detection.

### DIFF
--- a/user_guide/changelog.html
+++ b/user_guide/changelog.html
@@ -78,7 +78,6 @@ Change Log
 	<li>Fixed a bug (#697) - A wrong array key was used in the Upload library to check for mime-types.</li>
 	<li>Fixed a bug - form_open() compared $action against site_url() instead of base_url()</li>
 	<li>Fixed a bug - CI_Upload::_file_mime_type() could've failed if mime_content_type() is used for the detection and returns FALSE.</li>
-	<li>Fixed a bug - CI_Upload::_file_mime_type() could've failed if popen() is used for the detection.</li>
 	<li>Fixed a bug (#538) - Windows paths were ignored when using the <a href="libraries/image_lib.html">Image Manipulation Class</a> to create a new file.</li>
 	<li>Fixed a bug - When database caching was enabled, $this->db->query() checked the cache before binding variables which resulted in cached queries never being found.</li>
 </ul>


### PR DESCRIPTION
$test variable does not exist. Correct one is $proc.
