### PR TITLE
Use single column on count_all_results() in Active Record

### DIFF
--- a/system/database/DB_active_rec.php
+++ b/system/database/DB_active_rec.php
@@ -1129,7 +1129,7 @@ class CI_DB_active_record extends CI_DB_driver {
 		if (count($this->ar_select) === 1)
 		{
 			// try and replace the single column into it
-			$result = $this->query($this->_compile_select(str_replace('*', implode($this->ar_select), $this->_count_string).$this->protect_identifiers('numrows')));
+			$result = $this->query($this->_compile_select(str_replace('*', $this->ar_select[0], $this->_count_string).$this->protect_identifiers('numrows')));
 		}
 		else
 		{


### PR DESCRIPTION
Updated the count_all_results in active record to if a single column is set, then use that as the key to count against otherwise ignore it and default to legacy functionality
