### PR TITLE
Update system/libraries/Upload.php

### DIFF
--- a/system/libraries/Upload.php
+++ b/system/libraries/Upload.php
@@ -998,11 +998,11 @@ class CI_Upload {
 		{
 			if ( ! in_array(strtolower($part), $this->allowed_types) OR $this->mimes_types(strtolower($part)) === FALSE)
 			{
-				$filename .= '.'.$part.'_';
+				$filename .= '_'.$part.'_';
 			}
 			else
 			{
-				$filename .= '.'.$part;
+				$filename .= '_'.$part;
 			}
 		}
 


### PR DESCRIPTION
appending back the '.' in the filename breaks compatibility later on in input.php as a '.' is not allowed, especially when working with forms and filenames, causing one extra step to rename files or sanitize them.
