### PR TITLE
Fix #1741 is_unique duplicated in documentation for Form_validation

### DIFF
--- a/user_guide_src/source/libraries/form_validation.rst
+++ b/user_guide_src/source/libraries/form_validation.rst
@@ -884,7 +884,6 @@ Rule                      Parameter  Description                                
                                      0, 1, 2, 3, etc.
 **is_natural_no_zero**    No         Returns FALSE if the form element contains anything other than a natural
                                      number, but not zero: 1, 2, 3, etc.
-**is_unique**             Yes        Returns FALSE if the form element is not unique in a database table.                          is_unique[table.field] 
 **valid_email**           No         Returns FALSE if the form element does not contain a valid email address.
 **valid_emails**          No         Returns FALSE if any value provided in a comma separated list is not a valid email.
 **valid_ip**              No         Returns FALSE if the supplied IP is not valid.


### PR DESCRIPTION
The Form Validation method is_unique is duplicated in the documentation function references. It was seem to happen between CI user guide 2.1.2 and the switch to Sphinx/Markdown format. This changeset removes the duplicate.
