### PR TITLE
Fix test errors in Loader_test.php and URI_test.php

### DIFF
--- a/tests/codeigniter/core/Loader_test.php
+++ b/tests/codeigniter/core/Loader_test.php
@@ -104,7 +104,7 @@ class Loader_test extends CI_TestCase {
 	public function test_non_existent_model()
 	{
 		$this->setExpectedException(
-			'Exception',
+			'RuntimeException',
 			'CI Error: Unable to locate the model you have specified: ci_test_nonexistent_model.php'
 			);
 			
@@ -170,7 +170,7 @@ class Loader_test extends CI_TestCase {
 	public function test_non_existent_view()
 	{
 		$this->setExpectedException(
-			'Exception',
+			'RuntimeException',
 			'CI Error: Unable to load the requested file: ci_test_nonexistent_view.php'
 			);
 			
@@ -192,7 +192,7 @@ class Loader_test extends CI_TestCase {
 		$this->assertEquals($content, $load);
 		
 		$this->setExpectedException(
-			'Exception',
+			'RuntimeException',
 			'CI Error: Unable to load the requested file: ci_test_file_not_exists'
 			);
 		
@@ -219,7 +219,7 @@ class Loader_test extends CI_TestCase {
 		$this->assertEquals(NULL, $this->load->helper('array'));
 		
 		$this->setExpectedException(
-			'Exception',
+			'RuntimeException',
 			'CI Error: Unable to load the requested file: helpers/bad_helper.php'
 			);
 		
@@ -256,7 +256,7 @@ class Loader_test extends CI_TestCase {
 		$this->_setup_config_mock();
 		
 		$this->setExpectedException(
-			'Exception',
+			'RuntimeException',
 			'CI Error: The configuration file foobar.php does not exist.'
 			);
 		

--- a/tests/codeigniter/core/URI_test.php
+++ b/tests/codeigniter/core/URI_test.php
@@ -189,7 +189,7 @@ class URI_test extends CI_TestCase {
 
     public function test_filter_uri_throws_error()
     {
-		$this->setExpectedException('Exception');
+		$this->setExpectedException('RuntimeException');
 		
 		$this->uri->config->set_item('enable_query_strings', FALSE);
 		$this->uri->config->set_item('permitted_uri_chars', 'a-z 0-9~%.:_\-');

--- a/tests/lib/common.php
+++ b/tests/lib/common.php
@@ -87,17 +87,17 @@ function remove_invisible_characters($str, $url_encoded = TRUE)
 
 function show_error($message, $status_code = 500, $heading = 'An Error Was Encountered')
 {
-	throw new Exception('CI Error: '.$message);
+	throw new RuntimeException('CI Error: '.$message);
 }
 
 function show_404($page = '', $log_error = TRUE)
 {
-	throw new Exception('CI Error: 404');
+	throw new RuntimeException('CI Error: 404');
 }
 
 function _exception_handler($severity, $message, $filepath, $line)
 {
-	throw new Exception('CI Exception: '.$message.' | '.$filepath.' | '.$line);
+	throw new RuntimeException('CI Exception: '.$message.' | '.$filepath.' | '.$line);
 }
 
 


### PR DESCRIPTION
Before: [![Build Status](https://secure.travis-ci.org/tiyowan/CodeIgniter.png?build=832518)](http://travis-ci.org/#!/tiyowan/CodeIgniter/builds/832518)

Now: [![Build Status](https://secure.travis-ci.org/tiyowan/CodeIgniter.png)](http://travis-ci.org/tiyowan/CodeIgniter)

Yes, the build still fails, but there are no errors now because of the test classes mentioned above. The only test failing is a broken camelize() function - issue opened for that already.

Thank you.
