### PR TITLE
Added driver extension support

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -669,6 +669,12 @@ class CI_Loader {
 			return FALSE;
 		}
 
+		if ( ! class_exists('CI_Driver_Library'))
+		{
+			// We aren't instantiating an object here, just making the base class available
+			require BASEPATH.'libraries/Driver.php';
+		}
+
 		// We can save the loader some time since Drivers will *always* be in a subfolder,
 		// and typically identically named to the library
 		if ( ! strpos($library, '/'))
@@ -949,13 +955,6 @@ class CI_Loader {
 
 			// Get the filename from the path
 			$class = substr($class, $last_slash);
-
-			// Check for match and driver base class
-			if (strtolower(trim($subdir, '/')) == strtolower($class) && ! class_exists('CI_Driver_Library'))
-			{
-				// We aren't instantiating an object here, just making the base class available
-				require BASEPATH.'libraries/Driver.php';
-			}
 		}
 
 		// We'll test for both lowercase and capitalized versions of the file name

--- a/system/libraries/Cache/Cache.php
+++ b/system/libraries/Cache/Cache.php
@@ -43,12 +43,12 @@ class CI_Cache extends CI_Driver_Library {
 	 * @var array
 	 */
 	protected $valid_drivers = array(
-		'cache_apc',
-		'cache_dummy',
-		'cache_file',
-		'cache_memcached',
-		'cache_redis',
-		'cache_wincache'
+		'apc',
+		'dummy',
+		'file',
+		'memcached',
+		'redis',
+		'wincache'
 	);
 
 	/**

--- a/system/libraries/Driver.php
+++ b/system/libraries/Driver.php
@@ -60,8 +60,8 @@ class CI_Driver_Library {
 	 * The first time a child is used it won't exist, so we instantiate it
 	 * subsequents calls will go straight to the proper child.
 	 *
-	 * @param   string  Child class name
-	 * @return  object  Child class
+	 * @param	string	Child class name
+	 * @return	object	Child class
 	 */
 	public function __get($child)
 	{
@@ -74,61 +74,120 @@ class CI_Driver_Library {
 	 *
 	 * Separate load_driver call to support explicit driver load by library or user
 	 *
-	 * @param   string  Child class name
-	 * @return  object  Child class
+	 * @param	string	Driver name (w/o parent prefix)
+	 * @return	object	Child class
 	 */
 	public function load_driver($child)
 	{
+		// Get CodeIgniter instance and subclass prefix
+		$CI = get_instance();
+		$prefix = (string) $CI->config->item('subclass_prefix');
+
 		if ( ! isset($this->lib_name))
 		{
-			$this->lib_name = get_class($this);
+			// Get library name without any prefix
+			$this->lib_name = str_replace(array('CI_', $prefix), '', get_class($this));
 		}
 
-		// The class will be prefixed with the parent lib
-		$child_class = $this->lib_name.'_'.$child;
+		// The child will be prefixed with the parent lib
+		$child_name = $this->lib_name.'_'.$child;
 
-		// Remove the CI_ prefix and lowercase
-		$lib_name = ucfirst(strtolower(str_replace('CI_', '', $this->lib_name)));
-		$driver_name = strtolower(str_replace('CI_', '', $child_class));
-
-		if (in_array($driver_name, array_map('strtolower', $this->valid_drivers)))
+		// See if requested child is a valid driver
+		if ( ! in_array($child, array_map('strtolower', $this->valid_drivers)))
 		{
-			// check and see if the driver is in a separate file
-			if ( ! class_exists($child_class))
-			{
-				// check application path first
-				foreach (get_instance()->load->get_package_paths(TRUE) as $path)
-				{
-					// loves me some nesting!
-					foreach (array(ucfirst($driver_name), $driver_name) as $class)
-					{
-						$filepath = $path.'libraries/'.$lib_name.'/drivers/'.$class.'.php';
+			// The requested driver isn't valid!
+			$msg = 'Invalid driver requested: '.$child_name;
+			log_message('error', $msg);
+			show_error($msg);
+		}
 
-						if (file_exists($filepath))
+		// All driver files should be in a library subdirectory - capitalized
+		$subdir = ucfirst(strtolower($this->lib_name));
+
+		// Get package paths and filename case variations to search
+		$paths = $CI->load->get_package_paths(TRUE);
+		$cases = array(ucfirst($child_name), strtolower($child_name));
+
+		// Is there an extension?
+		$class_name = $prefix.$child_name;
+		$found = class_exists($class_name);
+		if ( ! $found)
+		{
+			// Check for subclass file
+			foreach ($paths as $path)
+			{
+				// Extension will be in drivers subdirectory
+				$path .= 'libraries/'.$subdir.'/drivers/';
+
+				// Try filename with caps and all lowercase
+				foreach ($cases as $name)
+				{
+					// Does the file exist?
+					$file = $path.$prefix.$name.'.php';
+					if (file_exists($file))
+					{
+						// Yes - require base class from BASEPATH
+						$basepath = BASEPATH.'libraries/'.$subdir.'/drivers/'.ucfirst($child_name).'.php';
+						if ( ! file_exists($basepath))
 						{
-							include_once $filepath;
+							$msg = 'Unable to load the requested class: CI_'.$child_name;
+							log_message('error', $msg);
+							show_error($msg);
+						}
+
+						// Include both sources and mark found
+						include($basepath);
+						include($file);
+						$found = TRUE;
+						break 2;
+					}
+				}
+			}
+		}
+
+		// Do we need to search for the class?
+		if ( ! $found)
+		{
+			// Use standard class name
+			$class_name = 'CI_'.$child_name;
+			$found = class_exists($class_name);
+			if ( ! $found)
+			{
+				// Check package paths
+				foreach ($paths as $path)
+				{
+					// Class will be in drivers subdirectory
+					$path .= 'libraries/'.$subdir.'/drivers/';
+
+					// Try filename with caps and all lowercase
+					foreach ($cases as $name)
+					{
+						// Does the file exist?
+						$file = $path.$name.'.php';
+						if (file_exists($file))
+						{
+							// Include source
+							include($file);
 							break 2;
 						}
 					}
 				}
-
-				// it's a valid driver, but the file simply can't be found
-				if ( ! class_exists($child_class))
-				{
-					log_message('error', 'Unable to load the requested driver: '.$child_class);
-					show_error('Unable to load the requested driver: '.$child_class);
-				}
 			}
-
-			$obj = new $child_class;
-			$obj->decorate($this);
-			$this->$child = $obj;
-			return $this->$child;
 		}
 
-		// The requested driver isn't valid!
-		log_message('error', 'Invalid driver requested: '.$child_class);
-		show_error('Invalid driver requested: '.$child_class);
+		// Did we finally find the class?
+		if ( ! class_exists($class_name))
+		{
+			$msg = 'Unable to load the requested driver: '.$class_name;
+			log_message('error', $msg);
+			show_error($msg);
+		}
+
+		// Instantiate, decorate, and add child
+		$obj = new $class_name;
+		$obj->decorate($this);
+		$this->$child = $obj;
+		return $this->$child;
 	}
 
 }

--- a/system/libraries/Session/Session.php
+++ b/system/libraries/Session/Session.php
@@ -107,17 +107,15 @@ class CI_Session extends CI_Driver_Library {
 
 		// Get valid drivers list
 		$this->valid_drivers = array(
-			'Session_native',
-			'Session_cookie'
+			'native',
+			'cookie'
 		);
 		$key = 'sess_valid_drivers';
 		$drivers = isset($params[$key]) ? $params[$key] : $CI->config->item($key);
 		if ($drivers)
 		{
-			is_array($drivers) OR $drivers = array($drivers);
-
 			// Add driver names to valid list
-			foreach ($drivers as $driver)
+			foreach ((array) $drivers as $driver)
 			{
 				if ( ! in_array(strtolower($driver), array_map('strtolower', $this->valid_drivers)))
 				{
@@ -134,9 +132,9 @@ class CI_Session extends CI_Driver_Library {
 			$driver = 'cookie';
 		}
 
-		if ( ! in_array('session_'.strtolower($driver), array_map('strtolower', $this->valid_drivers)))
+		if ( ! in_array(strtolower($driver), array_map('strtolower', $this->valid_drivers)))
 		{
-			$this->valid_drivers[] = 'Session_'.$driver;
+			$this->valid_drivers[] = $driver;
 		}
 
 		// Save a copy of parameters in case drivers need access
@@ -178,17 +176,17 @@ class CI_Session extends CI_Driver_Library {
 	/**
 	 * Select default session storage driver
 	 *
-	 * @param	string	Driver classname
+	 * @param	string	Driver name
 	 * @return	void
 	 */
 	public function select_driver($driver)
 	{
 		// Validate driver name
-		$lowername = strtolower(str_replace('CI_', '', $driver));
-		if (in_array($lowername, array_map('strtolower', $this->valid_drivers)))
+		$prefix = (string) get_instance()->config->item('subclass_prefix');
+		$child = strtolower(str_replace(array('CI_', $prefix, $this->lib_name.'_'), '', $driver));
+		if (in_array($child, array_map('strtolower', $this->valid_drivers)))
 		{
 			// See if driver is loaded
-			$child = str_replace($this->lib_name.'_', '', $driver);
 			if (isset($this->$child))
 			{
 				// See if driver is already current

--- a/tests/codeigniter/libraries/Driver_test.php
+++ b/tests/codeigniter/libraries/Driver_test.php
@@ -1,0 +1,176 @@
+<?php
+
+/**
+ * Driver library base class unit test
+ */
+class Driver_test extends CI_TestCase {
+	/**
+	 * Set up test framework
+	 */
+	public function set_up()
+	{
+		// Set our subclass prefix
+		$this->subclass = 'Mock_Libraries_';
+		$this->ci_set_config('subclass_prefix', $this->subclass);
+
+        // Mock Loader->get_package_paths
+        $paths = 'get_package_paths';
+        $ldr = $this->getMock('CI_Loader', array($paths));
+        $ldr->expects($this->any())->method($paths)->will($this->returnValue(array(APPPATH, BASEPATH)));
+        $this->ci_instance_var('load', $ldr);
+
+		// Create mock driver library
+		$this->name = 'Driver';
+		$this->lib = new Mock_Libraries_Driver();
+	}
+
+	/**
+	 * Test driver child loading
+	 */
+	public function test_load_driver()
+	{
+		// Create driver file
+		$driver = 'basic';
+		$file = $this->name.'_'.$driver;
+		$class = 'CI_'.$file;
+		$prop = 'called';
+		$content = '<?php class '.$class.' extends CI_Driver { public $'.$prop.' = FALSE; '.
+			'public function decorate($parent) { $this->'.$prop.' = TRUE; } }';
+		$this->ci_vfs_create($file, $content, $this->ci_base_root, array('libraries', $this->name, 'drivers'));
+
+		// Make driver valid
+		$this->lib->driver_list($driver);
+
+		// Load driver
+		$this->assertNotNull($this->lib->load_driver($driver));
+
+		// Did lib name get set?
+		$this->assertEquals($this->name, $this->lib->get_name());
+
+		// Was driver loaded?
+		$this->assertObjectHasAttribute($driver, $this->lib);
+		$this->assertAttributeInstanceOf($class, $driver, $this->lib);
+		$this->assertAttributeInstanceOf('CI_Driver', $driver, $this->lib);
+
+		// Was decorate called?
+		$this->assertObjectHasAttribute($prop, $this->lib->$driver);
+		$this->assertTrue($this->lib->$driver->$prop);
+
+		// Do we get an error for an invalid driver?
+		$driver = 'unlisted';
+		$this->setExpectedException('RuntimeException', 'CI Error: Invalid driver requested: '.$this->name.'_'.$driver);
+		$this->lib->load_driver($driver);
+	}
+
+	/**
+	 * Test loading lowercase from app path
+	 */
+	public function test_load_app_driver()
+	{
+		// Create driver file
+		$driver = 'lowpack';
+		$file = $this->name.'_'.$driver;
+		$class = 'CI_'.$file;
+		$content = '<?php class '.$class.' extends CI_Driver {  }';
+		$this->ci_vfs_create(strtolower($file), $content, $this->ci_app_root,
+			array('libraries', $this->name, 'drivers'));
+
+		// Make valid list
+		$nodriver = 'absent';
+		$this->lib->driver_list(array($driver, $nodriver));
+
+		// Load driver
+		$this->assertNotNull($this->lib->load_driver($driver));
+
+		// Was driver loaded?
+		$this->assertObjectHasAttribute($driver, $this->lib);
+		$this->assertAttributeInstanceOf($class, $driver, $this->lib);
+		$this->assertAttributeInstanceOf('CI_Driver', $driver, $this->lib);
+
+		// Do we get an error for a non-existent driver?
+		$this->setExpectedException('RuntimeException', 'CI Error: Unable to load the requested driver: CI_'.
+			$this->name.'_'.$nodriver);
+		$this->lib->load_driver($nodriver);
+	}
+
+	/**
+	 * Test loading driver extension
+	 */
+	public function test_load_driver_ext()
+	{
+		// Create base file
+		$driver = 'extend';
+		$base = $this->name.'_'.$driver;
+		$baseclass = 'CI_'.$base;
+		$content = '<?php class '.$baseclass.' extends CI_Driver {  }';
+		$this->ci_vfs_create($base, $content, $this->ci_base_root, array('libraries', $this->name, 'drivers'));
+
+		// Create driver file
+		$class = $this->subclass.$base;
+		$content = '<?php class '.$class.' extends '.$baseclass.' {  }';
+		$this->ci_vfs_create($class, $content, $this->ci_app_root, array('libraries', $this->name, 'drivers'));
+
+		// Make valid list
+		$this->lib->driver_list($driver);
+
+		// Load driver
+		$this->assertNotNull($this->lib->load_driver($driver));
+
+		// Was driver loaded?
+		$this->assertObjectHasAttribute($driver, $this->lib);
+		$this->assertAttributeInstanceOf($class, $driver, $this->lib);
+		$this->assertAttributeInstanceOf($baseclass, $driver, $this->lib);
+		$this->assertAttributeInstanceOf('CI_Driver', $driver, $this->lib);
+
+		// Create driver extension without base
+		$driver = 'baseless';
+		$base = $this->name.'_'.$driver;
+		$class = $this->subclass.$base;
+		$content = '<?php class '.$class.' extends CI_Driver {  }';
+		$this->ci_vfs_create($class, $content, $this->ci_app_root, array('libraries', $this->name, 'drivers'));
+		$this->lib->driver_list($driver);
+
+		// Do we get an error when base class isn't found?
+		$this->setExpectedException('RuntimeException', 'CI Error: Unable to load the requested class: CI_'.$base);
+		$this->lib->load_driver($driver);
+	}
+
+	/**
+	 * Test decorating driver with parent attributes
+	 */
+	public function test_decorate()
+	{
+		// Create parent with a method and property to access
+		$pclass = 'Test_Parent';
+		$prop = 'parent_prop';
+		$value = 'initial';
+		$method = 'parent_func';
+		$return = 'func return';
+		$code = 'class '.$pclass.' { public $'.$prop.' = \''.$value.'\'; '.
+			'public function '.$method.'() { return \''.$return.'\'; } }';
+		eval($code);
+		$parent = new $pclass();
+
+		// Create child driver to decorate
+		$class = 'Test_Driver';
+		eval('class '.$class.' extends CI_Driver {  }');
+		$child = new $class();
+
+		// Decorate child
+		$child->decorate($parent);
+
+		// Do we get the initial parent property value?
+		$this->assertEquals($value, $child->$prop);
+
+		// Can we change the parent property?
+		$newval = 'changed';
+		$child->$prop = $newval;
+		$this->assertEquals($newval, $parent->$prop);
+
+		// Do we get back the updated value?
+		$this->assertEquals($newval, $child->$prop);
+
+		// Can we call the parent method?
+		$this->assertEquals($return, $child->$method());
+	}
+}

--- a/tests/codeigniter/libraries/Session_test.php
+++ b/tests/codeigniter/libraries/Session_test.php
@@ -6,8 +6,8 @@
 class Session_test extends CI_TestCase {
 	protected $settings = array(
 		'use_cookies' => 0,
-	   	'use_only_cookies' => 0,
-	   	'cache_limiter' => false
+		'use_only_cookies' => 0,
+		'cache_limiter' => false
 	);
 	protected $setting_vals = array();
 	protected $cookie_vals;
@@ -28,11 +28,12 @@ class Session_test extends CI_TestCase {
 		$this->cookie_vals = $_COOKIE;
 		$_COOKIE = array();
 
+		// Set subclass prefix to match our mock
+		$this->ci_set_config('subclass_prefix', 'Mock_Libraries_');
+
 		// Establish necessary support classes
-		$cfg = $this->ci_core_class('cfg');
-		$ldr = $this->ci_core_class('load');
 		$ci = $this->ci_instance();
-		$ci->config = new $cfg();
+		$ldr = $this->ci_core_class('load');
 		$ci->load = new $ldr();
 		$ci->input = new Mock_Core_Input(NULL, NULL);
 
@@ -56,11 +57,7 @@ class Session_test extends CI_TestCase {
 			'sess_time_to_update' => 300,
 			'time_reference' => 'local',
 			'cookie_prefix' => '',
-			'encryption_key' => 'foobar',
-			'sess_valid_drivers' => array(
-				'Mock_Libraries_Session_native',
-			   	'Mock_Libraries_Session_cookie'
-			)
+			'encryption_key' => 'foobar'
 		);
 		$this->session = new Mock_Libraries_Session($config);
 	}
@@ -83,9 +80,6 @@ class Session_test extends CI_TestCase {
 
 	/**
 	 * Test set_userdata() function
-	 *
-	 * @covers  CI_Session::set_userdata
-	 * @covers  CI_Session::userdata
 	 */
 	public function test_set_userdata()
 	{
@@ -117,8 +111,6 @@ class Session_test extends CI_TestCase {
 
 	/**
 	 * Test the has_userdata() function
-	 *
-	 * @covers	CI_Session::has_userdata
 	 */
 	public function test_has_userdata()
 	{
@@ -141,8 +133,6 @@ class Session_test extends CI_TestCase {
 
 	/**
 	 * Test the all_userdata() function
-	 *
-	 * @covers	CI_Session::all_userdata
 	 */
 	public function test_all_userdata()
 	{
@@ -150,16 +140,16 @@ class Session_test extends CI_TestCase {
 		$cdata = array(
 			'one' => 'first',
 			'two' => 'second',
-		   	'three' => 'third',
-		   	'foo' => 'bar',
-		   	'bar' => 'baz'
+			'three' => 'third',
+			'foo' => 'bar',
+			'bar' => 'baz'
 		);
 		$ndata = array(
 			'one' => 'gold',
-		   	'two' => 'silver',
-		   	'three' => 'bronze',
-		   	'foo' => 'baz',
-		   	'bar' => 'foo'
+			'two' => 'silver',
+			'three' => 'bronze',
+			'foo' => 'baz',
+			'bar' => 'foo'
 		);
 		$this->session->cookie->set_userdata($cdata);
 		$this->session->native->set_userdata($ndata);
@@ -177,8 +167,6 @@ class Session_test extends CI_TestCase {
 
 	/**
 	 * Test the unset_userdata() function
-	 *
-	 * @covers	CI_Session::unset_userdata
 	 */
 	public function test_unset_userdata()
 	{
@@ -202,9 +190,6 @@ class Session_test extends CI_TestCase {
 
 	/**
 	 * Test the flashdata() functions
-	 *
-	 * @covers	CI_Session::set_flashdata
-	 * @covers	CI_Session::flashdata
 	 */
 	public function test_flashdata()
 	{
@@ -234,8 +219,6 @@ class Session_test extends CI_TestCase {
 
 	/**
 	 * Test the keep_flashdata() function
-	 *
-	 * @covers	CI_Session::keep_flashdata
 	 */
 	public function test_keep_flashdata()
 	{
@@ -271,25 +254,23 @@ class Session_test extends CI_TestCase {
 
 	/**
 	 * Test the all_flashdata() function
-	 *
-	 * @covers	CI_Session::all_flashdata
 	 */
 	public function test_all_flashdata()
 	{
 		// Set a specific series of data for each driver
 		$cdata = array(
 			'one' => 'first',
-		   	'two' => 'second',
-		   	'three' => 'third',
-		   	'foo' => 'bar',
-		   	'bar' => 'baz'
+			'two' => 'second',
+			'three' => 'third',
+			'foo' => 'bar',
+			'bar' => 'baz'
 		);
 		$ndata = array(
 			'one' => 'gold',
-		   	'two' => 'silver',
-		   	'three' => 'bronze',
-		   	'foo' => 'baz',
-		   	'bar' => 'foo'
+			'two' => 'silver',
+			'three' => 'bronze',
+			'foo' => 'baz',
+			'bar' => 'foo'
 		);
 		$this->session->cookie->set_flashdata($cdata);
 		$this->session->native->set_flashdata($ndata);
@@ -303,9 +284,6 @@ class Session_test extends CI_TestCase {
 
 	/**
 	 * Test the tempdata() functions
-	 *
-	 * @covers	CI_Session::set_tempdata
-	 * @covers	CI_Session::tempdata
 	 */
 	public function test_set_tempdata()
 	{
@@ -332,8 +310,6 @@ class Session_test extends CI_TestCase {
 
 	/**
 	 * Test the unset_tempdata() function
-	 *
-	 * @covers	CI_Session::unset_tempdata
 	 */
 	public function test_unset_tempdata()
 	{
@@ -357,8 +333,6 @@ class Session_test extends CI_TestCase {
 
 	/**
 	 * Test the sess_regenerate() function
-	 *
-	 * @covers	CI_Session::sess_regenerate
 	 */
 	public function test_sess_regenerate()
 	{
@@ -378,8 +352,6 @@ class Session_test extends CI_TestCase {
 
 	/**
 	 * Test the sess_destroy() function
-	 *
-	 * @covers	CI_Session::sess_destroy
 	 */
 	public function test_sess_destroy()
 	{

--- a/tests/mocks/libraries/driver.php
+++ b/tests/mocks/libraries/driver.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Mock library to subclass Driver for testing
+ */
+class Mock_Libraries_Driver extends CI_Driver_Library {
+	/**
+	 * Set valid drivers list
+	 */
+	public function driver_list($drivers = NULL)
+	{
+		if (empty($drivers))
+		{
+			return $this->valid_drivers;
+		}
+
+		$this->valid_drivers = (array) $drivers;
+	}
+
+	/**
+	 * Get library name
+	 */
+	public function get_name()
+	{
+		return $this->lib_name;
+	}
+}

--- a/tests/mocks/libraries/session.php
+++ b/tests/mocks/libraries/session.php
@@ -4,7 +4,6 @@
  * Mock library to add testing features to Session driver library
  */
 class Mock_Libraries_Session extends CI_Session {
-
 	/**
 	 * Simulate new page load
 	 */
@@ -20,7 +19,6 @@ class Mock_Libraries_Session extends CI_Session {
  * Mock cookie driver to overload cookie setting
  */
 class Mock_Libraries_Session_cookie extends CI_Session_cookie {
-
 	/**
 	 * Overload _setcookie to manage $_COOKIE values, since actual cookies can't be set in unit testing
 	 */
@@ -36,8 +34,3 @@ class Mock_Libraries_Session_cookie extends CI_Session_cookie {
 		}
 	}
 }
-
-/**
- * Mock native driver (just for consistency in loading)
- */
-class Mock_Libraries_Session_native extends CI_Session_native { }

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -274,7 +274,6 @@ Release Date: Not Released
 	 -  Added method ``get_vars()`` to the Loader to retrieve all variables loaded with ``$this->load->vars()``.
 	 -  ``_ci_autoloader()`` is now a protected method.
 	 -  Added autoloading of drivers with ``$autoload['drivers']``.
-	 -  ``library()`` method will now load drivers as well, for backward compatibility of converted libraries (like :doc:`Session <libraries/sessions>`).
 	 -  ``$config['rewrite_short_tags']`` now has no effect when using PHP 5.4 as ``<?=`` will always be available.
 	 -  Changed method ``config()`` to return whatever ``CI_Config::load()`` returns instead of always being void.
    -  :doc:`Input Library <libraries/input>` changes include:

--- a/user_guide_src/source/installation/upgrade_300.rst
+++ b/user_guide_src/source/installation/upgrade_300.rst
@@ -42,9 +42,13 @@ or extensions to work, you need to move them to **application/core/**::
 	application/libraries/Log.php -> application/core/Log.php
 	application/libraries/MY_Log.php -> application/core/MY_log.php
 
-**************************************************************
-Step 5: Add new session driver items to your config/config.php
-**************************************************************
+*********************************************************
+Step 5: Convert your Session usage from library to driver
+*********************************************************
+
+When you load (or autoload) the Session library, you must now load it as a driver instead of a library. This means
+calling ``$this->load->driver('session')`` instead of ``$this->load->library('session')`` and/or listing 'session'
+in ``$autoload['drivers']`` instead of ``$autoload['libraries']``.
 
 With the change from a single Session Library to the new Session Driver, two new config items have been added:
 
@@ -57,6 +61,10 @@ With the change from a single Session Library to the new Session Driver, two new
 As the new Session Driver library loads the classic Cookie driver by default and always makes 'cookie' and 'native'
 available as valid drivers, neither of these configuration items are required. However, it is recommended that you
 add them for clarity and ease of configuration in the future.
+
+If you have written a Session extension, you must move it into a 'Session' sub-directory of 'libraries', following the
+standard for Drivers. Also beware that some functions which are not part of the external Session API have moved into
+the drivers, so your extension may have to be broken down into separate library and driver class extensions.
 
 ***************************************
 Step 6: Update your config/database.php

--- a/user_guide_src/source/libraries/sessions.rst
+++ b/user_guide_src/source/libraries/sessions.rst
@@ -28,10 +28,6 @@ use the $this->load->driver function::
 Once loaded, the Sessions library object will be available using:
 $this->session
 
-.. note:: For backward compatibility, the Session class may stil be loaded
-	using the $this->load->library function, but converting your applications
-	to use $this->load->driver is strongly recommended.
-
 How do Sessions work?
 =====================
 
@@ -485,4 +481,3 @@ without making it the initially loaded driver, set 'sess_valid_drivers' in
 your config.php file to an array including your driver name::
 
 	$config['sess_valid_drivers'] = array('sess_driver');
-


### PR DESCRIPTION
Retooling of #1787

Enables mix-and-match extension of Driver library and child classes. Extend library without requiring child extensions and vice-versa.

Session and Cache drivers updated to work with changes to valid_drivers list, which now lists child class names without parent class name included. Driver child class and file names still require parent name prefix.

Adds unit testing of Driver library base class.

Reverts loading CI_Driver in _ci_load_class() - all drivers (including Session!) must be loaded with `CI_Loader->driver()` NOT `CI_Loader->library()`.

Signed-off-by: dchill42 dchill42@gmail.com
