### PR TITLE
I added so the DB.php is aware of database config files in packages.

### DIFF
--- a/system/database/DB.php
+++ b/system/database/DB.php
@@ -49,19 +49,19 @@ function &DB($params = '', $query_builder_override = NULL)
 		include($file_path);
 		//make packages contain database config files
 		foreach(get_instance()->load->get_package_paths() as $path)
-                {
-                    if ($path != APPPATH)
-                        {
-                        if ( file_exists($file_path = $path.'config/'.ENVIRONMENT.'/database.php'))
-                        {
-                            include($file_path);
-                        }
-                        elseif ( file_exists($file_path = $path.'config/database.php'))
-                        {
-                            include($file_path);
-                        }
-                    }
-                }
+		{
+			if ($path !== APPPATH)
+			{
+				if (file_exists ($file_path = $path.'config/'.ENVIRONMENT.'/database.php'))
+				{
+					include ($file_path);
+				}
+				elseif ( file_exists ($file_path = $path.'config/database.php'))
+				{
+					include ($file_path);
+				}
+			}
+		}
 
 		if ( ! isset($db) OR count($db) === 0)
 		{

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -137,6 +137,7 @@ Release Date: Not Released
    -  Added PDO support for create_database(), drop_database and drop_table() in :doc:`Database Forge <database/forge>`.
    -  Added unbuffered_row() method for getting a row without prefetching whole result (consume less memory).
    -  Added PDO support for ``list_fields()`` in :doc:`Database Results <database/results>`.
+   -  Added capability for packages to hold database.php config files 
 
 -  Libraries
 


### PR DESCRIPTION
This way if a package is containing a database.php file in its config folder this will be
parset alongside the aplication/config/database.php file.
