### PR TITLE
Autocommit already handled by MySQL implicitly.

### DIFF
--- a/system/database/drivers/mysql/mysql_driver.php
+++ b/system/database/drivers/mysql/mysql_driver.php
@@ -220,7 +220,6 @@ class CI_DB_mysql_driver extends CI_DB {
 		// even if the queries produce a successful result.
 		$this->_trans_failure = ($test_mode === TRUE);
 
-		$this->simple_query('SET AUTOCOMMIT=0');
 		$this->simple_query('START TRANSACTION'); // can also be BEGIN or BEGIN WORK
 		return TRUE;
 	}
@@ -241,7 +240,6 @@ class CI_DB_mysql_driver extends CI_DB {
 		}
 
 		$this->simple_query('COMMIT');
-		$this->simple_query('SET AUTOCOMMIT=1');
 		return TRUE;
 	}
 
@@ -261,7 +259,6 @@ class CI_DB_mysql_driver extends CI_DB {
 		}
 
 		$this->simple_query('ROLLBACK');
-		$this->simple_query('SET AUTOCOMMIT=1');
 		return TRUE;
 	}
 


### PR DESCRIPTION
See MySQL documentation (http://dev.mysql.com/doc/refman/5.5/en/commit.html):
"To disable autocommit mode implicitly for a single series of statements, use the START TRANSACTION statement: 
<snip>
 With START TRANSACTION, autocommit remains disabled until you end the transaction with COMMIT or ROLLBACK. The autocommit mode then reverts to its previous state."

So removing them saves 2 database calls per transaction..
