### PR TITLE
Unit tests: Updated unit tests for url_title() helper function

### DIFF
--- a/tests/codeigniter/helpers/url_helper_test.php
+++ b/tests/codeigniter/helpers/url_helper_test.php
@@ -8,19 +8,17 @@ class Url_helper_test extends CI_TestCase
 	{
 		$words = array(
 			'foo bar /' 	=> 'foo-bar',
-			'\  testing 12' => 'testing-12'
+			'\  testing 12' => 'testing-12',
+			'%&/ fu Bar'    => 'fu-bar',
+			'FU BAR %&/'    => 'fu-bar'
 		);
 
 		foreach ($words as $in => $out)
 		{
 			$this->assertEquals($out, url_title($in, 'dash', TRUE));
 		}
-	}
-
-	// --------------------------------------------------------------------
-
-	public function test_url_title_extra_dashes()
-	{
+		
+		// Leading and trailing separators
 		$words = array(
 			'_foo bar_' 	=> 'foo_bar',
 			'_What\'s wrong with CSS?_' => 'Whats_wrong_with_CSS'
@@ -30,6 +28,14 @@ class Url_helper_test extends CI_TestCase
 		{
 			$this->assertEquals($out, url_title($in, 'underscore'));
 		}
+		
+		// Entities
+		$this->assertEquals('FU_BAR', url_title('FU &#169;BAR &copy;', '_'));
+		
+		// Other separators
+		$this->assertEquals('foo+bar', url_title('[^foo ] bar+ ', '+'));
+		$this->assertEquals('_whats[+]wrong[+]with[+]css_', url_title('_What\'s wrong with CSS?_', '[+]', TRUE));
+		$this->assertEquals('Whats--wrong--with--CSS', url_title('--What\'s ----wrong with CSS?----', '--'));
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
@philsturgeon

I've already written the tests. However I've noticed the url_title() function in the feature/unit-tests branch is a bit different from the one in the 2.1-stable branch (the one I requested for a merge).

For example:

The unit-tests branch version uses `=== 'dash'` instead of `==`. That's fine but why not use the identical operator for `=== 'underscore'` too?

Here's another one, the unit-tests branch version makes a double trim `trim(trim(...))`. That's useless since the regular expression '\s+' takes care of leading and trailing spaces (spaces get converted to $separator).

I don't know who introduced those changes but they are not needed IMHO and I don't understand how Unit tests can be useful when the code used in unit tests can be different from the production code.
