### PR TITLE
Fixed libraries/Email.php: UTF8 subject line encoding for Apple Mail (and iOS Mail) / WordWrap for plaintext email

### DIFF
--- a/system/libraries/Email.php
+++ b/system/libraries/Email.php
@@ -761,7 +761,7 @@ class CI_Email {
 	{
 		if ($this->alt_message != '')
 		{
-			return ($this->wordwrap) ? $this->word_wrap($this->alt_message) : $this->alt_messasge;
+			return ($this->wordwrap) ? $this->word_wrap($this->alt_message) : $this->alt_message;
 		}
 
 		$body = (preg_match('/\<body.*?\>(.*)\<\/body\>/si', $this->_body, $match)) ? $match[1] : $this->_body;


### PR DESCRIPTION
This patches the Email.php library so that UTF8 subject lines (currently encoded with Q encoding) will show up correctly in Apple Mail / iOS Mail (using B encoding instead).

It also patches the _get_alt_message function so that emails sent from CI will honor the $config['wordwrap'] and $config['wrapchars'] settings.

PS: The word_wrap function used in the master source code does not work well with multibyte characters.  It wraps multibyte characters in the middle and breaks multibyte characters making them look like random symbol. This led me to try and disable wordwrap in config only to find out wordwrap wasn't honored in the existing source.
