### PR TITLE
correcting PHPUnit execution error path, in Setup_test.php load file pat...

### DIFF
--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -11,7 +11,7 @@
 	stopOnSkipped="false">
 	<testsuites>
 		<testsuite name="CodeIgniter Core Test Suite">
-			<file>codeigniter/Setup_test.php</file>
+			<file>./codeigniter/Setup_test.php</file>
 			<directory suffix="test.php">codeigniter/core</directory>
 			<directory suffix="test.php">codeigniter/helpers</directory>
 			<directory suffix="test.php">codeigniter/libraries</directory>
@@ -19,7 +19,6 @@
 			<directory suffix="test.php">codeigniter/libraries</directory>
 			<directory suffix="test.php">codeigniter/helpers</directory>
 			-->
-			
 		</testsuite>
 	</testsuites>
 	<filters>


### PR DESCRIPTION
An error occurs when running the tests, Setup_test.php not found it was enough to correct the path.
