### PR TITLE
Fix Posgres driver connection string. Current version has incorrect "use...

### DIFF
--- a/system/database/drivers/postgre/postgre_driver.php
+++ b/system/database/drivers/postgre/postgre_driver.php
@@ -89,7 +89,7 @@ class CI_DB_postgre_driver extends CI_DB {
 
 		if ($this->username !== '')
 		{
-			$this->dsn .= 'username='.$this->username.' ';
+			$this->dsn .= ' user='.$this->username.' ';
 
 			/* An empty password is valid!
 			 *


### PR DESCRIPTION
...rname" parameter, which should be "user"
