### PR TITLE
Prevent sending multiple Set-Cookie headers

### DIFF
--- a/system/core/Output.php
+++ b/system/core/Output.php
@@ -420,6 +420,11 @@ class CI_Output {
 			}
 		}
 
+		if($CI->session) {
+			// Save the session. If using session cookies, this ensures only one "Set-Cookie" header is sent
+			$CI->session->get_driver()->sess_save();
+		}
+
 		// --------------------------------------------------------------------
 
 		// Does the $CI object exist?

--- a/system/libraries/Session/Session.php
+++ b/system/libraries/Session/Session.php
@@ -177,6 +177,11 @@ class CI_Session extends CI_Driver_Library {
 		}
 	}
 
+	public function get_driver()
+	{
+		return $this->current;
+	}
+
 	// ------------------------------------------------------------------------
 
 	/**
@@ -279,9 +284,6 @@ class CI_Session extends CI_Driver_Library {
 				$this->userdata[$key] = $val;
 			}
 		}
-
-		// Tell driver data changed
-		$this->current->sess_save();
 	}
 
 	// ------------------------------------------------------------------------

--- a/system/libraries/Session/drivers/Session_cookie.php
+++ b/system/libraries/Session/drivers/Session_cookie.php
@@ -512,9 +512,6 @@ class CI_Session_cookie extends CI_Session_driver {
 			// Add empty user_data field and save the data to the DB
 			$this->CI->db->set('user_data', '')->insert($this->sess_table_name, $this->userdata);
 		}
-
-		// Write the cookie
-		$this->_set_cookie();
 	}
 
 	// ------------------------------------------------------------------------
@@ -555,9 +552,6 @@ class CI_Session_cookie extends CI_Session_driver {
 					 'session_id' => $this->userdata['session_id']
 			), array('session_id' => $old_sessid));
 		}
-
-		// Write the cookie
-		$this->_set_cookie();
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
By default when using the cookie session handler (encrypted or unencrypted), CI sends the entire "Set-Cookie" header each time a new value is written to the session. This results in multiple headers being sent to the client. 

This is a problem because if too many values are written to the session, the HTTP headers can grow quite large, and some web servers will reject the response. (see http://wiki.nginx.org/HttpProxyModule#proxy_buffer_size)

The solution is to only run 'sess_save()' one time right after all other headers are sent before outputting the page contents.

Signed-off-by: Aaron Parecki <aaron@parecki.com>