### PR TITLE
Fix warning by profiler when userdata has objects

### DIFF
--- a/system/libraries/Profiler.php
+++ b/system/libraries/Profiler.php
@@ -506,7 +506,7 @@ class CI_Profiler {
 
 		foreach ($this->CI->session->all_userdata() as $key => $val)
 		{
-			if (is_array($val))
+			if (is_array($val) || is_object($val))
 			{
 				$val = print_r($val, TRUE);
 			}


### PR DESCRIPTION
If session data has objects and profiler is enabled, a warning is thrown:

> A PHP Error was encountered
> Severity: Warning
> Message: htmlspecialchars() expects parameter 1 to be string, object given
> Filename: libraries/Profiler.php
> Line Number: 514
