### PR TITLE
Adding flatten function to array helper.

### DIFF
--- a/system/helpers/array_helper.php
+++ b/system/helpers/array_helper.php
@@ -102,5 +102,28 @@ if ( ! function_exists('elements'))
 	}
 }
 
+if ( ! function_exists('flatten')) 
+{
+        /**
+         * Flatten
+         *
+         * Returns all of the leaves of an array, flattening it.
+         *
+         * @param  array       
+         * @return array      leaves of the array 
+         */
+        function flatten(array $array)
+	{
+	        $return = array();
+
+                array_walk_recursive($array, 
+				     function($el) use (&$return) {
+				             $return[] = $el;
+				     });
+    
+		return $return;
+	}
+}
+
 /* End of file array_helper.php */
 /* Location: ./system/helpers/array_helper.php */


### PR DESCRIPTION
Often times in manipulating arrays all the leaf elements are desired, an example is given below. Using a flattening function can do this.

Argument:

``` array
  0 => 
    array
      0 => int 4124
  1 => 
    array
      0 => int 1224
  2 => 
    array
      0 => int 2129
  3 => 
    array
      0 => int 8194
  4 => 
    array
      0 => int 3125
  5 => 
    array
      0 => int 1121
  6 => 
    array
      0 => int 5174
```

Result:

``` array
  0 => int 4124
  1 => int 1224
  2 => int 2129
  3 => int 8194
  4 => int 3125
  5 => int 1121
  6 => int 5174
```
