### PR TITLE
Refactored Unit_test in order to remove redundant code.

### DIFF
--- a/system/libraries/Unit_test.php
+++ b/system/libraries/Unit_test.php
@@ -158,7 +158,7 @@ class CI_Unit_test {
 
 		$back = $this->_backtrace();
 
-		$report[] = array (
+		$report = array (
 							'test_name'			=> $test_name,
 							'test_datatype'		=> gettype($test),
 							'res_datatype'		=> $extype,
@@ -170,7 +170,7 @@ class CI_Unit_test {
 
 		$this->results[] = $report;
 
-		return $this->report($this->result($report));
+		return $this->report($this->result(array($report)));
 	}
 
 	// --------------------------------------------------------------------
@@ -284,30 +284,11 @@ class CI_Unit_test {
 					continue;
 				}
 
-				if (is_array($val))
+				if (FALSE !== ($line = $CI->lang->line(strtolower('ut_'.$val))))
 				{
-					foreach ($val as $k => $v)
-					{
-						if ( ! in_array($k, $this->_test_items_visible))
-						{
-							continue;
-						}
-
-						if (FALSE !== ($line = $CI->lang->line(strtolower('ut_'.$v))))
-						{
-							$v = $line;
-						}
-						$temp[$CI->lang->line('ut_'.$k)] = $v;
-					}
+					$val = $line;
 				}
-				else
-				{
-					if (FALSE !== ($line = $CI->lang->line(strtolower('ut_'.$val))))
-					{
-						$val = $line;
-					}
-					$temp[$CI->lang->line('ut_'.$key)] = $val;
-				}
+				$temp[$CI->lang->line('ut_'.$key)] = $val;
 			}
 
 			$retval[] = $temp;


### PR DESCRIPTION
The Unit_test::run method was adding another dimension to the
Unit_test::$results array. For example:

```
Array
(
    [0] => Array
        (
            [0] => Array
                (
                    [test_name] => first_test
                    [test_datatype] => integer
                    [res_datatype] => integer
                    [result] => passed
                    [file] => ########################################
                    [line] => 60
                    [notes] => Im expecting this test to pass!
                )

        )

    [1] => Array
        (
            [0] => Array
                (
                    [test_name] => second_test
                    [test_datatype] => integer
                    [res_datatype] => boolean
                    [result] => failed
                    [file] => #######################################
                    [line] => 65
                    [notes] => Im expecting this to fail.
                )

        )

)
```

The above unneeded dimension created a need to loop through an array in the
Unit_test::result method if the method was looping through all results.

Signed-off-by: Daniel Paul Searles daniel.paul.searles@gmail.com
