### PR TITLE
Modified Form Validation class's set_rules()

### DIFF
--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -187,8 +187,14 @@ class CI_Form_validation {
 			return $this;
 		}
 
+		// Convert an array of rules to a string
+		if (is_array($rules))
+		{
+			$rules = implode('|', $rules);
+		}
+
 		// No fields? Nothing to do...
-		if ( ! is_string($field) OR ! is_string($rules) OR $field === '')
+		if ( ! is_string($field) OR $field === '')
 		{
 			return $this;
 		}


### PR DESCRIPTION
Modified Form Validation class's set_rules() so it can now handle an array of rules, instead of just a string.

Makes it easy to modify a set of rules before they're passed to the set_rules() method.

Very simple example:

```
class Foobar extends CI_Controller {

    public $validation_rules = array(

        'id' => array(

            'field' => 'id',
            'label' => 'Id',
            'rules' => array('trim', 'numeric', 'required')

        ),

        ...

    );

    public function foobaz()
    {
        $rules = $this->validation_rules;

        unset($rules['id'][2]);

        $this->form_validation->set_rules($rules);

        ...

    }
}
```
