### PR TITLE
Logging should obey error_reporting() setting

### DIFF
--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -527,17 +527,17 @@ if ( ! function_exists('_exception_handler'))
 		// Should we ignore the error? We'll get the current error_reporting
 		// level and add its bits with the severity bits to find out.
 		if (($severity & error_reporting()) !== $severity)
-        {
-            return;
-        }
-        
-    	// Should we display the error?
-        if ((bool) ini_get('display_errors') === TRUE)
+		{
+			return;
+		}
+
+		// Should we display the error?
+		if ((bool) ini_get('display_errors') === TRUE)
 		{
 			$_error->show_php_error($severity, $message, $filepath, $line);
 		}
 
-	    $_error->log_exception($severity, $message, $filepath, $line);
+		$_error->log_exception($severity, $message, $filepath, $line);
 	}
 }
 


### PR DESCRIPTION
If the php error level is not included in the current
error_reporting() setting, we should not log it.

Also, the log_threshold check is redundant, it's
already taken care of by the write_log() method.
