### PR TITLE
SQLSRV - Connection error if database name contains space-characters

### DIFF
--- a/system/database/drivers/sqlsrv/sqlsrv_driver.php
+++ b/system/database/drivers/sqlsrv/sqlsrv_driver.php
@@ -135,7 +135,7 @@ class CI_DB_sqlsrv_driver extends CI_DB {
 			$database = $this->database;
 		}
 
-		if ($this->_execute('USE ['.$database.']'))
+		if ($this->_execute('USE '.$this->escape_identifiers($database)))
 		{
 			$this->database = $database;
 			return TRUE;


### PR DESCRIPTION
Connection error if database name contains space-characters. 
Use of MSSQL brackets around database name => 
'USE [Database Name]' 
instead of 
'USE Database Name'
