### PR TITLE
output->_display_cache() simplifications

### DIFF
--- a/system/core/Output.php
+++ b/system/core/Output.php
@@ -552,13 +552,13 @@ class CI_Output {
 		fclose($fp);
 
 		// Strip out the embedded timestamp
-		if ( ! preg_match('/(\d+TS--->)/', $cache, $match))
+		if ( ! preg_match('/\d+TS--->/', $cache, $match))
 		{
 			return FALSE;
 		}
 
 		$last_modified = filemtime($cache_path);
-		$expire = trim(str_replace('TS--->', '', $match[1]));
+		$expire = str_replace('TS--->', '', $match[0]);
 
 		// Has the file expired?
 		if ($_SERVER['REQUEST_TIME'] >= $expire && is_really_writable($cache_path))


### PR DESCRIPTION
remove an unneeded regex capturing group and an unneeded trim()
