### PR TITLE
Fix form_input() associative array example to match actual return

### DIFF
--- a/user_guide_src/source/helpers/form_helper.rst
+++ b/user_guide_src/source/helpers/form_helper.rst
@@ -177,7 +177,7 @@ form to contain
 	/*
 		Would produce:
 
-		<input type="text" name="username" id="username" value="johndoe" maxlength="100" size="50" style="width:50%" />
+		<input type="text" name="username" value="johndoe" id="username" maxlength="100" size="50" style="width:50%"  />
 	*/
 
 If you would like your form to contain some additional data, like


### PR DESCRIPTION
This fixes an example given in the documentation for form_helper.php
