### PR TITLE
2.1 stable

### DIFF
--- a/system/database/drivers/pdo/pdo_result.php
+++ b/system/database/drivers/pdo/pdo_result.php
@@ -36,11 +36,9 @@ class CI_DB_pdo_result extends CI_DB_result {
 	{
 		if (is_numeric(stripos($this->result_id->queryString, 'SELECT')))
 		{
-			$dbh = $this->conn_id;
-			$query = $dbh->query($this->result_id->queryString);
-			$result = $query->fetchAll();
-			unset($dbh, $query);
-			return count($result);
+			$count = count($this->result_id->fetchAll());
+			$this->result_id->execute();
+			return $count;
 		}
 		else
 		{


### PR DESCRIPTION
fixed system/database/drivers/pdo/pdo_result.php to return correct num_rows() in all situations and in a way consistent with CI_DB_pdo_driver::_execute() (system/database/drivers/pdo/pdo_driver.php)

Signed-off-by: webdevelopersdiary info@webdevelopersdiary.com
