### PR TITLE
odbc driver connections with MSSQL

### DIFF
--- a/system/database/drivers/odbc/odbc_driver.php
+++ b/system/database/drivers/odbc/odbc_driver.php
@@ -353,12 +353,7 @@ class CI_DB_odbc_driver extends CI_DB {
 	 */
 	protected function _from_tables($tables)
 	{
-		if ( ! is_array($tables))
-		{
-			$tables = array($tables);
-		}
-
-		return '('.implode(', ', $tables).')';
+		return ( ! is_array($tables)) ? strstr($tables, ',') ? '('.$tables.')' : $tables : count($tables) > 1 ? '('.implode(', ', $tables).')' : end($tables);
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
When I use odbc driver for MSSQL, some error messages as below, but it is working for connecting to MySQL.

``` code
[Microsoft][ODBC SQL Server Driver][SQL Server]Incorrect syntax near ')'.

SELECT * FROM (ci_sessions) WHERE session_id = '3ad914bb5f5728e8ac69ad1db8fc9841' AND user_agent = 'Mozilla/5.0 (Windows NT 6.1; rv:10.0.2) Gecko/20100101 Firefox/10.0.2'
```

I modified the _from_tables function of odbc driver to fix this issue.
