### PR TITLE
Error on line 1407 of db_active_rec.php traces to mis-named variables

### DIFF
--- a/system/database/DB_active_rec.php
+++ b/system/database/DB_active_rec.php
@@ -1404,7 +1404,7 @@ class CI_DB_active_record extends CI_DB_driver {
 				}
 				else
 				{
-					$not[] = $k.'-'.$v;
+					$not[] = $k2.'-'.$v2;
 				}
 
 				if ($escape === FALSE)


### PR DESCRIPTION
Corrected variables to $k2 and $v2

Using update_batch() with an associative array fails and throws and error at live 1407 of db_active_rec.php.

Amir Syafrudin proposed the fix here - http://stackoverflow.com/questions/11279262/update-database-field-error-codeigniter (answer 2, as of this pull request)
