### PR TITLE
print_debugger() now accepts three optional parameters to decide what the function returns

### DIFF
--- a/system/libraries/Email.php
+++ b/system/libraries/Email.php
@@ -1,4 +1,4 @@
-<?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+﻿<?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
 /**
  * CodeIgniter
  *
@@ -1780,9 +1780,12 @@ class CI_Email {
 	/**
 	 * Get Debug Message
 	 *
+	 * @param	bool
+	 * @param	bool
+	 * @param	bool	 
 	 * @return	string
 	 */
-	public function print_debugger()
+	public function print_debugger($inc_header = TRUE, $inc_subject = TRUE, $inc_body = TRUE)
 	{
 		$msg = '';
 
@@ -1794,7 +1797,29 @@ class CI_Email {
 			}
 		}
 
-		return $msg.'<pre>'.$this->_header_str."\n".htmlspecialchars($this->_subject)."\n".htmlspecialchars($this->_finalbody).'</pre>';
+		$options = array();
+
+		if ($inc_header)
+		{
+			$options[] = $this->_header_str;
+		}
+		
+		if ($inc_subject)
+		{
+			$options[] = htmlspecialchars($this->_subject);
+		}
+		
+		if ($inc_body)
+		{
+			$options[] = htmlspecialchars($this->_finalbody);
+		}
+		
+		if ( ! empty($options))
+		{
+			$msg .= '<pre>'.implode("\n", $options).'</pre>';
+		}
+		
+		return $msg;
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
The function now accepts three boolean parameters for: header, subject and body (including attachment data). The user can decide what combination of the above the function should return. The parameters all have a default value of TRUE, so it is fully backwards compatible with the previous version of the function. The debug message(s) will be returned regardless of what the parameters are set to.
