### PR TITLE
Inconsistency between log_message and show_error when encountering a non-existant class

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -1091,7 +1091,7 @@ class CI_Loader {
 		if ( ! class_exists($name))
 		{
 			log_message('error', 'Non-existent class: '.$name);
-			show_error('Non-existent class: '.$class);
+			show_error('Non-existent class: '.$name);
 		}
 
 		// Set the variable name we will assign the class to


### PR DESCRIPTION
minor error reporting issue within the core Loader class (slight inconsistency).

Signed-off-by: jonnu jontce@gmail.com
