### PR TITLE
Allow extra SPL autoloader

### DIFF
--- a/tests/mocks/autoloader.php
+++ b/tests/mocks/autoloader.php
@@ -87,7 +87,7 @@ function autoload($class)
 			return FALSE;
 		}
 
-		throw new InvalidArgumentException("Unable to load $class.");
+		throw new InvalidArgumentException("Unable to load {$class}.");
 	}
 
 	include_once($file);


### PR DESCRIPTION
This will allow other registered SPL autoloader to be executed, if there was another custom autoloader in our app test-suites.
