### PR TITLE
fix backtrace filtering

### DIFF
--- a/application/errors/error_php.php
+++ b/application/errors/error_php.php
@@ -40,12 +40,15 @@
 	<p>Backtrace: </p>
 	<?php foreach(debug_backtrace() as $error): ?>
 
-		<?php if(isset($error['file']) &&  ! stristr($error['file'], SYSDIR)): ?>
+		<?php if(isset($error['file']) &&
+		         strpos($error['file'], realpath(BASEPATH)) !== 0): ?>
+
 			<p style="margin-left:10px">
 			File: <?php echo $error['file'] ?><br />
 			Line: <?php echo $error['line'] ?><br />
 			Function: <?php echo $error['function'] ?>
 			</p>
+
 		<?php endif ?>
 
 	<?php endforeach ?></p>


### PR DESCRIPTION
The backtrace was filtered to remove CI system files,
but the filter was buggy.  It would also filter out
application files which happened to contain the string "system"...
or ALL files, if the application directory is under /system/
(Perhaps the latter comes as a surprise, but it's explicitly
 mentioned in index.php and http://codeigniter.com/wiki/mod_rewrite).

Instead, we should test whether the file is underneath BASEPATH
(using realpath() to make sure we have the same sort of slashes).
