### PR TITLE
Fix in index.php inline documentation

### DIFF
--- a/index.php
+++ b/index.php
@@ -135,7 +135,7 @@ switch (ENVIRONMENT)
 	// if your controller is not in a sub-folder within the "controllers" folder
 	// $routing['directory'] = '';
 
-	// The controller class file name.  Example:  Mycontroller
+	// The controller class file name.  Example:  mycontroller
 	// $routing['controller'] = '';
 
 	// The controller function you wish to be called.


### PR DESCRIPTION
$routing['controller'] has to respect the capitalization of the
filename, which is in lowercase. Otherwise, the application fails on
case-sensitive servers.
