### PR TITLE
Use the VIEWPATH constant, instead of assuming the user hasn't moved them

### DIFF
--- a/system/core/Exceptions.php
+++ b/system/core/Exceptions.php
@@ -143,7 +143,7 @@ class CI_Exceptions {
 			ob_end_flush();
 		}
 		ob_start();
-		include(APPPATH.'views/errors/'.$template.'.php');
+		include(VIEWPATH.'errors/'.$template.'.php');
 		$buffer = ob_get_contents();
 		ob_end_clean();
 		return $buffer;
@@ -177,7 +177,7 @@ class CI_Exceptions {
 			ob_end_flush();
 		}
 		ob_start();
-		include(APPPATH.'views/errors/error_php.php');
+		include(VIEWPATH.'errors/error_php.php');
 		$buffer = ob_get_contents();
 		ob_end_clean();
 		echo $buffer;


### PR DESCRIPTION
Currently, the PHP Error function's hard-coded to ignore VIEWPATH.
