### PR TITLE
Don't assume input data is urlencoded when removing invisible characters

### DIFF
--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -530,7 +530,7 @@ class CI_Input {
 		}
 
 		// Remove control characters
-		$str = remove_invisible_characters($str);
+		$str = remove_invisible_characters($str, false);
 
 		// Should we filter the input data?
 		if ($this->_enable_xss === TRUE)


### PR DESCRIPTION
When cleaning input data, set url_encode to be false when removing invisible characters. The $_POST, $_GET, and $_COOKIE variables are not urlencoded, but remove_invisible_characters assume that it is and will remove characters such as "%00" unless the url_encoded parameter is set to false.
