### PR TITLE
Fix issue where cache backup is ignored on first call.

### DIFF
--- a/system/libraries/Cache/Cache.php
+++ b/system/libraries/Cache/Cache.php
@@ -68,7 +68,7 @@ class CI_Cache extends CI_Driver_Library {
 	 *
 	 * @param string
 	 */
-	protected $_backup_driver;
+	protected $_backup_driver = 'dummy';
 
 	/**
 	 * Constructor
@@ -100,6 +100,22 @@ class CI_Cache extends CI_Driver_Library {
 			if (in_array('cache_'.$config['backup'], $this->valid_drivers))
 			{
 				$this->_backup_driver = $config['backup'];
+			}
+		}
+
+		// If the specified adapter isn't available, check the backup.
+		if ( ! $this->is_supported($this->_adapter))
+		{
+			if ( ! $this->is_supported($this->_backup_driver))
+			{
+				// Backup isn't supported either. Default to 'Dummy' driver.
+				log_message('error', 'Cache adapter "'.$this->_adapter.'" and backup "'.$this->_backup_driver.'" are both unavailable. Cache is now using "Dummy" adapter.');
+				$this->_adapter = 'dummy';
+			}
+			else
+			{
+				// Backup is supported. Set it to primary.
+				$this->_adapter = $this->_backup_driver;
 			}
 		}
 	}
@@ -204,26 +220,6 @@ class CI_Cache extends CI_Driver_Library {
 		}
 
 		return $support[$driver];
-	}
-
-	// ------------------------------------------------------------------------
-
-	/**
-	 * __get()
-	 *
-	 * @param	child
-	 * @return	object
-	 */
-	public function __get($child)
-	{
-		$obj = parent::__get($child);
-
-		if ( ! $this->is_supported($child))
-		{
-			$this->_adapter = $this->_backup_driver;
-		}
-
-		return $obj;
 	}
 
 }


### PR DESCRIPTION
This is a (potential) fix to the issue where the backup Cache driver is not used upon the first request, resulting in errors related to the primary adapter. Based on the existing code, the error is likely to only happen on the first call, since it is corrected at that point. But obviously that doesn't do us any good now does it? :)

Reference issues: #146, #456

I don't know why the other recommends suggest fixing this in a place other than the constructor. Someone referenced `_initialize()` but that doesn't seem to be utilized anymore.

This fix assigns the "dummy" adapter as the default backup automatically when the property is declared. It then does the config assignments, and finally verifies if the primary and backup adapters are supported.

The original `is_supported()` check was done in the `__get()` magic method defined in Cache.php. I removed it entirely since, aside from the support check, all it did was return `parent::__get()`.

Curious what people think regarding the log message level (error or debug?). Also would be nice if others could verify it works with them.
