### PR TITLE
Fix / Disallowed Key Characters. 

### DIFF
--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -620,7 +620,7 @@ class CI_Input {
 	 */
 	protected function _clean_input_keys($str)
 	{
-		if ( ! preg_match('/^[a-z0-9:_\/-]+$/i', $str))
+		if ( ! preg_match('/^[a-z0-9:_\/|-]+$/i', $str))
 		{
 			set_status_header(503);
 			exit('Disallowed Key Characters.');


### PR DESCRIPTION
China's biggest ICP China Telecom will hijack user and leave a cookie contains | .

such as "1345466626|7601294|43373|0|0|0"
it's impossible to fix this shit for my Chinese user...
