### PR TITLE
Add support for per field/rule error messages to the Form Validation Library

### DIFF
--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -206,7 +206,7 @@ class CI_Form_validation {
 	 */
 	public function set_message($lang, $val = '', $name = FALSE)
 	{
-		if($name){
+		if($name !== FALSE){
 			$lang = $name.'.'.$lang;
 		}
 


### PR DESCRIPTION
This commit gives the ability to pass an associative array of error
message as the fourth parameter of the set_rules method. This adds a
simple way to pass field/input specific error messages rather than rule
specific messages that set_messsage provides.
