### PR TITLE
use get_config instead of get_instance in encrypt library

### DIFF
--- a/system/libraries/Encrypt.php
+++ b/system/libraries/Encrypt.php
@@ -104,10 +104,9 @@ class CI_Encrypt {
 				return $this->encryption_key;
 			}
 
-			$CI =& get_instance();
-			$key = $CI->config->item('encryption_key');
+			$config =& get_config();
 
-			if ($key === FALSE)
+			if ( ! isset($config['encryption_key']))
 			{
 				show_error('In order to use the encryption class requires that you set an encryption key in your config file.');
 			}


### PR DESCRIPTION
This commit simplifies future testing of the encrypt library.
