### PR TITLE
Dispatcher class; decouples from bootstrapping

### DIFF
--- a/application/tests/Bootstrap.php
+++ b/application/tests/Bootstrap.php
@@ -1,0 +1,9 @@
+<?php
+$dir = realpath(dirname(__FILE__));
+
+// bootstrap CodeIgniter
+define('ENVIRONMENT', 'testing');
+require_once $dir . '/../../index.php';
+
+// load controller test case class
+require_once $dir . '/lib/ci_controller_testcase.php';

--- a/application/tests/controllers/welcome_test.php
+++ b/application/tests/controllers/welcome_test.php
@@ -1,0 +1,11 @@
+<?php
+
+class WelcomeTest extends CI_Controller_TestCase {
+	
+	public function testIndex()
+	{
+		$this->dispatch(array('controller' => 'welcome', 'function' => 'index'));
+		$this->expectOutputRegex('/<h1>Welcome to CodeIgniter!<\/h1>/');
+	}
+	
+}

--- a/application/tests/lib/ci_controller_testcase.php
+++ b/application/tests/lib/ci_controller_testcase.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * TestCase class used for testing CodeIgniter application controllers. 
+ */
+class CI_Controller_TestCase extends PHPUnit_Framework_TestCase {
+	
+	/**
+	 * Dispatches a request.
+	 * 
+	 * @param array
+	 * @return void
+	 */
+	public function dispatch(array $routing = array())
+	{
+		$dispatcher =& load_class('Dispatcher', 'core');
+		$dispatcher->dispatch($routing);
+	}
+	
+}

--- a/application/tests/phpunit.xml
+++ b/application/tests/phpunit.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit 
+	bootstrap="Bootstrap.php"
+	colors="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	stopOnError="false"
+	stopOnFailure="false"
+	stopOnIncomplete="false"
+	stopOnSkipped="false">
+	
+	<testsuites>
+		<testsuite name="Application Controllers">
+			<directory suffix="test.php">controllers</directory>
+		</testsuite>
+	</testsuites>
+	
+	<filter>
+		<whitelist>
+			<directory suffix=".php">../controllers</directory>
+		</whitelist>
+	</filter>
+	
+	<!-- 
+	<logging>
+	 <log type="coverage-html" target="./coverage-html"></log>
+	</logging>
+	-->
+	
+</phpunit>

--- a/index.php
+++ b/index.php
@@ -42,7 +42,12 @@
  *
  * NOTE: If you change these, also change the error_reporting() code below
  */
+
+if ( ! defined('ENVIRONMENT'))
+{
 	define('ENVIRONMENT', 'development');
+}
+
 /*
  *---------------------------------------------------------------
  * ERROR REPORTING
@@ -249,6 +254,17 @@ if (defined('ENVIRONMENT'))
  * And away we go...
  */
 require_once BASEPATH.'core/CodeIgniter.php';
+
+/*
+ * ------------------------------------------------------
+ * Dispatch the request.
+ * ------------------------------------------------------
+ */
+if (ENVIRONMENT !== 'testing')
+{
+	$dispatcher =& load_class('Dispatcher', 'core');
+	$dispatcher->dispatch();
+}
 
 /* End of file index.php */
 /* Location: ./index.php */

--- a/system/core/CodeIgniter.php
+++ b/system/core/CodeIgniter.php
@@ -117,7 +117,7 @@
  *  Start the timer... tick tock tick tock...
  * ------------------------------------------------------
  */
-	$BM =& load_class('Benchmark', 'core');
+	$GLOBALS['BM'] = $BM =& load_class('Benchmark', 'core');
 	$BM->mark('total_execution_time_start');
 	$BM->mark('loading_time:_base_classes_start');
 
@@ -126,7 +126,7 @@
  *  Instantiate the hooks class
  * ------------------------------------------------------
  */
-	$EXT =& load_class('Hooks', 'core');
+	$GLOBALS['EXT'] = $EXT =& load_class('Hooks', 'core');
 
 /*
  * ------------------------------------------------------
@@ -140,7 +140,7 @@
  *  Instantiate the config class
  * ------------------------------------------------------
  */
-	$CFG =& load_class('Config', 'core');
+	$GLOBALS['CFG'] = $CFG =& load_class('Config', 'core');
 
 	// Do we have any manually set config items in the index.php file?
 	if (isset($assign_to_config))
@@ -159,21 +159,21 @@
  * after the Config class is instantiated.
  *
  */
-	$UNI =& load_class('Utf8', 'core');
+	$GLOBALS['UNI'] = $UNI =& load_class('Utf8', 'core');
 
 /*
  * ------------------------------------------------------
  *  Instantiate the URI class
  * ------------------------------------------------------
  */
-	$URI =& load_class('URI', 'core');
+	$GLOBALS['URI'] = $URI =& load_class('URI', 'core');
 
 /*
  * ------------------------------------------------------
  *  Instantiate the routing class and set the routing
  * ------------------------------------------------------
  */
-	$RTR =& load_class('Router', 'core');
+	$GLOBALS['RTR'] = $RTR =& load_class('Router', 'core');
 	$RTR->_set_routing();
 
 	// Set any routing overrides that may exist in the main index file
@@ -187,7 +187,7 @@
  *  Instantiate the output class
  * ------------------------------------------------------
  */
-	$OUT =& load_class('Output', 'core');
+	$GLOBALS['OUT'] = $OUT =& load_class('Output', 'core');
 
 /*
  * ------------------------------------------------------
@@ -205,197 +205,32 @@
  * Load the security class for xss and csrf support
  * -----------------------------------------------------
  */
-	$SEC =& load_class('Security', 'core');
+	$GLOBALS['SEC'] = $SEC =& load_class('Security', 'core');
 
 /*
  * ------------------------------------------------------
  *  Load the Input class and sanitize globals
  * ------------------------------------------------------
  */
-	$IN	=& load_class('Input', 'core');
+	$GLOBALS['IN'] = $IN =& load_class('Input', 'core');
 
 /*
  * ------------------------------------------------------
  *  Load the Language class
  * ------------------------------------------------------
  */
-	$LANG =& load_class('Lang', 'core');
+	$GLOBALS['LANG'] = $LANG =& load_class('Lang', 'core');
 
 /*
  * ------------------------------------------------------
- *  Load the app controller and local controller
+ *  Load the base controller class
  * ------------------------------------------------------
- *
  */
-	// Load the base controller class
 	require BASEPATH.'core/Controller.php';
 
 	function &get_instance()
 	{
 		return CI_Controller::get_instance();
-	}
-
-
-	if (file_exists(APPPATH.'core/'.$CFG->config['subclass_prefix'].'Controller.php'))
-	{
-		require APPPATH.'core/'.$CFG->config['subclass_prefix'].'Controller.php';
-	}
-
-	// Load the local application controller
-	// Note: The Router class automatically validates the controller path using the router->_validate_request().
-	// If this include fails it means that the default controller in the Routes.php file is not resolving to something valid.
-	if ( ! file_exists(APPPATH.'controllers/'.$RTR->fetch_directory().$RTR->fetch_class().'.php'))
-	{
-		show_error('Unable to load your default controller. Please make sure the controller specified in your Routes.php file is valid.');
-	}
-
-	include(APPPATH.'controllers/'.$RTR->fetch_directory().$RTR->fetch_class().'.php');
-
-	// Set a mark point for benchmarking
-	$BM->mark('loading_time:_base_classes_end');
-
-/*
- * ------------------------------------------------------
- *  Security check
- * ------------------------------------------------------
- *
- *  None of the functions in the app controller or the
- *  loader class can be called via the URI, nor can
- *  controller functions that begin with an underscore
- */
-	$class  = $RTR->fetch_class();
-	$method = $RTR->fetch_method();
-
-	if ( ! class_exists($class)
-		OR strpos($method, '_') === 0
-		OR in_array(strtolower($method), array_map('strtolower', get_class_methods('CI_Controller')))
-		)
-	{
-		if ( ! empty($RTR->routes['404_override']))
-		{
-			$x = explode('/', $RTR->routes['404_override'], 2);
-			$class = $x[0];
-			$method = (isset($x[1]) ? $x[1] : 'index');
-			if ( ! class_exists($class))
-			{
-				if ( ! file_exists(APPPATH.'controllers/'.$class.'.php'))
-				{
-					show_404("{$class}/{$method}");
-				}
-
-				include_once(APPPATH.'controllers/'.$class.'.php');
-			}
-		}
-		else
-		{
-			show_404("{$class}/{$method}");
-		}
-	}
-
-/*
- * ------------------------------------------------------
- *  Is there a "pre_controller" hook?
- * ------------------------------------------------------
- */
-	$EXT->_call_hook('pre_controller');
-
-/*
- * ------------------------------------------------------
- *  Instantiate the requested controller
- * ------------------------------------------------------
- */
-	// Mark a start point so we can benchmark the controller
-	$BM->mark('controller_execution_time_( '.$class.' / '.$method.' )_start');
-
-	$CI = new $class();
-
-/*
- * ------------------------------------------------------
- *  Is there a "post_controller_constructor" hook?
- * ------------------------------------------------------
- */
-	$EXT->_call_hook('post_controller_constructor');
-
-/*
- * ------------------------------------------------------
- *  Call the requested method
- * ------------------------------------------------------
- */
-	// Is there a "remap" function? If so, we call it instead
-	if (method_exists($CI, '_remap'))
-	{
-		$CI->_remap($method, array_slice($URI->rsegments, 2));
-	}
-	else
-	{
-		// is_callable() returns TRUE on some versions of PHP 5 for private and protected
-		// methods, so we'll use this workaround for consistent behavior
-		if ( ! in_array(strtolower($method), array_map('strtolower', get_class_methods($CI))))
-		{
-			// Check and see if we are using a 404 override and use it.
-			if ( ! empty($RTR->routes['404_override']))
-			{
-				$x = explode('/', $RTR->routes['404_override'], 2);
-				$class = $x[0];
-				$method = (isset($x[1]) ? $x[1] : 'index');
-				if ( ! class_exists($class))
-				{
-					if ( ! file_exists(APPPATH.'controllers/'.$class.'.php'))
-					{
-						show_404("{$class}/{$method}");
-					}
-
-					include_once(APPPATH.'controllers/'.$class.'.php');
-					unset($CI);
-					$CI = new $class();
-				}
-			}
-			else
-			{
-				show_404("{$class}/{$method}");
-			}
-		}
-
-		// Call the requested method.
-		// Any URI segments present (besides the class/function) will be passed to the method for convenience
-		call_user_func_array(array(&$CI, $method), array_slice($URI->rsegments, 2));
-	}
-
-	// Mark a benchmark end point
-	$BM->mark('controller_execution_time_( '.$class.' / '.$method.' )_end');
-
-/*
- * ------------------------------------------------------
- *  Is there a "post_controller" hook?
- * ------------------------------------------------------
- */
-	$EXT->_call_hook('post_controller');
-
-/*
- * ------------------------------------------------------
- *  Send the final rendered output to the browser
- * ------------------------------------------------------
- */
-	if ($EXT->_call_hook('display_override') === FALSE)
-	{
-		$OUT->_display();
-	}
-
-/*
- * ------------------------------------------------------
- *  Is there a "post_system" hook?
- * ------------------------------------------------------
- */
-	$EXT->_call_hook('post_system');
-
-/*
- * ------------------------------------------------------
- *  Close the DB connection if one exists
- * ------------------------------------------------------
- */
-	if (class_exists('CI_DB') && isset($CI->db))
-	{
-		$CI->db->close();
 	}
 
 /* End of file CodeIgniter.php */

--- a/system/core/Dispatcher.php
+++ b/system/core/Dispatcher.php
@@ -1,0 +1,193 @@
+<?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+
+class CI_Dispatcher {
+
+	protected $_class;
+	protected $_method;
+
+	/**
+	 * Dispatch the request to the correct class and method. Routing options may
+	 * be given here to override the options already parsed by the router class.
+	 *
+	 * @param array
+	 * @return void
+	 */
+	public function dispatch(array $routing = array())
+	{
+		global $RTR;
+		 
+		// set any routing overrides
+		if ( ! empty($routing))
+		{
+			$RTR->_set_overrides($routing);
+		}
+
+		$this->_load_controllers();
+		$this->_security_check();
+		$this->_pre_dispatch();
+		$this->_dispatch();
+		$this->_post_dispatch();
+	}
+
+	/**
+	 * Load the controllers needed to dispatch the request.
+	 *
+	 * @return void
+	 */
+	protected function _load_controllers()
+	{
+		global $CFG, $RTR, $BM;
+		 
+		if (file_exists(APPPATH.'core/'.$CFG->config['subclass_prefix'].'Controller.php'))
+		{
+			require APPPATH.'core/'.$CFG->config['subclass_prefix'].'Controller.php';
+		}
+
+		// Load the local application controller
+		// Note: The Router class automatically validates the controller path using the router->_validate_request().
+		// If this include fails it means that the default controller in the Routes.php file is not resolving to something valid.
+		if ( ! file_exists(APPPATH.'controllers/'.$RTR->fetch_directory().$RTR->fetch_class().'.php'))
+		{
+			show_error('Unable to load your default controller. Please make sure the controller specified in your Routes.php file is valid.');
+		}
+
+		include(APPPATH.'controllers/'.$RTR->fetch_directory().$RTR->fetch_class().'.php');
+
+		// Set a mark point for benchmarking
+		$BM->mark('loading_time:_base_classes_end');
+	}
+
+	/**
+	 * Performs a security check before entering the pre-dispatch phase.
+	 *
+	 * None of the functions in the app controller or the loader class can be
+	 * called via the URI, nor can controller functions that begin with an
+	 * underscore.
+	 *
+	 * @return void
+	 */
+	protected function _security_check()
+	{
+		global $RTR;
+		 
+		$this->_class = $RTR->fetch_class();
+		$this->_method = $RTR->fetch_method();
+
+		if ( ! class_exists($this->_class)
+		OR strpos($this->_method, '_') === 0
+		OR in_array(strtolower($this->_method), array_map('strtolower', get_class_methods('CI_Controller')))
+		)
+		{
+			if ( ! empty($RTR->routes['404_override']))
+			{
+				$x = explode('/', $RTR->routes['404_override'], 2);
+				$this->_class = $x[0];
+				$this->_method = (isset($x[1]) ? $x[1] : 'index');
+				if ( ! class_exists($this->_class))
+				{
+					if ( ! file_exists(APPPATH.'controllers/'.$this->_class.'.php'))
+					{
+						show_404("{$this->_class}/{$this->_method}");
+					}
+
+					include_once(APPPATH.'controllers/'.$this->_class.'.php');
+				}
+			}
+			else
+			{
+				show_404("{$this->_class}/{$this->_method}");
+			}
+		}
+	}
+
+	/**
+	 * Initial setup and call hooks before dispatching the request.
+	 *
+	 * @return void
+	 */
+	protected function _pre_dispatch()
+	{
+		global $EXT, $BM;
+		 
+		$EXT->_call_hook('pre_controller');
+
+		// Mark a start point so we can benchmark the controller
+		$BM->mark('controller_execution_time_( '.$this->_class.' / '.$this->_method.' )_start');
+		$GLOBALS['CI'] = new $this->_class();
+
+		$EXT->_call_hook('post_controller_constructor');
+	}
+
+	/**
+	 * Perform the actual dispatch by calling the method.
+	 *
+	 * @return void
+	 */
+	protected function _dispatch()
+	{
+		global $CI, $URI, $RTR, $BM;
+		 
+		// Is there a "remap" function? If so, we call it instead
+		if (method_exists($CI, '_remap'))
+		{
+			$CI->_remap($this->_method, array_slice($URI->rsegments, 2));
+		}
+		else
+		{
+			// is_callable() returns TRUE on some versions of PHP 5 for private and protected
+			// methods, so we'll use this workaround for consistent behavior
+			if ( ! in_array(strtolower($this->_method), array_map('strtolower', get_class_methods($CI))))
+			{
+				// Check and see if we are using a 404 override and use it.
+				if ( ! empty($RTR->routes['404_override']))
+				{
+					$x = explode('/', $RTR->routes['404_override'], 2);
+					$this->_class = $x[0];
+					$this->_method = (isset($x[1]) ? $x[1] : 'index');
+					if ( ! class_exists($this->_class))
+					{
+						if ( ! file_exists(APPPATH.'controllers/'.$this->_class.'.php'))
+						{
+							show_404("{$this->_class}/{$this->_method}");
+						}
+
+						include_once(APPPATH.'controllers/'.$this->_class.'.php');
+						unset($CI);
+						$CI = new $this->_class();
+					}
+				}
+				else
+				{
+					show_404("{$this->_class}/{$this->_method}");
+				}
+			}
+
+			// Call the requested method.
+			// Any URI segments present (besides the class/function) will be passed to the method for convenience
+			call_user_func_array(array(&$CI, $this->_method), array_slice($URI->rsegments, 2));
+		}
+
+		// Mark a benchmark end point
+		$BM->mark('controller_execution_time_( '.$this->_class.' / '.$this->_method.' )_end');
+	}
+
+	/**
+	 * Release resources and call hooks after dispatching the request.
+	 */
+	protected function _post_dispatch()
+	{
+		global $EXT, $OUT, $CI;
+		 
+		$EXT->_call_hook('post_controller');
+		if ($EXT->_call_hook('display_override') === FALSE)
+		{
+			$OUT->_display();
+		}
+		$EXT->_call_hook('post_system');
+
+		if (class_exists('CI_DB') && isset($CI->db))
+		{
+			$CI->db->close();
+		}
+	}
+}


### PR DESCRIPTION
This is my attempt to decouple the "dispatching" away from the bootstrapping of the framework in CodeIgniter.php to allow for unit testing of controllers. While I got it so I could test a single controller action, attempting to call the dispatcher a second time in an additional test fails. So I think there still is some work to do to reset the state in some of the global classes.
