### PR TITLE
Fixed creation of non-PK composite keys.

### DIFF
--- a/system/database/DB_forge.php
+++ b/system/database/DB_forge.php
@@ -132,7 +132,7 @@ abstract class CI_DB_forge {
 	 */
 	public function add_key($key = '', $primary = FALSE)
 	{
-		if (is_array($key))
+		if (is_array($key) && $primary === TRUE)
 		{
 			foreach ($key as $one)
 			{


### PR DESCRIPTION
Modified CI_DB_forge::add_key() to only recursively add each key in an passed array of keys if they're meant to be primary keys.

Otherwise, the array needs to be maintained so that composite keys are preserved.

Tested against MySQL database only, using mysql, mysqli, and pdo drivers (PDO driver validated semi-manually due to another error outside of the scope of this PR).
