### PR TITLE
Detecting for 0 in file name, along with attached tests - fixes #1757

### DIFF
--- a/system/helpers/directory_helper.php
+++ b/system/helpers/directory_helper.php
@@ -62,7 +62,7 @@ if ( ! function_exists('directory_map'))
 			while (FALSE !== ($file = readdir($fp)))
 			{
 				// Remove '.', '..', and hidden files [optional]
-				if ( ! trim($file, '.') OR ($hidden === FALSE && $file[0] === '.'))
+				if ( ! isset($file) OR ($hidden === FALSE && $file[0] === '.'))
 				{
 					continue;
 				}

--- a/tests/codeigniter/helpers/directory_helper_test.php
+++ b/tests/codeigniter/helpers/directory_helper_test.php
@@ -19,6 +19,7 @@ class Directory_helper_test extends CI_TestCase {
 				'benchmark.html' => '',
 				'database' => array('active_record.html' => '', 'binds.html' => ''),
 				'email.html' => '',
+				'0' => '',
 				'.hiddenfile.txt' => ''
 			)
 		);
@@ -30,7 +31,8 @@ class Directory_helper_test extends CI_TestCase {
 			'libraries' => array(
 				'benchmark.html',
 				'database' => array('active_record.html', 'binds.html'),
-				'email.html'
+				'email.html',
+				'0'
 			)
 		);
 


### PR DESCRIPTION
`directory_map();` will now display file names such as 0, will still avoid all previous filenames. Also includes tests.
