### PR TITLE
Fixes issue #1815 - input::ip_address() returns incorrect IP behind prox...

### DIFF
--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -383,7 +383,7 @@ class CI_Input {
 		if (strpos($this->ip_address, ',') !== FALSE)
 		{
 			$x = explode(',', $this->ip_address);
-			$this->ip_address = trim(end($x));
+			$this->ip_address = trim($x[0]);
 		}
 
 		if ( ! $this->valid_ip($this->ip_address))


### PR DESCRIPTION
...y when multiple IPs are sent back from the server in HTTP_X_FORWARDED_FOR.

Problematic code:

if (strpos($this->ip_address, ',') !== FALSE)
{
$x = explode(',', $this->ip_address);
$this->ip_address = trim(end($x));
}

This is due to it taking the last IP.

As far as I can tell (let http://en.wikipedia.org/wiki/X-Forwarded-For be my witness), the client is generally listed as the first IP address, not the last, so this is a simple case of changing the line:

$this->ip_address = trim(end($x));
to
$this->ip_address = trim($x[0]);

[TESTED USING APACHE/HAPROXY]
