### PR TITLE
improvement for latest migration id calculation

### DIFF
--- a/system/libraries/Migration.php
+++ b/system/libraries/Migration.php
@@ -292,7 +292,7 @@ class CI_Migration {
 
 		// Calculate the last migration step from existing migration
 		// filenames and procceed to the standard version migration
-		return $this->version((int)$last_migration);
+		return $this->version((int) $last_migration);
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
It is better to use

```
(int)$last_migration
```

instead of 

```
(int)substr($last_migration, 0, 3)
```

result is the same but in first case there is no limits for length of number part, who knows how big it can be.
