### PR TITLE
A TTL of 0 will keep the cache persistant.

### DIFF
--- a/system/libraries/Cache/drivers/Cache_file.php
+++ b/system/libraries/Cache/drivers/Cache_file.php
@@ -73,7 +73,7 @@ class CI_Cache_file extends CI_Driver {
 
 		$data = unserialize(file_get_contents($this->_cache_path.$id));
 
-		if (time() >  $data['time'] + $data['ttl'])
+		if ($data['ttl'] > 0 AND time() >  $data['time'] + $data['ttl'])
 		{
 			unlink($this->_cache_path.$id);
 			return FALSE;


### PR DESCRIPTION
In the APC and Redis cache, a TTL of 0 will keep the cache as persistant. For the file cache, it should be the same. If you pass a TTL as 0, it will be persistant (and never expire).
