### PR TITLE
Respect display_errors when deciding if to display an error... 

### DIFF
--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -526,7 +526,7 @@ if ( ! function_exists('_exception_handler'))
 
 		// Should we display the error? We'll get the current error_reporting
 		// level and add its bits with the severity bits to find out.
-        // And respect display_errors
+		// And respect display_errors
 		if (($severity & error_reporting()) === $severity && (bool) ini_get('display_errors') === TRUE)
 		{
 			$_error->show_php_error($severity, $message, $filepath, $line);

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -178,6 +178,7 @@ Release Date: Not Released
 
 -  Core
 
+   -  _exception_handler now respects php.ini's display_errors
    -  Changed private methods in the :doc:`URI Library <libraries/uri>` to protected so MY_URI can override them.
    -  Removed CI_CORE boolean constant from CodeIgniter.php (no longer Reactor and Core versions).
    -  Added method get_vars() to the :doc:`Loader Library <libraries/loader>` to retrieve all variables loaded with $this->load->vars().


### PR DESCRIPTION
-- useful for environments where you want to log errors, but not show them.

Pretty self explanatory, it just checks ini_get('display_errors') to see if it's a positive value or not before actually showing an error.
