### PR TITLE
Reconnect to PostgreSQL database if connection dropped.

### DIFF
--- a/system/database/drivers/postgre/postgre_driver.php
+++ b/system/database/drivers/postgre/postgre_driver.php
@@ -132,7 +132,15 @@ class CI_DB_postgre_driver extends CI_DB {
 	 */
 	public function db_pconnect()
 	{
-		return @pg_pconnect($this->dsn);
+		$conn = @pg_pconnect($this->dsn);
+		if ($conn && pg_connection_status($conn) === PGSQL_CONNECTION_BAD)
+		{
+			if (pg_ping($conn) === FALSE)
+			{
+				return FALSE;
+			}
+		}
+		return $conn;
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
This change will fix the error message "server closed the connection unexpectedly This probably means the server terminated abnormally before or while processing the request.".
This error shows up on restarting the database server without restarting the web server.
