### PR TITLE
Bug fix #1695 Update Nintendo mobile user agents.

### DIFF
--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -321,7 +321,6 @@ Bug fixes for 3.0
 -  Fixed a bug (#1613) - :doc:`Form Helper <helpers/form_helper>` functions ``form_multiselect()``, ``form_dropdown()`` didn't properly handle empty array option groups.
 -  Fixed a bug (#1605) - :doc:`Pagination Library <libraries/pagination>` produced incorrect *previous* and *next* link values.
 -  Fixed a bug in SQLSRV's ``affected_rows()`` method where an erroneous function name was used.
--  Fixed a bug (#1695) - IE8 occasionally registered as mobile browser, due to Nintedo DS user agent's "ds" key.
 
 Version 2.1.2
 =============


### PR DESCRIPTION
Based on everything I could find for Nintendo user agents, they are always written as "Nintendo DS", or "Nintendo 3DS". So based on the bug report that the `ds` key was false matching a different user agent (IE8 in their case), adding the `nintendo` portion is a safe bet. Those user agents I found that did not specify Nintendo, the agent still had something that defined it as mobile (such as "Opera Mini").

The `wii` key was left alone - I figure Wii is pretty unique as is.

Some sources:
- http://www.botsvsbrowsers.com/category/28/index.html
- http://dsibrew.org/wiki/Nintendo_DSi_Browser#User_Agent_strings
- http://www.nintendo.com/3ds/internetbrowser/specs/
