### PR TITLE
detect for not instantiable in model loader (and don't instantiate if no...

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -304,6 +304,14 @@ class CI_Loader {
 			require_once($mod_path.'models/'.$path.$model.'.php');
 
 			$model = ucfirst($model);
+
+			$class = new ReflectionClass($model);
+			if ( ! $class->isInstantiable())
+			{
+				// return here because there is no need to instantiate the model
+				return;
+			}
+
 			$CI->$name = new $model();
 			$this->_ci_models[] = $name;
 			return;


### PR DESCRIPTION
...t

I'm not sure if this violates model guidelines, but I've had a need to load abstract subclasses of Model, and didn't want to put includes all over the place.

This adds a check to see if the class can be instantiated before doing a 'new'.
