### PR TITLE
Change in Loader, improved way to load extensions

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -516,29 +516,29 @@ class CI_Loader {
 				continue;
 			}
 
-			$ext_helper = APPPATH.'helpers/'.config_item('subclass_prefix').$helper.'.php';
-
-			// Is this a helper extension request?
-			if (file_exists($ext_helper))
-			{
-				$base_helper = BASEPATH.'helpers/'.$helper.'.php';
-
-				if ( ! file_exists($base_helper))
-				{
-					show_error('Unable to load the requested file: helpers/'.$helper.'.php');
-				}
-
-				include_once($ext_helper);
-				include_once($base_helper);
-
-				$this->_ci_helpers[$helper] = TRUE;
-				log_message('debug', 'Helper loaded: '.$helper);
-				continue;
-			}
-
-			// Try to load the helper
 			foreach ($this->_ci_helper_paths as $path)
 			{
+				$ext_helper = $path.'helpers/'.config_item('subclass_prefix').$helper.'.php';
+
+				// Is this a helper extension request?
+				if (file_exists($ext_helper))
+				{
+					$base_helper = BASEPATH.'helpers/'.$helper.'.php';
+
+					if ( ! file_exists($base_helper))
+					{
+						show_error('Unable to load the requested file: helpers/'.$helper.'.php');
+					}
+
+					include_once($ext_helper);
+					include_once($base_helper);
+
+					$this->_ci_helpers[$helper] = TRUE;
+					log_message('debug', 'Helper loaded: '.$helper);
+					continue;
+				}
+
+				// Try to load the helper
 				if (file_exists($path.'helpers/'.$helper.'.php'))
 				{
 					include_once($path.'helpers/'.$helper.'.php');
@@ -921,50 +921,51 @@ class CI_Loader {
 		// We'll test for both lowercase and capitalized versions of the file name
 		foreach (array(ucfirst($class), strtolower($class)) as $class)
 		{
-			$subclass = APPPATH.'libraries/'.$subdir.config_item('subclass_prefix').$class.'.php';
-
-			// Is this a class extension request?
-			if (file_exists($subclass))
-			{
-				$baseclass = BASEPATH.'libraries/'.ucfirst($class).'.php';
-
-				if ( ! file_exists($baseclass))
-				{
-					log_message('error', 'Unable to load the requested class: '.$class);
-					show_error('Unable to load the requested class: '.$class);
-				}
-
-				// Safety: Was the class already loaded by a previous call?
-				if (in_array($subclass, $this->_ci_loaded_files))
-				{
-					// Before we deem this to be a duplicate request, let's see
-					// if a custom object name is being supplied. If so, we'll
-					// return a new instance of the object
-					if ( ! is_null($object_name))
-					{
-						$CI =& get_instance();
-						if ( ! isset($CI->$object_name))
-						{
-							return $this->_ci_init_class($class, config_item('subclass_prefix'), $params, $object_name);
-						}
-					}
-
-					$is_duplicate = TRUE;
-					log_message('debug', $class.' class already loaded. Second attempt ignored.');
-					return;
-				}
-
-				include_once($baseclass);
-				include_once($subclass);
-				$this->_ci_loaded_files[] = $subclass;
-
-				return $this->_ci_init_class($class, config_item('subclass_prefix'), $params, $object_name);
-			}
-
-			// Lets search for the requested library file and load it.
-			$is_duplicate = FALSE;
 			foreach ($this->_ci_library_paths as $path)
 			{
+				$subclass = $path.'libraries/'.$subdir.config_item('subclass_prefix').$class.'.php';
+
+				// Is this a class extension request?
+				if (file_exists($subclass))
+				{
+					$baseclass = BASEPATH.'libraries/'.ucfirst($class).'.php';
+
+					if ( ! file_exists($baseclass))
+					{
+						log_message('error', 'Unable to load the requested class: '.$class);
+						show_error('Unable to load the requested class: '.$class);
+					}
+
+					// Safety: Was the class already loaded by a previous call?
+					if (in_array($subclass, $this->_ci_loaded_files))
+					{
+						// Before we deem this to be a duplicate request, let's see
+						// if a custom object name is being supplied. If so, we'll
+						// return a new instance of the object
+						if ( ! is_null($object_name))
+						{
+							$CI =& get_instance();
+							if ( ! isset($CI->$object_name))
+							{
+								return $this->_ci_init_class($class, config_item('subclass_prefix'), $params, $object_name);
+							}
+						}
+
+						$is_duplicate = TRUE;
+						log_message('debug', $class.' class already loaded. Second attempt ignored.');
+						return;
+					}
+
+					include_once($baseclass);
+					include_once($subclass);
+					$this->_ci_loaded_files[] = $subclass;
+
+					return $this->_ci_init_class($class, config_item('subclass_prefix'), $params, $object_name);
+				}
+
+				// Lets search for the requested library file and load it.
+				$is_duplicate = FALSE;
+
 				$filepath = $path.'libraries/'.$subdir.$class.'.php';
 
 				// Does the file exist? No? Bummer...


### PR DESCRIPTION
Once a package is autoloaded, you can place your lib / model / helper extensions in it and not duplicate any of them per application instance.

Again, package must be autoloaded, as far as I tested.
