### PR TITLE
added the ability to log queryes to logfile when db_debug is true

### DIFF
--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -483,8 +483,25 @@ abstract class CI_DB_driver {
 		{
 			$this->initialize();
 		}
-
-		return $this->_execute($sql);
+		$query = $this->_execute($sql);
+		
+		if ($this->db_debug) 
+		{
+			// Set log type
+			$log_type = 'DEBUG';
+			// Check if query failed
+			if ($this->_error_number()) 
+			{
+			// Change log type to error
+				$log_type = 'ERROR';
+				// Log query error message
+				log_message($log_type, 'Query error: (' . $this->_error_number() . ')' . $this->_error_message());
+			}
+			// Log the query
+			log_message($log_type, 'Query: ' . str_replace(array("\n", "\r"), " ", $sql));
+		}
+		
+		return $query;
 	}
 
 	// --------------------------------------------------------------------

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -140,6 +140,7 @@ Release Date: Not Released
    -  Added PDO support for ``list_fields()`` in :doc:`Database Results <database/results>`.
    -  Added capability for packages to hold database.php config files 
    -  Added subdrivers support (currently only used by PDO).
+   -  Added query logging to DB_driver when the database config have $db['default']['db_debug']=TRUE;
 
 -  Libraries
 


### PR DESCRIPTION
DB_driver.php now have the ability to log query's when the database config property  db_debug is true like this:

``` php
$db['default']['db_debug'] = true;
```
