### PR TITLE
handle calls to sess_write after sess_destroy

### DIFF
--- a/system/libraries/Session.php
+++ b/system/libraries/Session.php
@@ -393,7 +393,7 @@ class CI_Session {
 		// If the sess_destroy had previously been called in the same
 		// connection, $this->userdata['session_id'] will not be available
 		// so we won't be able to complete the rest of this function.
-		if (!isset($this->userdata['session_id']))
+		if ( ! isset($this->userdata['session_id']))
 		{
 			return;
 		}


### PR DESCRIPTION
If sess_destroy is called prior to sess_write, ignore any future calls to sess_writes instead of trying to access $this->userdata['session_id'] which won't exist anymore
