### PR TITLE
Add delayed option to active record insert class

### DIFF
--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -1406,9 +1406,10 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 *
 	 * @param	string	the table to insert data into
 	 * @param	array	an associative array of insert values
+     * @param   bool	TRUE: delay inserts for MYISAM tables only; FALSE: do not delay
 	 * @return	object
 	 */
-	public function insert($table = '', $set = NULL)
+	public function insert($table = '', $set = NULL, $delayed = FALSE)
 	{
 		if ( ! is_null($set))
 		{
@@ -1425,7 +1426,8 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 				$this->qb_from[0], TRUE, NULL, FALSE
 			),
 			array_keys($this->qb_set),
-			array_values($this->qb_set)
+			array_values($this->qb_set),
+            $delayed
 		);
 
 		$this->_reset_write();
@@ -1442,12 +1444,13 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 * @param	string	the table name
 	 * @param	array	the insert keys
 	 * @param	array	the insert values
+     * @param   bool    to delay the insert
 	 * @return	string
 	 */
-	protected function _insert($table, $keys, $values)
+	protected function _insert($table, $keys, $values, $delayed)
 	{
-		return 'INSERT INTO '.$table.' ('.implode(', ', $keys).') VALUES ('.implode(', ', $values).')';
-	}
+            return 'INSERT '.($delayed === FALSE ? '':'DELAYED ').'INTO '.$table.' ('.implode(', ', $keys).') VALUES ('.implode(', ', $values).')';      
+    }
 
 	// --------------------------------------------------------------------
 

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -597,7 +597,7 @@ function. Here is an example using an array::
 	// Produces: INSERT INTO mytable (title, name, date) VALUES ('My title', 'My name', 'My date')
 
 The first parameter will contain the table name, the second is an
-associative array of values.
+associative array of values and the third is a boolean value (defaulted to FALSE) to delay the insert.
 
 Here is an example using an object::
 
@@ -615,6 +615,11 @@ Here is an example using an object::
 
 The first parameter will contain the table name, the second is an
 object.
+
+Here is an example with a delayed insert (MYISAM tables only)::
+
+    $this->db->insert('mytable, $data, TRUE);
+	// Produces: INSERT DELAYED INTO mytable (title, name, date) VALUES ('My title', 'My name', 'My date')
 
 .. note:: All values are escaped automatically producing safer queries.
 


### PR DESCRIPTION
I added an additional BOOL argument (defaulted to FALSE) to the INSERT active record method to DELAY the insert if TRUE. When not using batch inserts and iterating inserts via a loop over a long period of time will sometimes require an INSERT DELAYED option to ensure the server can process the request for MYISAM tables safely.
