### PR TITLE
Allow drivers to be loaded as an array, like models and libraries.

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -622,9 +622,9 @@ class CI_Loader {
 	 */
 	public function driver($library = '', $params = NULL, $object_name = NULL)
 	{
-		if(is_array($library))
+		if (is_array($library))
 		{
-			foreach ( $library as $driver )
+			foreach ($library as $driver)
 			{
 				$this->driver($driver);
 			}


### PR DESCRIPTION
I've committed a simple change that allows one to load multiple drivers as an array, similar to models and libraries.

From a user perspective, it's expected for this to be included functionality.
