### PR TITLE
Suppress duplicate cookies

### DIFF
--- a/system/helpers/html_helper.php
+++ b/system/helpers/html_helper.php
@@ -215,7 +215,7 @@ if ( ! function_exists('img'))
 			}
 		}
 
-		return $img._stringify_attributes($attributes).'/>';
+		return $img._stringify_attributes($attributes).' />';
 	}
 }
 

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -102,12 +102,13 @@ Release Date: Not Released
    -  Replaced the _error_message() and _error_number() methods with error(), that returns an array containing the last database error code and message.
    -  Improved version() implementation so that drivers that have a native function to get the version number don't have to be defined in the core DB_driver class.
    -  Improved support of the PostgreSQL driver, including:
-	 - pg_version() is now used to get the database version number, when possible.
-	 - Added db_set_charset() support.
-	 - Added support for optimize_table() in :doc:`Database Utilities <database/utilities>` (rebuilds table indexes).
-	 - Added boolean data type support in escape().
-	 - Added update_batch() support.
-	 - Removed limit() and order_by() support for UPDATE and DELETE queries in as PostgreSQL does not support those features.
+	 - ``pg_version()`` is now used to get the database version number, when possible.
+	 - Added ``db_set_charset()`` support.
+	 - Added support for ``optimize_table()`` in :doc:`Database Utilities <database/utilities>` (rebuilds table indexes).
+	 - Added boolean data type support in ``escape()``.
+	 - Added ``update_batch()`` support.
+	 - Removed ``limit()`` and ``order_by()`` support for UPDATE and DELETE queries as PostgreSQL does not support those features.
+	 - Added a work-around for dead persistent connections to be re-created after a database restart.
    -  Added a constructor to the DB_result class and moved all driver-specific properties and logic out of the base DB_driver class to allow better abstraction.
    -  Removed protect_identifiers() and renamed internal method _protect_identifiers() to it instead - it was just an alias.
    -  Renamed internal method _escape_identifiers() to escape_identifiers().


### PR DESCRIPTION
Suppress multiple instances of the same cookie being sent when multiple calls to Session::set_userdata are made.  Currently, a call to _set_cookie is made on every call to set_userdata, and _set_cookie calls php's setcookie.
