### PR TITLE
[library:log] info and debug log level index swaped

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -199,13 +199,13 @@ $config['directory_trigger']	= 'd'; // experimental not currently in use
 |
 |	0 = Disables logging, Error logging TURNED OFF
 |	1 = Error Messages (including PHP errors)
-|	2 = Debug Messages
-|	3 = Informational Messages
+|	2 = Informational Messages
+|	3 = Debug Messages
 |	4 = All Messages
 |
 | You can also pass in a array with threshold levels to show individual error types
 |
-| 	array(2) = Debug Messages, without Error Messages
+| 	array(3) = Debug Messages, without Error and Informational Messages
 |
 | For a live site you'll usually only enable Errors (1) to be logged otherwise
 | your log files will fill up very fast.

--- a/system/libraries/Log.php
+++ b/system/libraries/Log.php
@@ -83,7 +83,7 @@ class CI_Log {
 	 *
 	 * @var array
 	 */
-	protected $_levels		= array('ERROR' => 1, 'DEBUG' => 2,  'INFO' => 3, 'ALL' => 4);
+	protected $_levels		= array('ERROR' => 1, 'INFO' => 2,  'DEBUG' => 3, 'ALL' => 4);
 
 	/**
 	 * Initialize Logging class

--- a/user_guide_src/source/general/errors.rst
+++ b/user_guide_src/source/general/errors.rst
@@ -51,7 +51,7 @@ log_message('level', 'message')
 
 This function lets you write messages to your log files. You must supply
 one of three "levels" in the first parameter, indicating what type of
-message it is (debug, error, info), with the message itself in the
+message it is (debug, info, error), with the message itself in the
 second parameter. Example::
 
 	if ($some_var == "")
@@ -69,13 +69,13 @@ There are three message types:
 
 #. Error Messages. These are actual errors, such as PHP errors or user
    errors.
-#. Debug Messages. These are messages that assist in debugging. For
-   example, if a class has been initialized, you could log this as
-   debugging info.
 #. Informational Messages. These are the lowest priority messages,
    simply giving information regarding some process. CodeIgniter doesn't
    natively generate any info messages but you may want to in your
    application.
+#. Debug Messages. These are messages that assist in debugging. For
+   example, if a class has been initialized, you could log this as
+   debugging info.
 
 .. note:: In order for the log file to actually be written, the "logs"
 	folder must be writable. In addition, you must set the "threshold" for


### PR DESCRIPTION
This is related to codeigniter Log librarary.

It has given more priority to DEBUG logs rather than INFO logs.
So this commit will fix it.

Now final log levels looks like this

` protected $_levels		= array('ERROR' => 1, 'INFO' => 2,  'DEBUG' => 3, 'ALL' => 4);`