### PR TITLE
Fix #1946 dbforge add_key

### DIFF
--- a/system/database/DB_forge.php
+++ b/system/database/DB_forge.php
@@ -132,7 +132,7 @@ abstract class CI_DB_forge {
 	 */
 	public function add_key($key = '', $primary = FALSE)
 	{
-		if (is_array($key))
+		if ($primary && is_array($key))
 		{
 			foreach ($key as $one)
 			{


### PR DESCRIPTION
add_key not setting multiple-column keys when given an array

Signed-off-by: GDmac grdalenoort@gmail.com
