### PR TITLE
improved form_dropdown() to detect if $name is an array instead of just ...

### DIFF
--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -304,7 +304,7 @@ if ( ! function_exists('form_multiselect'))
  * Drop-down Menu
  *
  * @access	public
- * @param	string
+ * @param	mixed
  * @param	array
  * @param	string
  * @param	string
@@ -314,28 +314,40 @@ if ( ! function_exists('form_dropdown'))
 {
 	function form_dropdown($name = '', $options = array(), $selected = array(), $extra = '')
 	{
-		if ( is_array($name) ) {
-      if (!isset($name['options'])) {
-        $name['selected'] = false;
-      }     
-      if (!isset($name['selected'])) {
+    // If name is really an array we have a winner! we'll call the function again
+    if ( is_array($name) ) 
+    {
+      if ( ! isset($name['options'])) 
+      {
         $name['selected'] = false;
       }
-      if (!isset($name['extra'])) {
+      
+      if ( ! isset($name['selected'])) 
+      {
+        $name['selected'] = false;
+      }
+      
+      if ( ! isset($name['extra'])) 
+      {
         $name['extra'] = false;
       }
       
       return form_dropdown($name['name'], $name['options'], $name['selected'], $name['extra']);
     }
+    
 		if ( ! is_array($selected))
 		{
 			$selected = array($selected);
 		}
 
 		// If no selected state was submitted we will attempt to set it automatically
-		if (count($selected) === 0 && isset($_POST[$name]))
+		if (count($selected) === 0)
 		{
-			$selected = array($_POST[$name]);
+			// If the form name appears in the $_POST array we have a winner!
+			if (isset($_POST[$name]))
+			{
+				$selected = array($_POST[$name]);
+			}
 		}
 
 		if ($extra != '') $extra = ' '.$extra;
@@ -350,11 +362,12 @@ if ( ! function_exists('form_dropdown'))
 
 			if (is_array($val) && ! empty($val))
 			{
-				$form .= '<optgroup label="'.$key."\">\n";
+				$form .= '<optgroup label="'.$key.'">'."\n";
 
 				foreach ($val as $optgroup_key => $optgroup_val)
 				{
 					$sel = (in_array($optgroup_key, $selected)) ? ' selected="selected"' : '';
+
 					$form .= '<option value="'.$optgroup_key.'"'.$sel.'>'.(string) $optgroup_val."</option>\n";
 				}
 
@@ -362,11 +375,13 @@ if ( ! function_exists('form_dropdown'))
 			}
 			else
 			{
-				$form .= '<option value="'.$key.'"'.(in_array($key, $selected) ? ' selected="selected"' : '').'>'.(string) $val."</option>\n";
+				$sel = (in_array($key, $selected)) ? ' selected="selected"' : '';
+
+				$form .= '<option value="'.$key.'"'.$sel.'>'.(string) $val."</option>\n";
 			}
 		}
 
-		$form .= "</select>\n";
+		$form .= '</select>';
 
 		return $form;
 	}

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -44,6 +44,7 @@ Release Date: Not Released
    -  Refactored ``plural()`` and ``singular()`` to avoid double pluralization and support more words.
    -  Added an optional third parameter to ``force_download()`` that enables/disables sending the actual file MIME type in the Content-Type header (disabled by default).
    -  Added a work-around in force_download() for a bug Android <= 2.1, where the filename extension needs to be in uppercase.
+   -  form_dropdown() will now also take an array for unity with other form helpers.
 
 -  Database
 


### PR DESCRIPTION
...a string.

```
$this->data['user_id'] = array(
                'name'  => 'user_id',
                'id'    => 'user_id',
                'type'  => 'hidden',
                'value' => $user->id,
            );
```

but with something like this for a drop down..

```
            $this->data['dropdown'] = array(
                'name'  => 'dropdown[]',
                'options'    => array( … ),
                'selected'  => $item->selected,
                'extra' => array('id' => 'adropdown' … ),
            );
```

with the following code in php:

```
    orm_dropdown($this->data['dropdown']);
```
