### PR TITLE
html5 form inputs

### DIFF
--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -236,6 +236,32 @@ if ( ! function_exists('form_search'))
 
 // ------------------------------------------------------------------------
 
+if ( ! function_exists('form_email'))
+{
+	/**
+	 * Email Field
+	 *
+	 * Identical to the input function but adds the "email" type
+	 *
+	 * @param	mixed
+	 * @param	string
+	 * @param	string
+	 * @return	string
+	 */
+	function form_email($data = '', $value = '', $extra = '')
+	{
+		if ( ! is_array($data))
+		{
+			$data = array('name' => $data);
+		}
+
+		$data['type'] = 'email';
+		return form_input($data, $value, $extra);
+	}
+}
+
+// ------------------------------------------------------------------------
+
 if ( ! function_exists('form_password'))
 {
 	/**

--- a/tests/codeigniter/helpers/form_helper_test.php
+++ b/tests/codeigniter/helpers/form_helper_test.php
@@ -71,6 +71,26 @@ EOH;
 		$this->assertEquals($expected, form_search($data));
 	}
 	
+	public function test_form_email()
+ 	{
+ 		$expected = <<<EOH
+<input type="email" name="email" value="my@address.sk" id="email_input" maxlength="100" size="50" style="width:50%" pattern="[^ @]*@[^ @]*"  />
+
+EOH;
+ 	
+ 		$data = array(
+			'name'        => 'email',
+			'id'          => 'email_input',
+			'value'       => 'my@address.sk',
+ 			'maxlength'   => '100',
+ 			'size'        => '50',
+ 			'style'       => 'width:50%',
+ 			'pattern'     => '[^ @]*@[^ @]*'
+		);
+ 
+ 		$this->assertEquals($expected, form_email($data));
+ 	}
+	
 	public function test_form_password()
 	{				
 		$expected = <<<EOH


### PR DESCRIPTION
form_input() can be used for creating input[type=email] or input[type=<whatever>] html tags by changing its arguments, but using form_email()/form_url()/form_search() is more obvious in code (code is more readable).

Codeigniter should support new html5 tags.
