### PR TITLE
Clarified  error messages of $active_group value (error msgs in DB.php)

### DIFF
--- a/system/database/DB.php
+++ b/system/database/DB.php
@@ -79,7 +79,7 @@ function &DB($params = '', $query_builder_override = NULL)
 		if ( ! isset($active_group) )
         {
 			show_error('You have not specified a valid database connection group using the $active_group variable.');
-        } elseif (! isset($db[$active_group]))
+        } elseif ( ! isset($db[$active_group]))
 		{
 			show_error('You have specified an invalid database connection group named [' . $active_group . ']');
 		}


### PR DESCRIPTION
Used the load->model wrong (had 3rd param as class alias, not second) and spent 30 minutes tracking down the "You have specified an invalid database connection" error rendered from DB.php.  
I modified the code to have two different error messages, one unset $active_group, and the other to display the active_group it was looking for.
