### PR TITLE
Better debugging for DB Cache path

### DIFF
--- a/system/database/DB_cache.php
+++ b/system/database/DB_cache.php
@@ -97,7 +97,7 @@ class CI_DB_Cache {
 
 		if ( ! is_dir($path))
 		{
-			log_message('debug', 'Cache Path Error: '.$path);
+			log_message('debug', 'DB cache path error: '.$path);
 
 			// If the path is wrong we'll turn off caching
 			return $this->db->cache_off();
@@ -105,7 +105,7 @@ class CI_DB_Cache {
 
 		if ( ! is_really_writable($path))
 		{
-			log_message('debug', 'Cache Dir Not Writable: '.$path);
+			log_message('debug', 'DB cache dir not writable: '.$path);
 
 			// If the path is not really writable we'll turn off caching
 			return $this->db->cache_off();


### PR DESCRIPTION
Because there is no debug level logging for the cache path, it may be difficult to figure out problems associated with setting up DB caching. Also, the check for is dir and is really writable being in the same if statement doesn't really allow for specific debug messages.
