### PR TITLE
Hotfix PDO

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,3 @@ branches:
   only:
     - develop
     - master
-    - pdo-patch


### PR DESCRIPTION
Fixed the wrong usage property name in PDO driver introduced at 2387ed3057c9c886389df736b3dd3f341d82d1d0.
