### PR TITLE
Fix issue #920

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,20 +11,19 @@
 			<directory suffix="test.php">codeigniter/libraries</directory>
 			<directory suffix="test.php">codeigniter/helpers</directory>
 			-->
-			
 		</testsuite>
 	</testsuites>
-	 <filters>
-               <blacklist>
-                       <directory suffix=".php">PEAR_INSTALL_DIR</directory>
-                       <directory suffix=".php">PHP_LIBDIR</directory>
-                       <directory suffix=".php">PROJECT_BASE.'tests'</directory>
-                       <directory suffix=".php">'../system/core/CodeIgniter.php'</directory>
-               </blacklist>
-               <whitelist>
-                       <!--
-                       <directory suffix=".php">'../system/core'</directory>
-                       -->
-               </whitelist>
-       </filters>
+	<filters>
+		<blacklist>
+			<directory suffix=".php">PEAR_INSTALL_DIR</directory>
+			<directory suffix=".php">PHP_LIBDIR</directory>
+			<directory suffix=".php">PROJECT_BASE.'tests'</directory>
+			<directory suffix=".php">'../system/core/CodeIgniter.php'</directory>
+		</blacklist>
+		<whitelist>
+			<!--
+			<directory suffix=".php">'../system/core'</directory>
+			-->
+		</whitelist>
+	</filters>
 </phpunit>

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -6,17 +6,13 @@ error_reporting(E_ALL | E_STRICT);
 
 $dir = realpath(dirname(__FILE__));
 
-
 // Path constants
 define('PROJECT_BASE',	realpath($dir.'/../').'/');
 define('BASEPATH',		PROJECT_BASE.'system/');
 define('APPPATH',		PROJECT_BASE.'application/');
 
-
 // Prep our test environment
 require_once $dir.'/lib/common.php';
 require_once $dir.'/lib/ci_testcase.php';
-
-
 
 unset($dir);


### PR DESCRIPTION
Remove PHP_CodeCoverage_Filter::getInstance() methods from Bootstrap.php and reimplement the same functionality in phpunit.xml. This enables unit tests to work with the newer PHPUnit version 3.6.10 and PHP_CodeCoverage 1.1.2, as well as older versions PHPUnit (PHPUnit 3.5.14/PHP_CodeCoverage 1.0.4)

Signed-off-by: tiyowan tiyowan@gmail.com
