### PR TITLE
Modified the Config library so that an array of items can be set using set_item()

### DIFF
--- a/system/core/Config.php
+++ b/system/core/Config.php
@@ -320,13 +320,26 @@ class CI_Config {
 	/**
 	 * Set a config file item
 	 *
-	 * @param	string	the config item key
+	 * An array can optionally be passed as the first parameter, in which
+	 * case each item in the array will be added to the config
+	 * 
+	 * @param	mixed	the config item key
 	 * @param	string	the config item value
 	 * @return	void
 	 */
-	public function set_item($item, $value)
+	public function set_item($item, $value = '')
 	{
-		$this->config[$item] = $value;
+		if (is_array($item))
+		{
+			foreach ($item as $key => $value)
+			{
+				$this->set_item($key, $value);
+			}
+		}
+		else
+		{
+			$this->config[$item] = $value;
+		}	
 	}
 
 	// --------------------------------------------------------------------

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -86,6 +86,7 @@ Release Date: Not Released
    -  Added function set_data() to Form_validation library, which can be used in place of the default $_POST array.
    -  Added function reset_validation() to form validation library, which resets internal validation variables in case of multiple validation routines.
    -  Changed the Session library to select only one row when using database sessions.
+   -  Modified the Config library so that an array of items can be set using the set->item() method.
 
 -  Core
 

--- a/user_guide_src/source/libraries/config.rst
+++ b/user_guide_src/source/libraries/config.rst
@@ -119,6 +119,13 @@ one, you can do so using::
 Where item_name is the $config array index you want to change, and
 item_value is its value.
 
+You can also set an array of items as follows::
+	$items = array(
+		'first_item' => 'first_item_value,
+		'second_item' => 'second_item_value,
+	);
+	$this->config->set_item($items);
+
 .. _config-environments:
 
 Environments


### PR DESCRIPTION
I was not sure if we should be testing for empty values in the array, but the original version doesn't, so I left it as-is.
