### PR TITLE
[Database] Extra debug info when there is a Query error.

### DIFF
--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -352,7 +352,7 @@ abstract class CI_DB_driver {
 			$error = $this->error();
 
 			// Log errors
-			log_message('error', 'Query error: '.$error['message']);
+			log_message('error', 'Query error: '.$error['message'] . ' - Invalid query: ' . $sql);
 
 			if ($this->db_debug)
 			{


### PR DESCRIPTION
Added extra debug data when there is a Query error. The current situation is when you get a log of a query error, it is like this:

**Query error: Unknown column 'user_id' in 'where clause'**

It is easier to also know what the exact query was that was executed.
