### PR TITLE
Added small improvement to the _remove_evil_attributes function

### DIFF
--- a/system/core/Security.php
+++ b/system/core/Security.php
@@ -526,17 +526,17 @@ class CI_Security {
 			$charset = config_item('charset');
 		}
 
-                do
-                {
-                    $matches = $matches1 = 0;
+		do
+		{
+			$matches = $matches1 = 0;
 
-                    $str = html_entity_decode($str, ENT_COMPAT, $charset);
-                    $str = preg_replace('~&#x(0*[0-9a-f]{2,5})~ei', 'chr(hexdec("\\1"))', $str, -1, $matches);
-                    $str = preg_replace('~&#([0-9]{2,4})~e', 'chr(\\1)', $str, -1, $matches1);
-                }
-                while($matches || $matches1);
+			$str = html_entity_decode($str, ENT_COMPAT, $charset);
+			$str = preg_replace('~&#x(0*[0-9a-f]{2,5})~ei', 'chr(hexdec("\\1"))', $str, -1, $matches);
+			$str = preg_replace('~&#([0-9]{2,4})~e', 'chr(\\1)', $str, -1, $matches1);
+		}
+		while($matches OR $matches1);
 
-                return $str;
+		return $str;
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
I reversed the order in which the illegal attributes were matched because in some cases they were not removed entirely. For example the following string 
`<input type="text" value="test" id="test1" onfocus="alert('test');" style="border: 1px">` 
would have been cleaned like so: `<input type="text" value="test" id="test1" 1px">`. 

With the new change the style attribute get's removed entirely: `<input type="text" value="test" id="test1" >`

The second modification fixes a bug in the regexp that is used to find and replace the attributes. The regexp would have failed in case the following string was passed to the xss_clean function: `" onfocus="alert(\'test\');"`. This XSS could be applied to an input box that takes it's value from GET/POST. With the new modifications, the XSS gets filtered.
