### PR TITLE
url_title() accents support

### DIFF
--- a/system/helpers/url_helper.php
+++ b/system/helpers/url_helper.php
@@ -463,12 +463,21 @@ if ( ! function_exists('prep_url'))
  * @param	string	the string
  * @param	string	the separator
  * @param	bool
+ * @param	bool
  * @return	string
  */
 if ( ! function_exists('url_title'))
 {
-	function url_title($str, $separator = '-', $lowercase = FALSE)
+	function url_title($str, $separator = '-', $lowercase = FALSE, $convert_accents = TRUE)
 	{
+		if($convert_accents)
+		{
+			$CI =& get_instance();
+			$CI->load->helper('text');
+			
+			$str = convert_accented_characters($str);
+		}
+
 		if ($separator === 'dash')
 		{
 			$separator = '-';


### PR DESCRIPTION
At the moment url_title() breaks when using accents.
For example:

``` php
<?php
$string = 'Café';
echo url_title($string, '-', TRUE); // Returns caf
echo convert_accented_characters($string); // Returns Cafe
```

This change will convert the accents so a proper url title is returned.

``` php
echo url_title($string, '-', TRUE); // Returns cafe
```
