### PR TITLE
Fix: Added a bool parameter to Lang::line() to bypass error logging

### DIFF
--- a/system/core/Lang.php
+++ b/system/core/Lang.php
@@ -138,14 +138,15 @@ class CI_Lang {
 	 *
 	 * @access	public
 	 * @param	string	$line	the language line
+	 * @param 	bool 	$log 	bypass error logging (default: TRUE)
 	 * @return	string
 	 */
-	function line($line = '')
+	function line($line = '', $log = TRUE)
 	{
 		$value = ($line == '' OR ! isset($this->language[$line])) ? FALSE : $this->language[$line];
 
 		// Because killer robots like unicorns!
-		if ($value === FALSE)
+		if ($value === FALSE && $log)
 		{
 			log_message('error', 'Could not find the language line "'.$line.'"');
 		}

--- a/system/libraries/Unit_test.php
+++ b/system/libraries/Unit_test.php
@@ -243,7 +243,7 @@ class CI_Unit_test {
 				{
 					foreach ($val as $k => $v)
 					{
-						if (FALSE !== ($line = $CI->lang->line(strtolower('ut_'.$v))))
+						if (FALSE !== ($line = $CI->lang->line(strtolower('ut_'.$v), FALSE)))
 						{
 							$v = $line;
 						}
@@ -252,7 +252,7 @@ class CI_Unit_test {
 				}
 				else
 				{
-					if (FALSE !== ($line = $CI->lang->line(strtolower('ut_'.$val))))
+					if (FALSE !== ($line = $CI->lang->line(strtolower('ut_'.$val), FALSE)))
 					{
 						$val = $line;
 					}


### PR DESCRIPTION
Bug: Unit_test.php bloats the error_log when calling report(). Incorrect
keys are sent to the Lang class causing many errors to be logged.
