### PR TITLE
Update system/libraries/Cart.php  -  To enable integrity when using associative arrays

### DIFF
--- a/system/libraries/Cart.php
+++ b/system/libraries/Cart.php
@@ -244,7 +244,7 @@ class CI_Cart {
 		// This becomes the unique "row ID"
 		if (isset($items['options']) && count($items['options']) > 0)
 		{
-			$rowid = md5($items['id'].implode('', $items['options']));
+			$rowid = md5($items['id'].serialize($items['options']));
 		}
 		else
 		{


### PR DESCRIPTION
For both examples below can pass through the same product, and to allow the use of arrays with multiple levels

``` php
<?php

//  examples of the current state using implode

$id = 1 ;

$options = array(
    'Pages'              => '4',
    'Stickers per page'  => '5'
)

$options = array(
    'Pages'              => '45'
)

$options = array(
    'Stickers per page'  => '45'
)

//  or even
$id = '145';

//  in all the same result

$row_id = md5( '145' )
```
