### PR TITLE
Added support for regex in the csrf_exclude_uris array so that URIs can ...

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -329,7 +329,7 @@ $config['global_xss_filtering'] = FALSE;
 | 'csrf_cookie_name' = The cookie name
 | 'csrf_expire' = The number in seconds the token should expire.
 | 'csrf_regenerate' = Regenerate token on every submission
-| 'csrf_exclude_uris' = Array of URIs which ignore CSRF checks
+| 'csrf_exclude_uris' = Array of URIs which ignore CSRF checks. Regex is supported
 */
 $config['csrf_protection'] = FALSE;
 $config['csrf_token_name'] = 'csrf_test_name';

--- a/system/core/Security.php
+++ b/system/core/Security.php
@@ -148,9 +148,12 @@ class CI_Security {
 		if ($exclude_uris = config_item('csrf_exclude_uris'))
 		{
 			$uri = load_class('URI', 'core');
-			if (in_array($uri->uri_string(), $exclude_uris))
+			foreach ($exclude_uris AS $excluded)
 			{
-				return $this;
+				if (preg_match('@^('.$excluded.')$@ms', $uri->uri_string()))
+				{
+					return $this;
+				}
 			}
 		}
 

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -111,6 +111,7 @@ Release Date: Not Released
    -  Added method() to CI_Input to retrieve $_SERVER['REQUEST_METHOD'].
    -  Modified valid_ip() to use PHP's filter_var() in the :doc:`Input Library <libraries/input>`.
    -  Added support for HTTP-Only cookies with new config option ``cookie_httponly`` (default FALSE).
+   -  Added support for regex in the csrf_exclude_uris array so that URIs can be skipped based on a pattern.
 
 Bug fixes for 3.0
 ------------------


### PR DESCRIPTION
...be skipped based on a pattern.

Example: to turn off CSRF checks everywhere but in an admin panel you could use: array('(?!admin).*?');

Plain strings should work as before: array('admin/demo-form', '(?!admin).*?');
