### PR TITLE
If we want E_STRICT, don't suppress it!

### DIFF
--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -487,16 +487,6 @@ if ( ! function_exists('_exception_handler'))
 	 */
 	function _exception_handler($severity, $message, $filepath, $line)
 	{
-		 // We don't bother with "strict" notices since they tend to fill up
-		 // the log file with excess information that isn't normally very helpful.
-		 // For example, if you are running PHP 5 and you use version 4 style
-		 // class functions (without prefixes like "public", "private", etc.)
-		 // you'll get notices telling you that these have been deprecated.
-		if ($severity == E_STRICT)
-		{
-			return;
-		}
-
 		$_error =& load_class('Exceptions', 'core');
 
 		// Should we display the error? We'll get the current error_reporting


### PR DESCRIPTION
15be8fc "Changed the 'development' environment default error
         reporting to included E_STRICT"

Not present in any tagged release, so
no need for -stable or a changlelog entry.
