### PR TITLE
config->site_url() optimizations

### DIFF
--- a/system/core/Config.php
+++ b/system/core/Config.php
@@ -245,7 +245,7 @@ class CI_Config {
 
 		if ($this->item('enable_query_strings') === FALSE)
 		{
-			$suffix = isset($this->config['url_suffix']) ? (string) $this->config['url_suffix'] : '';
+			$suffix = isset($this->config['url_suffix']) ? $this->config['url_suffix'] : '';
 
 			if ($suffix !== '')
 			{


### PR DESCRIPTION
- direct access to config array, instead of item() calls
- the string cast is just in case 'url_suffix' would be set to false or null; the function produces the same results without this cast, but it leads to a robuster code, as false and null are sanitized and skip the suffix insertion code
- altered conditional structure: if no suffix, skip the appending of an empty string to $uri
