### PR TITLE
Fixed typo in logs

### DIFF
--- a/system/libraries/Log.php
+++ b/system/libraries/Log.php
@@ -152,7 +152,7 @@ class CI_Log {
 		if ( ! file_exists($filepath))
 		{
 			$newfile = TRUE;
-			$message .= '<'."?php if defined('BASEPATH') OR exit('No direct script access allowed'); ?".">\n\n";
+			$message .= '<'."?php defined('BASEPATH') OR exit('No direct script access allowed'); ?".">\n\n";
 		}
 
 		if ( ! $fp = @fopen($filepath, FOPEN_WRITE_CREATE))


### PR DESCRIPTION
There was a typo in the logs library. It would give a PHP error.

EDIT:
It would create a log file that had a PHP error in it.
