### PR TITLE
Allow URL to route without index.php but with `?`

### DIFF
--- a/system/core/URI.php
+++ b/system/core/URI.php
@@ -207,6 +207,12 @@ class CI_URI {
 		if (strpos($uri, '?/') === 0)
 		{
 			$uri = substr($uri, 2);
+		} 
+		// This section allows to use URL without index.php but with just '?'
+		// Eg:- http://localhost:8080/ci/?/welcome
+		else if (strpos($uri, '/?/') === 0) 
+		{
+			$uri = substr($uri, 3);
 		}
 
 		$parts = explode('?', $uri, 2);

--- a/tests/codeigniter/core/URI_test.php
+++ b/tests/codeigniter/core/URI_test.php
@@ -36,6 +36,7 @@ class URI_test extends CI_TestCase {
 		// Test a variety of request uris
 		$requests = array(
 			'/index.php/controller/method' => 'controller/method',
+			'/?/controller/method' => 'controller/method',
 			'/index.php?/controller/method' => 'controller/method',
 			'/index.php?/controller/method/?var=foo' => 'controller/method'
 		);


### PR DESCRIPTION
This is simple hack to remove `index.php` from the URL but without using .htaccess.
What you have to do is just replace `index.php` into `?` in the url

eg:-

`http://localhost/?/controller` instead of `http://localhost/index.php/controller`
## Why 
- Some Servers does not support .htaccess
- It is hard to configure .htaccess for novice users (with this they can still avoid index.php)
- This works with flash resource loading without much trouble 
