### PR TITLE
Update system/libraries/Javascript.php

### DIFF
--- a/system/libraries/Javascript.php
+++ b/system/libraries/Javascript.php
@@ -723,14 +723,7 @@ class CI_Javascript {
 		{
 			if (is_object($result))
 			{
-				if (is_callable( array( $result, "result_array" ) ))
-				{
-					$json_result = $result->result_array();
-				}
-				else
-				{
-					$json_result = (array)$result;
-				}
+				$json_result = is_callable(array($result, 'result_array')) ? $result->result_array() : (array) $result;
 			}
 			elseif (is_array($result))
 			{


### PR DESCRIPTION
I think I've found a bug that crashes the json_encode function when trying to encode a multi-level object from the codeigniter ActiveRecord.

To reproduce, use 3 mysql tables for a many-to-many relationship from people to addresses.
# person_model.php

function get_all_people(){
    ..
    foreach($people as $person){
        $person->addresses = $this->addresses_model->get_by_person_id($person->id);
    }
    ..
}

json_encode($this->person_model->get_all_people());  //=> this crashes the json_encode function because the object to array conversion is bogus. The fix is very simple. 

Let me know what you think...
