### PR TITLE
added ROOTPATH constant

### DIFF
--- a/index.php
+++ b/index.php
@@ -209,6 +209,9 @@ if (defined('ENVIRONMENT'))
 	// Name of the "system folder"
 	define('SYSDIR', trim(strrchr(trim(BASEPATH, '/'), '/'), '/'));
 
+	// Path to the root folder
+	define('ROOTPATH', str_replace(SYSDIR.'/', '', BASEPATH));
+
 	// The path to the "application" folder
 	if (is_dir($application_folder))
 	{


### PR DESCRIPTION
ROOTPATH points to the folder where the system folder resides in. Ff you use the standard setup, then it's the same as FCPATH, but if you use a different setup, e.g. system and application folder are one level above index.php (to hide them from public access), then you can use ROOTPATH instead of FCPATH to address the folder that holds system and application. I use this in CI 2.1.x projects where I have a common folder next to system and application that holds libraries/packages that are shared between multiple apps.

Example:

``` php
require_once(ROOTPATH.'common/libraries/Some_lib.php');
```
