### PR TITLE
Added ability to override configurable settings from index.php

### DIFF
--- a/config.sample.php
+++ b/config.sample.php
@@ -1,0 +1,10 @@
+<?php
+/*
+ * This file allows you to override configurable settings (see index.php for
+ * more details). Examples:
+ *
+ * $environment = 'production';
+ * $application_folder = 'my_application';
+ * $assign_to_config['base_url'] = 'http://example.com/';
+ *
+ */

--- a/index.php
+++ b/index.php
@@ -40,9 +40,9 @@
  *     testing
  *     production
  *
- * NOTE: If you change these, also change the error_reporting() code below
+ * NOTE: If you change these, also change the error_reporting variable below
  */
-	define('ENVIRONMENT', isset($_SERVER['CI_ENV']) ? $_SERVER['CI_ENV'] : 'development');
+	$environment = isset($_SERVER['CI_ENV']) ? $_SERVER['CI_ENV'] : 'development';
 /*
  *---------------------------------------------------------------
  * ERROR REPORTING
@@ -52,16 +52,16 @@
  * By default development will show errors but testing and live will hide them.
  */
 
-if (defined('ENVIRONMENT'))
+if (isset($environment))
 {
-	switch (ENVIRONMENT)
+	switch ($environment)
 	{
 		case 'development':
-			error_reporting(-1);
+			$error_reporting = -1;
 		break;
 		case 'testing':
 		case 'production':
-			error_reporting(0);
+			$error_reporting = 0;
 		break;
 		default:
 			exit('The application environment is not set correctly.');
@@ -161,6 +161,26 @@ if (defined('ENVIRONMENT'))
 // --------------------------------------------------------------------
 // END OF USER CONFIGURABLE SETTINGS.  DO NOT EDIT BELOW THIS LINE
 // --------------------------------------------------------------------
+
+/*
+ * ---------------------------------------------------------------
+ *  Allow config.php to override configurable settings
+ * ---------------------------------------------------------------
+ */
+
+	// include config.php (if present)
+	$config_file = dirname(__FILE__) . '/config.php';
+	if(file_exists($config_file))
+	{
+		include $config_file;
+	}
+
+	// set up environment
+	if(isset($environment))
+	{
+		define('ENVIRONMENT', $environment);
+		error_reporting($error_reporting);
+	}
 
 /*
  * ---------------------------------------------------------------

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -190,6 +190,7 @@ Release Date: Not Released
    -  $config['time_reference'] now supports all timezone strings supported by PHP.
    -  Added support for HTTP code 303 ("See Other") in set_status_header().
    -  Changed :doc:`Config Library <libraries/config>` method site_url() to accept an array as well.
+   -  Added ability to override configurable settings from index.php in config.php
 
 Bug fixes for 3.0
 ------------------


### PR DESCRIPTION
If CodeIgniter's index.php is added under version control then all configurable settings in this file will also be tracked (even if some are machine specific). Having the ability to set or override configurable settings in a separate (unversioned and machine specific) file would make it easier to keep CodeIgniter's files under version control.

When upgrading index.php to a newer version one would not need to worry about changes to that file. The separate configuration file might also allow for logic for switching between different environments, applications or CodeIgniter installations.

For backwards compatibility this configuration file is optional.
