### PR TITLE
Travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: php
+
+phps:
+  - 5.2
+  - 5.3
+  - 5.4
+
+branches:
+  except:
+    - develop
+    - master


### PR DESCRIPTION
This will exclude and skip travis build in `develop` and `master` branch for a while, until the `unit-tests` branch ready to be merged.
