### PR TITLE
Fix email headers when using long email subjects and \r\n as crlf.

### DIFF
--- a/system/libraries/Email.php
+++ b/system/libraries/Email.php
@@ -1237,7 +1237,7 @@ class CI_Email {
 
 		// wrap each line with the shebang, charset, and transfer encoding
 		// the preceding space on successive lines is required for header "folding"
-		return trim(preg_replace('/^(.*?)(\n|\r)*$/m', ' =?'.$this->charset.'?Q?$1?=$2', $output.$temp));
+		return trim(preg_replace('/^(.*?)(\r*)$/m', ' =?'.$this->charset.'?Q?$1?=$2', $output.$temp));
 	}
 
 	// --------------------------------------------------------------------

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -243,6 +243,7 @@ Release Date: Not Released
 Bug fixes for 3.0
 ------------------
 
+-  Fixed a bug (#1709) where the email headers were broken when using long email subjects and \r\n as crlf.
 -  Fixed a bug where ``unlink()`` raised an error if cache file did not exist when you try to delete it.
 -  Fixed a bug (#181) where a mis-spelling was in the form validation language file.
 -  Fixed a bug (#159, #163) that mishandled Query Builder nested transactions because _trans_depth was not getting incremented.


### PR DESCRIPTION
## Issue

When using long email subjects and \r\n as crlf, the header is badly formatted, and either the email appears with headers on the body, or doesn't arrive at all.

The problem is that on the preg_replace, the multiline mode only matches the \n leaving the \r to be matched on the regex.
## Examples

I'm showing the part of the header where the subject is set.

**Current Code** (notice the **^M** on the first two lines)

```
Subject: =?utf-8?Q?Big_email_subject_with_some_non_ascii_chars:_=c3=a0_=c3=a1_=c3^M?=
 =?utf-8?Q?=a9_=c3=a8_=c3=b6_=c3=af_@_=e2=82=ac_=c2=a9_=c2=ae_>_=c2=bb_an^M?=
 =?utf-8?Q?d_so_on,_and_so_on...?=^M
```

**Patched Code**

```
Subject: =?utf-8?Q?Big_email_subject_with_some_non_ascii_chars:_=c3=a0_=c3=a1_=c3?=^M
 =?utf-8?Q?=a9_=c3=a8_=c3=b6_=c3=af_@_=e2=82=ac_=c2=a9_=c2=ae_>_=c2=bb_an?=^M
 =?utf-8?Q?d_so_on,_and_so_on...?=^M
```
