### PR TITLE
Add unit tests for path helper

### DIFF
--- a/tests/codeigniter/helpers/path_helper_test.php
+++ b/tests/codeigniter/helpers/path_helper_test.php
@@ -6,7 +6,7 @@ class Path_helper_test extends CI_TestCase
 {
 	public function test_set_realpath()
 	{				
-		$expected = getcwd() . '/';
+		$expected = getcwd() . DIRECTORY_SEPARATOR;
 		$this->assertEquals($expected, set_realpath(getcwd()));		
 	}
 


### PR DESCRIPTION
[![Build Status](https://secure.travis-ci.org/tiyowan/CodeIgniter.png)](http://travis-ci.org/tiyowan/CodeIgniter)

We have got a minor issue here.  The tests fail because I'm testing according to this documentation: http://codeigniter.com/user_guide/helpers/path_helper.html

According to the docs:
$directory = '/etc/passwd';
echo set_realpath($directory);
// returns "/etc/passwd"

However, actually set_realpath returns "/etc/passwd/"

We have two options:
1. Change docs and unit tests to reflect the correct return value. (with slash)
2. Change set_realpath() to operate according to the docs and unit tests

Let me know what needs to be done so I can amend this commit if necessary.
