### PR TITLE
Documentation: fix typos in name of application folder

### DIFF
--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -2399,7 +2399,7 @@ Release Date: September 17, 2006
 -  Moved the list of "allowed URI characters" out of the Router class
    and into the config file.
 -  Moved the MIME type array out of the Upload class and into its own
-   file in the applications/config/ folder.
+   file in the application/config/ folder.
 -  Updated the Upload class to allow the upload field name to be set
    when calling :doc:`do_upload() <./libraries/file_uploading>`.
 -  Updated the :doc:`Config Library <./libraries/config>` to be able to

--- a/user_guide_src/source/libraries/file_uploading.rst
+++ b/user_guide_src/source/libraries/file_uploading.rst
@@ -26,7 +26,7 @@ Creating the Upload Form
 ========================
 
 Using a text editor, create a form called upload_form.php. In it, place
-this code and save it to your applications/views/ folder::
+this code and save it to your application/views/ folder::
 
 	<html>
 	<head>
@@ -59,7 +59,7 @@ The Success Page
 ================
 
 Using a text editor, create a form called upload_success.php. In it,
-place this code and save it to your applications/views/ folder::
+place this code and save it to your application/views/ folder::
 
 	<html>
 	<head>
@@ -84,7 +84,7 @@ The Controller
 ==============
 
 Using a text editor, create a controller called upload.php. In it, place
-this code and save it to your applications/controllers/ folder::
+this code and save it to your application/controllers/ folder::
 
 	<?php
 

--- a/user_guide_src/source/libraries/form_validation.rst
+++ b/user_guide_src/source/libraries/form_validation.rst
@@ -63,7 +63,7 @@ The Form
 ========
 
 Using a text editor, create a form called myform.php. In it, place this
-code and save it to your applications/views/ folder::
+code and save it to your application/views/ folder::
 
 	<html>
 	<head>
@@ -98,7 +98,7 @@ The Success Page
 ================
 
 Using a text editor, create a form called formsuccess.php. In it, place
-this code and save it to your applications/views/ folder::
+this code and save it to your application/views/ folder::
 
 	<html>
 	<head>
@@ -117,7 +117,7 @@ The Controller
 ==============
 
 Using a text editor, create a controller called form.php. In it, place
-this code and save it to your applications/controllers/ folder::
+this code and save it to your application/controllers/ folder::
 
 	<?php
 

--- a/user_guide_src/source/libraries/xmlrpc.rst
+++ b/user_guide_src/source/libraries/xmlrpc.rst
@@ -297,7 +297,7 @@ The Client
 ----------
 
 Using a text editor, create a controller called xmlrpc_client.php. In
-it, place this code and save it to your applications/controllers/
+it, place this code and save it to your application/controllers/
 folder::
 
 	<?php
@@ -338,7 +338,7 @@ The Server
 ----------
 
 Using a text editor, create a controller called xmlrpc_server.php. In
-it, place this code and save it to your applications/controllers/
+it, place this code and save it to your application/controllers/
 folder::
 
 	<?php


### PR DESCRIPTION
The name is "application/", not "applications/".

(This commit does not change managing_apps.rst,
 where "applications/" is used intentionally).
