### PR TITLE
Changed the "FOREIGN KEY" statement for non-primary keys in PDO_Forge

### DIFF
--- a/system/database/drivers/pdo/pdo_forge.php
+++ b/system/database/drivers/pdo/pdo_forge.php
@@ -122,7 +122,7 @@ class CI_DB_pdo_forge extends CI_DB_forge {
 					? $this->db->escape_identifiers($key)
 					: array($this->db->escape_identifiers($key));
 
-				$sql .= ",\n\tFOREIGN KEY (".implode(', ', $key).')';
+				$sql .= ",\n\tKEY (".implode(', ', $key).')';
 			}
 		}
 


### PR DESCRIPTION
Line 125 of pdo_forge.php: When creating non-primary keys using the PDO driver, it defaults to issuing "FOREIGN KEY" instead of "KEY". Changed "FOREIGN KEY" back to "KEY" and it works again.
