### PR TITLE
missing '$this->' causing custom result objects to return as null/empty ...

### DIFF
--- a/system/database/DB_result.php
+++ b/system/database/DB_result.php
@@ -158,7 +158,7 @@ class CI_DB_result {
 
 		while ($row = $this->_fetch_object($class_name))
 		{
-			$custom_result_object[$class_name][] = $row;
+			$this->custom_result_object[$class_name][] = $row;
 		}
 
 		return $this->custom_result_object[$class_name];


### PR DESCRIPTION
`...arrays for ->row() and ->result() methods.`

Without this fix, code such as this seems broken:

``` php
class Test_Object {

    public function getId() {
        return $this->id;
    }

    public function getTitle() {
        return $this->title;
    }
}

class Test extends CI_Controller {

    public function index() {

        $this->db->select('*');
        $this->db->from('test');
        $this->db->where('id', 1);
        $test = $this->db->get();

        // Fetch a 'Test_Object'.
        $object = $test->row(0, 'Test_Object');

        // Expecting a dump of 'Test_Object' now:
        var_dump($object);
    }
}
```

It appears as if there is a typo (missing $this->) which is causing the problem.
