### PR TITLE
Allowing main constants defined via phpunit config or other bootstraper

### DIFF
--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -7,10 +7,10 @@ error_reporting(E_ALL | E_STRICT);
 $dir = realpath(dirname(__FILE__));
 
 // Path constants
-define('PROJECT_BASE',	realpath($dir.'/../').'/');
-define('BASEPATH',		PROJECT_BASE.'system/');
-define('APPPATH',		PROJECT_BASE.'application/');
-define('VIEWPATH',		PROJECT_BASE.'');
+defined('PROJECT_BASE') OR define('PROJECT_BASE', realpath($dir.'/../').'/');
+defined('BASEPATH') OR define('BASEPATH', PROJECT_BASE.'system/');
+defined('APPPATH') OR define('APPPATH', PROJECT_BASE.'application/');
+defined('VIEWPATH') OR define('VIEWPATH', PROJECT_BASE.'');
 
 // Get vfsStream either via PEAR or composer
 foreach (explode(PATH_SEPARATOR, get_include_path()) as $path)


### PR DESCRIPTION
This will allow anyone to include Bootstrap file after defining main constants in their own bootstrap (or via phpunit.xml).
