### PR TITLE
Improved next_row in DB_result.php (Issue #1351)

### DIFF
--- a/system/database/DB_result.php
+++ b/system/database/DB_result.php
@@ -334,7 +334,7 @@ class CI_DB_result {
 	public function next_row($type = 'object')
 	{
                 if ($this->EOF) {
-			return $false;
+			return false;
 		}
 
                 if($type=='object'){


### PR DESCRIPTION
added EOF public var to see if results had reached the end and optimized function next_row to be "$this->result" independent so won't exhaust server memory on large resulsets (>400k) 
with this modification there's no memory overhead when iterating over big results
now you can:

```
 while(!$query->EOF)
 { 
 $row=$query->next_row();
 // your process here with $row
 }
```

or

```
while($row=$query->next_row())
{
      // your process here $row
}
```
