### PR TITLE
core/Config.php - Moved variable assignment out of loop, other teeny weeny fixes.

### DIFF
--- a/system/core/Config.php
+++ b/system/core/Config.php
@@ -43,7 +43,7 @@ class CI_Config {
 	 *
 	 * @var array
 	 */
-	public $config =	array();
+	public $config = array();
 
 	/**
 	 * List of all loaded config files
@@ -172,7 +172,7 @@ class CI_Config {
 			{
 				return FALSE;
 			}
-			show_error('The configuration file '.$file.'.php'.' does not exist.');
+			show_error('The configuration file '.$file.'.php does not exist.');
 		}
 
 		return TRUE;
@@ -271,7 +271,7 @@ class CI_Config {
 	 */
 	public function base_url($uri = '')
 	{
-		return $this->slash_item('base_url').ltrim($this->_uri_string($uri),'/');
+		return $this->slash_item('base_url').ltrim($this->_uri_string($uri), '/');
 	}
 
 	// -------------------------------------------------------------


### PR DESCRIPTION
The `$check_locations` variable definition doesn't change when inside the loop, so there's no point in putting it there (naughty redundancy!).

I also removed an unnecessary tab white space, added a space between function arguments, and removed a stray string concatenation.

Happy coding!
