### PR TITLE
Added the ability to insert objects with insert_batch() in Active Record

### DIFF
--- a/system/database/DB_active_rec.php
+++ b/system/database/DB_active_rec.php
@@ -1252,11 +1252,12 @@ abstract class CI_DB_active_record extends CI_DB_driver {
 			$key = array($key => $value);
 		}
 
-		$keys = array_keys(current($key));
+		$keys = array_keys($this->_object_to_array(current($key)));
 		sort($keys);
 
 		foreach ($key as $row)
 		{
+			$row = $this->_object_to_array($row);
 			if (count(array_diff($keys, array_keys($row))) > 0 OR count(array_diff(array_keys($row), $keys)) > 0)
 			{
 				// batch function above returns an error on an empty array

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -54,6 +54,7 @@ Release Date: Not Released
 
 -  Database
 
+   -  Added the ability to insert objects with insert_batch() in :doc:`Active Record <database/active_record>`.
    -  Added new :doc:`Active Record <database/active_record>` methods that return
       the SQL string of queries without executing them: get_compiled_select(),
       get_compiled_insert(), get_compiled_update(), get_compiled_delete().


### PR DESCRIPTION
We now can't pass an array of objects to that function, we can only pass an array of arrays or an object of arrays. With this fix, we can pass an array of objects or an object of objects to the insert_batch() method.

This is a post in the CI forum, where you can see the problem:
http://codeigniter.com/forums/viewthread/215142/
