### PR TITLE
Adding in .ics MIME type for calendar invites.

### DIFF
--- a/system/libraries/Email.php
+++ b/system/libraries/Email.php
@@ -1891,6 +1891,7 @@ class CI_Email {
 						'tiff'	=>	'image/tiff',
 						'tif'	=>	'image/tiff',
 						'css'	=>	'text/css',
+						'ics'	=>	'text/calendar',
 						'html'	=>	'text/html',
 						'htm'	=>	'text/html',
 						'shtml'	=>	'text/html',


### PR DESCRIPTION
Was trying to attach calendar invites to emails and I had to add the ics key to the MIME type array for them to show up properly.
