### PR TITLE
Added extra info to form helper docs for set_value()

### DIFF
--- a/user_guide_src/source/helpers/form_helper.rst
+++ b/user_guide_src/source/helpers/form_helper.rst
@@ -500,6 +500,10 @@ form. Example
 
 The above form will show "0" when loaded for the first time.
 
+.. note:: In order for the POST data to be available to this function, the form variable 
+	must first be validated with the Form Validation Class. If this is not done, the
+	default value will always be returned.
+
 set_select()
 ============
 


### PR DESCRIPTION
Added the following to form helper docs for set_value():

.. note:: In order for the POST data to be available to this function, the form variable 
        must first be validated with the Form Validation Class. If this is not done, the
        default value will always be returned.
