### PR TITLE
Documentation: remaining PHP "var" declarations changed to "public"

### DIFF
--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -603,9 +603,9 @@ Here is an example using an object::
 
 	/*
 	class Myclass {
-		var  $title = 'My Title';
-		var  $content = 'My Content';
-		var  $date = 'My Date';
+		public $title = 'My Title';
+		public $content = 'My Content';
+		public $date = 'My Date';
 	}
 	*/
 
@@ -730,9 +730,9 @@ Or an object::
 
 	/*
 	class Myclass {
-		var  $title = 'My Title';
-		var  $content = 'My Content';
-		var  $date = 'My Date';
+		public $title = 'My Title';
+		public $content = 'My Content';
+		public $date = 'My Date';
 	}
 	*/
 
@@ -766,9 +766,9 @@ Or you can supply an object::
 
 	/*
 	class Myclass {
-		var  $title = 'My Title';
-		var  $content = 'My Content';
-		var  $date = 'My Date';
+		public $title = 'My Title';
+		public $content = 'My Content';
+		public $date = 'My Date';
 	}
 	*/
 

--- a/user_guide_src/source/general/models.rst
+++ b/user_guide_src/source/general/models.rst
@@ -18,9 +18,9 @@ model class might look like::
 
 	class Blog_model extends CI_Model {
 
-	    var $title   = '';
-	    var $content = '';
-	    var $date    = '';
+	    public $title   = '';
+	    public $content = '';
+	    public $date    = '';
 
 	    function __construct()
 	    {


### PR DESCRIPTION
Since PHP 4 isn't supported anymore, let's clean up these few
PHP "var" declarations which were remaining in the documentation.

According to my checks, there is no more PHP "var" left.
