### PR TITLE
Bug in 2.1-stable - language typo in Migrations library

### DIFF
--- a/system/libraries/Migration.php
+++ b/system/libraries/Migration.php
@@ -220,7 +220,7 @@ class CI_Migration {
 	{
 		if ( ! $migrations = $this->find_migrations())
 		{
-			$this->_error_string = $this->line->lang('migration_none_found');
+			$this->_error_string = $this->lang->line('migration_none_found');
 			return false;
 		}
 


### PR DESCRIPTION
This seems to have been fixed or made irrelevant in develop, but in 2.1-stable there is a bug in `CI_Migration::latest()`.

`lang` and `line` are out of order, so when latest() is called and `find_migrations()` fails, there is a fatal PHP error.
