### PR TITLE
Adds get_numeric_input()

### DIFF
--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -199,7 +199,66 @@ class CI_Input {
 
 		return $this->_fetch_from_array($_POST, $index, $xss_clean);
 	}
+	
+	// --------------------------------------------------------------------
 
+	/**
+	 * Checks and fetches an item from the POST or GET array and checks to see if it is numeric
+	 *
+	 * @param	string	The index key
+	 * @param	string	The POST or GET array
+	 * @param	bool	Required or not
+	 * @param	bool	XSS Cleaning
+	 * @return	mixed	Either the validated variable or False
+	 */	
+
+	function get_numeric_input($name, $source = "GET", $required = True, $xss_clean = True) {
+	    if ($source === "GET") {
+	        if ($this->get($name, $xss_clean)) {
+	            if (is_numeric($this->get($name, $xss_clean))) {
+	                return $this->get($name, $xss_clean);
+	            } else {
+	                if ($required) {
+	                    show_error("$source variable $name is not numeric!");
+	                    log_message('error', "$source variable $name is not numeric!");
+	                    return False;
+	                } else {
+	                    return False;
+	                }
+	            }
+	        } else {
+	            if ($required) {
+	                show_error("$source variable $name is not set!");
+	                log_message('error', "$source variable $name is not set!");
+	                return False;
+	            } else {
+	                return False;
+	            }
+	        }
+	    } elseif ($source === "POST") {
+	        if ($this->post($name, $xss_clean)) {
+	            if (is_numeric($this->post($name, $xss_clean))) {
+	                return $this->post($name, $xss_clean);
+	            } else {
+	                if ($required) {
+	                    show_error("$source variable $name is not numeric!");
+	                    log_message('error', "$source variable $name is not numeric!");
+	                    return False;
+	                } else {
+	                    return False;
+	                }
+	            }
+	        } else {
+	            if ($required) {
+	                show_error("$source variable $name is not set!");
+	                log_message('error', "$source variable $name is not set!");
+	                return False;
+	            } else {
+	                return False;
+	            }
+	        }
+	    }
+	}
 
 	// --------------------------------------------------------------------
 


### PR DESCRIPTION
This is a copy from my StackOverflow Q&A post: http://stackoverflow.com/questions/11927690/how-can-i-quickly-check-if-get-and-post-variables-in-codeigniter-are-both-set-an
## get_numeric_input() for CodeIgniter

> mixed **get_numeric_input** ( string _$name_ [, bool _$required_ = _True_ [, string _$source_ = _"GET"_ [, bool _$xss_clean_ = _True_ ]]] )

Below is a function that I created because I was tired of checking if GET and POST variables existed and were numeric. 

This was mainly used when handling errors or status messages, because I could use `redirect("original_page.php?error=1");` to pass an error to the original page. On the original page, I could simply do `if (isset($error)) { … }` and display a message depending on the value. However, it was necessary to check these variables before sending them to the view in the interest of security. This process proved to be quite repetitive and tedious.

This function below is to be added to the bottom of `wwwroot/application/system/core/Input.php`

It is to be used as follows:

**Example 1:** 

```
function index() {
   if ($error = $this->input->get_numeric_input('error', True, "GET", True)) {
      $data['error'] = $error;
   }
}
```

In this example, if `$_GET['error']` is both set and numeric, it will set `$data['error']` to that value. If it is either not set and/or not numeric, it will **terminate** the script.

**Example 2:** 

```
function index() {
   if ($error = $this->input->get_numeric_input('error', False, "POST", True)) {
      $data['error'] = $error;
   }
}
```

In this example, if `$_POST['error']` is both set and numeric, it will set `$data['error']` to that value. If it is either not set and/or not numeric, it will _continue_ and not set any values in the $data array.

The first argument is the variable name to be checked. The second variable is the boolean that makes the check required or not. If you have this set to TRUE, then if the variable is not set OR if it is not numeric, it will show an error and immediately terminate the script. If set to False, then it will will simply return False, and the script will move on. The third variable is either POST or GET, and will determine if the function looks for the variable in the $_GET or $_POST arrays. Finally, the fourth variable indicated whether or not the values will be XSS_CLEAN when returned.

**NOTE:** Both the second, third, and fourth arguments are optional, and default to True, “GET,” and True, respectively.
