### PR TITLE
Document in the 3.0.0 upgrade guide a breaking change in Array Helper

### DIFF
--- a/user_guide_src/source/installation/upgrade_300.rst
+++ b/user_guide_src/source/installation/upgrade_300.rst
@@ -46,3 +46,9 @@ Step 5: Move your errors folder
 ===============================
 
 In version 3.0.0, the errors folder has been moved from _application/errors* to _application/views/errors*.
+
+Step 6: Check the calls to Array Helper's element() and elements() functions
+============================================================================
+
+The default return value of these functions, when the required elements
+don't exist, has been changed from FALSE to NULL.


### PR DESCRIPTION
The default return value of Array Helper's element() and elements()
functions, when the required elements don't exist, has been changed
from FALSE to NULL.
