### PR TITLE
Fix encoding being skipped improperly in certain conditions

### DIFF
--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -1,30 +1,19 @@
-<?php
+<?php  if ( ! defined('BASEPATH')) exit('No direct script access allowed');
 /**
  * CodeIgniter
  *
- * An open source application development framework for PHP 5.2.4 or newer
- *
- * NOTICE OF LICENSE
- *
- * Licensed under the Open Software License version 3.0
- *
- * This source file is subject to the Open Software License (OSL 3.0) that is
- * bundled with this package in the files license.txt / license.rst.  It is
- * also available through the world wide web at this URL:
- * http://opensource.org/licenses/OSL-3.0
- * If you did not receive a copy of the license and are unable to obtain it
- * through the world wide web, please send an email to
- * licensing@ellislab.com so we can send you a copy immediately.
+ * An open source application development framework for PHP 5.1.6 or newer
  *
  * @package		CodeIgniter
- * @author		EllisLab Dev Team
- * @copyright	Copyright (c) 2008 - 2012, EllisLab, Inc. (http://ellislab.com/)
- * @license		http://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * @author		ExpressionEngine Dev Team
+ * @copyright	Copyright (c) 2008 - 2011, EllisLab, Inc.
+ * @license		http://codeigniter.com/user_guide/license.html
  * @link		http://codeigniter.com
  * @since		Version 1.0
  * @filesource
  */
-defined('BASEPATH') OR exit('No direct script access allowed');
+
+// ------------------------------------------------------------------------
 
 /**
  * CodeIgniter Form Helpers
@@ -32,29 +21,30 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  * @package		CodeIgniter
  * @subpackage	Helpers
  * @category	Helpers
- * @author		EllisLab Dev Team
+ * @author		ExpressionEngine Dev Team
  * @link		http://codeigniter.com/user_guide/helpers/form_helper.html
  */
 
 // ------------------------------------------------------------------------
 
+/**
+ * Form Declaration
+ *
+ * Creates the opening portion of the form.
+ *
+ * @access	public
+ * @param	string	the URI segments of the form destination
+ * @param	array	a key/value pair of attributes
+ * @param	array	a key/value pair hidden data
+ * @return	string
+ */
 if ( ! function_exists('form_open'))
 {
-	/**
-	 * Form Declaration
-	 *
-	 * Creates the opening portion of the form.
-	 *
-	 * @param	string	the URI segments of the form destination
-	 * @param	array	a key/value pair of attributes
-	 * @param	array	a key/value pair hidden data
-	 * @return	string
-	 */
 	function form_open($action = '', $attributes = '', $hidden = array())
 	{
 		$CI =& get_instance();
 
-		if ($attributes === '')
+		if ($attributes == '')
 		{
 			$attributes = 'method="post"';
 		}
@@ -64,23 +54,25 @@ if ( ! function_exists('form_open'))
 		{
 			$action = $CI->config->site_url($action);
 		}
-		elseif ( ! $action)
-		{
-			// If no action is provided then set to the current url
-			$action = $CI->config->site_url($CI->uri->uri_string());
-		}
 
-		$form = '<form action="'.$action.'"'._attributes_to_string($attributes, TRUE).">\n";
+		// If no action is provided then set to the current url
+		$action OR $action = $CI->config->site_url($CI->uri->uri_string());
 
-		// Add CSRF field if enabled, but leave it out for GET requests and requests to external websites
-		if ($CI->config->item('csrf_protection') === TRUE && ! (strpos($action, $CI->config->base_url()) === FALSE OR strpos($form, 'method="get"')))
+		$form = '<form action="'.$action.'"';
+
+		$form .= _attributes_to_string($attributes, TRUE);
+
+		$form .= '>';
+
+		// Add CSRF field if enabled, but leave it out for GET requests and requests to external websites	
+		if ($CI->config->item('csrf_protection') === TRUE AND ! (strpos($action, $CI->config->base_url()) === FALSE OR strpos($form, 'method="get"')))	
 		{
 			$hidden[$CI->security->get_csrf_token_name()] = $CI->security->get_csrf_hash();
 		}
 
-		if (is_array($hidden) && count($hidden) > 0)
+		if (is_array($hidden) AND count($hidden) > 0)
 		{
-			$form .= '<div style="display:none;">'.form_hidden($hidden).'</div>';
+			$form .= sprintf("<div style=\"display:none\">%s</div>", form_hidden($hidden));
 		}
 
 		return $form;
@@ -89,18 +81,19 @@ if ( ! function_exists('form_open'))
 
 // ------------------------------------------------------------------------
 
+/**
+ * Form Declaration - Multipart type
+ *
+ * Creates the opening portion of the form, but with "multipart/form-data".
+ *
+ * @access	public
+ * @param	string	the URI segments of the form destination
+ * @param	array	a key/value pair of attributes
+ * @param	array	a key/value pair hidden data
+ * @return	string
+ */
 if ( ! function_exists('form_open_multipart'))
 {
-	/**
-	 * Form Declaration - Multipart type
-	 *
-	 * Creates the opening portion of the form, but with "multipart/form-data".
-	 *
-	 * @param	string	the URI segments of the form destination
-	 * @param	array	a key/value pair of attributes
-	 * @param	array	a key/value pair hidden data
-	 * @return	string
-	 */
 	function form_open_multipart($action = '', $attributes = array(), $hidden = array())
 	{
 		if (is_string($attributes))
@@ -118,19 +111,19 @@ if ( ! function_exists('form_open_multipart'))
 
 // ------------------------------------------------------------------------
 
+/**
+ * Hidden Input Field
+ *
+ * Generates hidden fields.  You can pass a simple key/value string or an associative
+ * array with multiple values.
+ *
+ * @access	public
+ * @param	mixed
+ * @param	string
+ * @return	string
+ */
 if ( ! function_exists('form_hidden'))
 {
-	/**
-	 * Hidden Input Field
-	 *
-	 * Generates hidden fields. You can pass a simple key/value string or
-	 * an associative array with multiple values.
-	 *
-	 * @param	mixed	$name		Field name
-	 * @param	string	$value		Field value
-	 * @param	bool	$recursing
-	 * @return	string
-	 */
 	function form_hidden($name, $value = '', $recursing = FALSE)
 	{
 		static $form;
@@ -151,13 +144,13 @@ if ( ! function_exists('form_hidden'))
 
 		if ( ! is_array($value))
 		{
-			$form .= '<input type="hidden" name="'.$name.'" value="'.form_prep($value)."\" />\n";
+			$form .= '<input type="hidden" name="'.$name.'" value="'.form_prep($value, $name).'" />'."\n";
 		}
 		else
 		{
 			foreach ($value as $k => $v)
 			{
-				$k = is_int($k) ? '' : $k;
+				$k = (is_int($k)) ? '' : $k;
 				form_hidden($name.'['.$k.']', $v, TRUE);
 			}
 		}
@@ -168,38 +161,40 @@ if ( ! function_exists('form_hidden'))
 
 // ------------------------------------------------------------------------
 
+/**
+ * Text Input Field
+ *
+ * @access	public
+ * @param	mixed
+ * @param	string
+ * @param	string
+ * @return	string
+ */
 if ( ! function_exists('form_input'))
 {
-	/**
-	 * Text Input Field
-	 *
-	 * @param	mixed
-	 * @param	string
-	 * @param	string
-	 * @return	string
-	 */
 	function form_input($data = '', $value = '', $extra = '')
 	{
-		$defaults = array('type' => 'text', 'name' => ( ! is_array($data) ? $data : ''), 'value' => $value);
+		$defaults = array('type' => 'text', 'name' => (( ! is_array($data)) ? $data : ''), 'value' => $value);
 
-		return '<input '._parse_form_attributes($data, $defaults).$extra." />\n";
+		return "<input "._parse_form_attributes($data, $defaults).$extra." />";
 	}
 }
 
 // ------------------------------------------------------------------------
 
+/**
+ * Password Field
+ *
+ * Identical to the input function but adds the "password" type
+ *
+ * @access	public
+ * @param	mixed
+ * @param	string
+ * @param	string
+ * @return	string
+ */
 if ( ! function_exists('form_password'))
 {
-	/**
-	 * Password Field
-	 *
-	 * Identical to the input function but adds the "password" type
-	 *
-	 * @param	mixed
-	 * @param	string
-	 * @param	string
-	 * @return	string
-	 */
 	function form_password($data = '', $value = '', $extra = '')
 	{
 		if ( ! is_array($data))
@@ -214,18 +209,19 @@ if ( ! function_exists('form_password'))
 
 // ------------------------------------------------------------------------
 
+/**
+ * Upload Field
+ *
+ * Identical to the input function but adds the "file" type
+ *
+ * @access	public
+ * @param	mixed
+ * @param	string
+ * @param	string
+ * @return	string
+ */
 if ( ! function_exists('form_upload'))
 {
-	/**
-	 * Upload Field
-	 *
-	 * Identical to the input function but adds the "file" type
-	 *
-	 * @param	mixed
-	 * @param	string
-	 * @param	string
-	 * @return	string
-	 */
 	function form_upload($data = '', $value = '', $extra = '')
 	{
 		if ( ! is_array($data))
@@ -240,19 +236,20 @@ if ( ! function_exists('form_upload'))
 
 // ------------------------------------------------------------------------
 
+/**
+ * Textarea field
+ *
+ * @access	public
+ * @param	mixed
+ * @param	string
+ * @param	string
+ * @return	string
+ */
 if ( ! function_exists('form_textarea'))
 {
-	/**
-	 * Textarea field
-	 *
-	 * @param	mixed	$data
-	 * @param	string	$value
-	 * @param	string	$extra
-	 * @return	string
-	 */
 	function form_textarea($data = '', $value = '', $extra = '')
 	{
-		$defaults = array('name' => ( ! is_array($data) ? $data : ''), 'cols' => '40', 'rows' => '10');
+		$defaults = array('name' => (( ! is_array($data)) ? $data : ''), 'cols' => '40', 'rows' => '10');
 
 		if ( ! is_array($data) OR ! isset($data['value']))
 		{
@@ -264,24 +261,25 @@ if ( ! function_exists('form_textarea'))
 			unset($data['value']); // textareas don't use the value attribute
 		}
 
-		$name = is_array($data) ? $data['name'] : $data;
-		return '<textarea '._parse_form_attributes($data, $defaults).$extra.'>'.form_prep($val, TRUE)."</textarea>\n";
+		$name = (is_array($data)) ? $data['name'] : $data;
+		return "<textarea "._parse_form_attributes($data, $defaults).$extra.">".form_prep($val, $name)."</textarea>";
 	}
 }
 
 // ------------------------------------------------------------------------
 
+/**
+ * Multi-select menu
+ *
+ * @access	public
+ * @param	string
+ * @param	array
+ * @param	mixed
+ * @param	string
+ * @return	type
+ */
 if ( ! function_exists('form_multiselect'))
 {
-	/**
-	 * Multi-select menu
-	 *
-	 * @param	string
-	 * @param	array
-	 * @param	mixed
-	 * @param	string
-	 * @return	string
-	 */
 	function form_multiselect($name = '', $options = array(), $selected = array(), $extra = '')
 	{
 		if ( ! strpos($extra, 'multiple'))
@@ -295,41 +293,36 @@ if ( ! function_exists('form_multiselect'))
 
 // --------------------------------------------------------------------
 
+/**
+ * Drop-down Menu
+ *
+ * @access	public
+ * @param	string
+ * @param	array
+ * @param	string
+ * @param	string
+ * @return	string
+ */
 if ( ! function_exists('form_dropdown'))
 {
-	/**
-	 * Drop-down Menu
-	 *
-	 * @param	mixed	$name
-	 * @param	mixed	$options
-	 * @param	mixed	$selected
-	 * @param	mixed	$extra
-	 * @return	string
-	 */
 	function form_dropdown($name = '', $options = array(), $selected = array(), $extra = '')
 	{
-		// If name is really an array then we'll call the function again using the array
-		if (is_array($name) && isset($name['name']))
+		if ( ! is_array($selected))
 		{
-			isset($name['options']) OR $name['options'] = array();
-			isset($name['selected']) OR $name['selected'] = array();
-			isset($name['extra']) OR $name['extra'] = array();
-
-			return form_dropdown($name['name'], $name['options'], $name['selected'], $name['extra']);
+			$selected = array($selected);
 		}
-
-		is_array($selected) OR $selected = array($selected);
 
 		// If no selected state was submitted we will attempt to set it automatically
-		if (count($selected) === 0 && isset($_POST[$name]))
+		if (count($selected) === 0)
 		{
-			$selected = array($_POST[$name]);
+			// If the form name appears in the $_POST array we have a winner!
+			if (isset($_POST[$name]))
+			{
+				$selected = array($_POST[$name]);
+			}
 		}
 
-		if ($extra != '')
-		{
-			$extra = ' '.$extra;
-		}
+		if ($extra != '') $extra = ' '.$extra;
 
 		$multiple = (count($selected) > 1 && strpos($extra, 'multiple') === FALSE) ? ' multiple="multiple"' : '';
 
@@ -339,54 +332,52 @@ if ( ! function_exists('form_dropdown'))
 		{
 			$key = (string) $key;
 
-			if (is_array($val))
+			if (is_array($val) && ! empty($val))
 			{
-				if (empty($val))
-				{
-					continue;
-				}
-
-				$form .= '<optgroup label="'.$key."\">\n";
+				$form .= '<optgroup label="'.$key.'">'."\n";
 
 				foreach ($val as $optgroup_key => $optgroup_val)
 				{
-					$sel = in_array($optgroup_key, $selected) ? ' selected="selected"' : '';
-					$form .= '<option value="'.form_prep($optgroup_key).'"'.$sel.'>'
-						.(string) $optgroup_val."</option>\n";
+					$sel = (in_array($optgroup_key, $selected)) ? ' selected="selected"' : '';
+
+					$form .= '<option value="'.$optgroup_key.'"'.$sel.'>'.(string) $optgroup_val."</option>\n";
 				}
 
-				$form .= "</optgroup>\n";
+				$form .= '</optgroup>'."\n";
 			}
 			else
 			{
-				$form .= '<option value="'.form_prep($key).'"'
-					.(in_array($key, $selected) ? ' selected="selected"' : '').'>'
-					.(string) $val."</option>\n";
+				$sel = (in_array($key, $selected)) ? ' selected="selected"' : '';
+
+				$form .= '<option value="'.$key.'"'.$sel.'>'.(string) $val."</option>\n";
 			}
 		}
 
-		return $form."</select>\n";
+		$form .= '</select>';
+
+		return $form;
 	}
 }
 
 // ------------------------------------------------------------------------
 
+/**
+ * Checkbox Field
+ *
+ * @access	public
+ * @param	mixed
+ * @param	string
+ * @param	bool
+ * @param	string
+ * @return	string
+ */
 if ( ! function_exists('form_checkbox'))
 {
-	/**
-	 * Checkbox Field
-	 *
-	 * @param	mixed
-	 * @param	string
-	 * @param	bool
-	 * @param	string
-	 * @return	string
-	 */
 	function form_checkbox($data = '', $value = '', $checked = FALSE, $extra = '')
 	{
-		$defaults = array('type' => 'checkbox', 'name' => ( ! is_array($data) ? $data : ''), 'value' => $value);
+		$defaults = array('type' => 'checkbox', 'name' => (( ! is_array($data)) ? $data : ''), 'value' => $value);
 
-		if (is_array($data) && array_key_exists('checked', $data))
+		if (is_array($data) AND array_key_exists('checked', $data))
 		{
 			$checked = $data['checked'];
 
@@ -409,23 +400,24 @@ if ( ! function_exists('form_checkbox'))
 			unset($defaults['checked']);
 		}
 
-		return '<input '._parse_form_attributes($data, $defaults).$extra." />\n";
+		return "<input "._parse_form_attributes($data, $defaults).$extra." />";
 	}
 }
 
 // ------------------------------------------------------------------------
 
+/**
+ * Radio Button
+ *
+ * @access	public
+ * @param	mixed
+ * @param	string
+ * @param	bool
+ * @param	string
+ * @return	string
+ */
 if ( ! function_exists('form_radio'))
 {
-	/**
-	 * Radio Button
-	 *
-	 * @param	mixed
-	 * @param	string
-	 * @param	bool
-	 * @param	string
-	 * @return	string
-	 */
 	function form_radio($data = '', $value = '', $checked = FALSE, $extra = '')
 	{
 		if ( ! is_array($data))
@@ -440,90 +432,97 @@ if ( ! function_exists('form_radio'))
 
 // ------------------------------------------------------------------------
 
+/**
+ * Submit Button
+ *
+ * @access	public
+ * @param	mixed
+ * @param	string
+ * @param	string
+ * @return	string
+ */
 if ( ! function_exists('form_submit'))
 {
-	/**
-	 * Submit Button
-	 *
-	 * @param	mixed
-	 * @param	string
-	 * @param	string
-	 * @return	string
-	 */
 	function form_submit($data = '', $value = '', $extra = '')
 	{
-		$defaults = array('type' => 'submit', 'name' => ( ! is_array($data) ? $data : ''), 'value' => $value);
-		return '<input '._parse_form_attributes($data, $defaults).$extra." />\n";
+		$defaults = array('type' => 'submit', 'name' => (( ! is_array($data)) ? $data : ''), 'value' => $value);
+
+		return "<input "._parse_form_attributes($data, $defaults).$extra." />";
 	}
 }
 
 // ------------------------------------------------------------------------
 
+/**
+ * Reset Button
+ *
+ * @access	public
+ * @param	mixed
+ * @param	string
+ * @param	string
+ * @return	string
+ */
 if ( ! function_exists('form_reset'))
 {
-	/**
-	 * Reset Button
-	 *
-	 * @param	mixed
-	 * @param	string
-	 * @param	string
-	 * @return	string
-	 */
 	function form_reset($data = '', $value = '', $extra = '')
 	{
-		$defaults = array('type' => 'reset', 'name' => ( ! is_array($data) ? $data : ''), 'value' => $value);
-		return '<input '._parse_form_attributes($data, $defaults).$extra." />\n";
+		$defaults = array('type' => 'reset', 'name' => (( ! is_array($data)) ? $data : ''), 'value' => $value);
+
+		return "<input "._parse_form_attributes($data, $defaults).$extra." />";
 	}
 }
 
 // ------------------------------------------------------------------------
 
+/**
+ * Form Button
+ *
+ * @access	public
+ * @param	mixed
+ * @param	string
+ * @param	string
+ * @return	string
+ */
 if ( ! function_exists('form_button'))
 {
-	/**
-	 * Form Button
-	 *
-	 * @param	mixed
-	 * @param	string
-	 * @param	string
-	 * @return	string
-	 */
 	function form_button($data = '', $content = '', $extra = '')
 	{
-		$defaults = array('name' => ( ! is_array($data) ? $data : ''), 'type' => 'button');
-		if (is_array($data) && isset($data['content']))
+		$defaults = array('name' => (( ! is_array($data)) ? $data : ''), 'type' => 'button');
+
+		if ( is_array($data) AND isset($data['content']))
 		{
 			$content = $data['content'];
 			unset($data['content']); // content is not an attribute
 		}
 
-		return '<button '._parse_form_attributes($data, $defaults).$extra.'>'.$content."</button>\n";
+		return "<button "._parse_form_attributes($data, $defaults).$extra.">".$content."</button>";
 	}
 }
 
 // ------------------------------------------------------------------------
 
+/**
+ * Form Label Tag
+ *
+ * @access	public
+ * @param	string	The text to appear onscreen
+ * @param	string	The id the label applies to
+ * @param	string	Additional attributes
+ * @return	string
+ */
 if ( ! function_exists('form_label'))
 {
-	/**
-	 * Form Label Tag
-	 *
-	 * @param	string	The text to appear onscreen
-	 * @param	string	The id the label applies to
-	 * @param	string	Additional attributes
-	 * @return	string
-	 */
 	function form_label($label_text = '', $id = '', $attributes = array())
 	{
 
 		$label = '<label';
 
-		if ($id !== '')
+		if ($id != '')
 		{
-			$label .= ' for="'.$id.'"';
+			$label .= " for=\"$id\"";
 		}
 
-		if (is_array($attributes) && count($attributes) > 0)
+		if (is_array($attributes) AND count($attributes) > 0)
 		{
 			foreach ($attributes as $key => $val)
 			{
@@ -531,30 +530,37 @@ if ( ! function_exists('form_label'))
 			}
 		}
 
-		return $label.'>'.$label_text.'</label>';
+		$label .= ">$label_text</label>";
+
+		return $label;
 	}
 }
 
 // ------------------------------------------------------------------------
-
+/**
+ * Fieldset Tag
+ *
+ * Used to produce <fieldset><legend>text</legend>.  To close fieldset
+ * use form_fieldset_close()
+ *
+ * @access	public
+ * @param	string	The legend text
+ * @param	string	Additional attributes
+ * @return	string
+ */
 if ( ! function_exists('form_fieldset'))
 {
-	/**
-	 * Fieldset Tag
-	 *
-	 * Used to produce <fieldset><legend>text</legend>.  To close fieldset
-	 * use form_fieldset_close()
-	 *
-	 * @param	string	The legend text
-	 * @param	string	Additional attributes
-	 * @return	string
-	 */
 	function form_fieldset($legend_text = '', $attributes = array())
 	{
-		$fieldset = '<fieldset'._attributes_to_string($attributes, FALSE).">\n";
-		if ($legend_text !== '')
+		$fieldset = "<fieldset";
+
+		$fieldset .= _attributes_to_string($attributes, FALSE);
+
+		$fieldset .= ">\n";
+
+		if ($legend_text != '')
 		{
-			return $fieldset.'<legend>'.$legend_text."</legend>\n";
+			$fieldset .= "<legend>$legend_text</legend>\n";
 		}
 
 		return $fieldset;
@@ -563,114 +569,146 @@ if ( ! function_exists('form_fieldset'))
 
 // ------------------------------------------------------------------------
 
+/**
+ * Fieldset Close Tag
+ *
+ * @access	public
+ * @param	string
+ * @return	string
+ */
 if ( ! function_exists('form_fieldset_close'))
 {
-	/**
-	 * Fieldset Close Tag
-	 *
-	 * @param	string
-	 * @return	string
-	 */
 	function form_fieldset_close($extra = '')
 	{
-		return '</fieldset>'.$extra;
+		return "</fieldset>".$extra;
 	}
 }
 
 // ------------------------------------------------------------------------
 
+/**
+ * Form Close Tag
+ *
+ * @access	public
+ * @param	string
+ * @return	string
+ */
 if ( ! function_exists('form_close'))
 {
-	/**
-	 * Form Close Tag
-	 *
-	 * @param	string
-	 * @return	string
-	 */
 	function form_close($extra = '')
 	{
-		return '</form>'.$extra;
+		form_prep('','',TRUE);
+		return "</form>".$extra;
 	}
 }
 
 // ------------------------------------------------------------------------
 
+/**
+ * Form Prep
+ *
+ * Formats text so that it can be safely placed in a form field in the event it has HTML tags.
+ *
+ * @access	public
+ * @param	string
+ * @return	string
+ */
 if ( ! function_exists('form_prep'))
 {
-	/**
-	 * Form Prep
-	 *
-	 * Formats text so that it can be safely placed in a form field in the event it has HTML tags.
-	 *
-	 * @param	string|string[]	$str		Value to escape
-	 * @param	bool		$is_textarea	Whether we're escaping for a textarea element
-	 * @return	string|string[]	Escaped values
-	 */
-	function form_prep($str = '', $is_textarea = FALSE)
+	function form_prep($str = '', $field_name = '', $clear = FALSE)
 	{
+		static $prepped_fields = array();
+		
+		if ($clear === TRUE) {
+			$prepped_fields = array();
+			return;
+		}
+		// if the field name is an array we do this recursively
 		if (is_array($str))
 		{
-			foreach (array_keys($str) as $key)
+			foreach ($str as $key => $val)
 			{
-				$str[$key] = form_prep($str[$key], $is_textarea);
+				$str[$key] = form_prep($val);
 			}
 
 			return $str;
 		}
 
-		if ($is_textarea === TRUE)
+		if ($str === '')
 		{
-			return str_replace(array('<', '>'), array('&lt;', '&gt;'), stripslashes($str));
+			return '';
 		}
 
-		return str_replace(array("'", '"'), array('&#39;', '&quot;'), stripslashes($str));
+		// we've already prepped a field with this name
+		// @todo need to figure out a way to namespace this so
+		// that we know the *exact* field and not just one with
+		// the same name
+		if (isset($prepped_fields[$field_name]))
+		{
+			return $str;
+		}
+
+		$str = htmlspecialchars($str);
+
+		// In case htmlspecialchars misses these.
+		$str = str_replace(array("'", '"'), array("&#39;", "&quot;"), $str);
+
+		if ($field_name != '')
+		{
+			$prepped_fields[$field_name] = $field_name;
+		}
+
+		return $str;
 	}
 }
 
 // ------------------------------------------------------------------------
 
+/**
+ * Form Value
+ *
+ * Grabs a value from the POST array for the specified field so you can
+ * re-populate an input field or textarea.  If Form Validation
+ * is active it retrieves the info from the validation class
+ *
+ * @access	public
+ * @param	string
+ * @return	mixed
+ */
 if ( ! function_exists('set_value'))
 {
-	/**
-	 * Form Value
-	 *
-	 * Grabs a value from the POST array for the specified field so you can
-	 * re-populate an input field or textarea. If Form Validation
-	 * is active it retrieves the info from the validation class
-	 *
-	 * @param	string	$field		Field name
-	 * @param	string	$default	Default value
-	 * @param	bool	$is_textarea	Whether the field is a textarea element
-	 * @return	string
-	 */
-	function set_value($field = '', $default = '', $is_textarea = FALSE)
+	function set_value($field = '', $default = '')
 	{
 		if (FALSE === ($OBJ =& _get_validation_object()))
 		{
-			return isset($_POST[$field])
-				? form_prep($_POST[$field], $is_textarea)
-				: form_prep($default, $is_textarea);
+			if ( ! isset($_POST[$field]))
+			{
+				return $default;
+			}
+
+			return form_prep($_POST[$field], $field);
 		}
 
-		return form_prep($OBJ->set_value($field, $default), $is_textarea);
+		return form_prep($OBJ->set_value($field, $default), $field);
 	}
 }
 
 // ------------------------------------------------------------------------
 
+/**
+ * Set Select
+ *
+ * Let's you set the selected value of a <select> menu via data in the POST array.
+ * If Form Validation is active it retrieves the info from the validation class
+ *
+ * @access	public
+ * @param	string
+ * @param	string
+ * @param	bool
+ * @return	string
+ */
 if ( ! function_exists('set_select'))
 {
-	/**
-	 * Set Select
-	 *
-	 * Let's you set the selected value of a <select> menu via data in the POST array.
-	 * If Form Validation is active it retrieves the info from the validation class
-	 *
-	 * @param	string
-	 * @param	string
-	 * @param	bool
-	 * @return	string
-	 */
 	function set_select($field = '', $value = '', $default = FALSE)
 	{
 		$OBJ =& _get_validation_object();
@@ -679,7 +717,7 @@ if ( ! function_exists('set_select'))
 		{
 			if ( ! isset($_POST[$field]))
 			{
-				if (count($_POST) === 0 && $default === TRUE)
+				if (count($_POST) === 0 AND $default == TRUE)
 				{
 					return ' selected="selected"';
 				}
@@ -695,9 +733,12 @@ if ( ! function_exists('set_select'))
 					return '';
 				}
 			}
-			elseif (($field == '' OR $value == '') OR $field !== $value)
+			else
 			{
-				return '';
+				if (($field == '' OR $value == '') OR ($field != $value))
+				{
+					return '';
+				}
 			}
 
 			return ' selected="selected"';
@@ -709,19 +750,20 @@ if ( ! function_exists('set_select'))
 
 // ------------------------------------------------------------------------
 
+/**
+ * Set Checkbox
+ *
+ * Let's you set the selected value of a checkbox via the value in the POST array.
+ * If Form Validation is active it retrieves the info from the validation class
+ *
+ * @access	public
+ * @param	string
+ * @param	string
+ * @param	bool
+ * @return	string
+ */
 if ( ! function_exists('set_checkbox'))
 {
-	/**
-	 * Set Checkbox
-	 *
-	 * Let's you set the selected value of a checkbox via the value in the POST array.
-	 * If Form Validation is active it retrieves the info from the validation class
-	 *
-	 * @param	string
-	 * @param	string
-	 * @param	bool
-	 * @return	string
-	 */
 	function set_checkbox($field = '', $value = '', $default = FALSE)
 	{
 		$OBJ =& _get_validation_object();
@@ -730,58 +772,7 @@ if ( ! function_exists('set_checkbox'))
 		{
 			if ( ! isset($_POST[$field]))
 			{
-				if (count($_POST) === 0 && $default === TRUE)
-				{
-					return ' checked="checked"';
-				}
-				return '';
-			}
-
-			$field = $_POST[$field];
-
-			if (is_array($field))
-			{
-				if ( ! in_array($value, $field))
-				{
-					return '';
-				}
-			}
-			elseif (($field == '' OR $value == '') OR $field !== $value)
-			{
-				return '';
-			}
-
-			return ' checked="checked"';
-		}
-
-		return $OBJ->set_checkbox($field, $value, $default);
-	}
-}
-
-// ------------------------------------------------------------------------
-
-if ( ! function_exists('set_radio'))
-{
-	/**
-	 * Set Radio
-	 *
-	 * Let's you set the selected value of a radio field via info in the POST array.
-	 * If Form Validation is active it retrieves the info from the validation class
-	 *
-	 * @param	string
-	 * @param	string
-	 * @param	bool
-	 * @return	string
-	 */
-	function set_radio($field = '', $value = '', $default = FALSE)
-	{
-		$OBJ =& _get_validation_object();
-
-		if ($OBJ === FALSE)
-		{
-			if ( ! isset($_POST[$field]))
-			{
-				if (count($_POST) === 0 && $default === TRUE)
+				if (count($_POST) === 0 AND $default == TRUE)
 				{
 					return ' checked="checked"';
 				}
@@ -799,7 +790,62 @@ if ( ! function_exists('set_radio'))
 			}
 			else
 			{
-				if (($field == '' OR $value == '') OR $field !== $value)
+				if (($field == '' OR $value == '') OR ($field != $value))
+				{
+					return '';
+				}
+			}
+
+			return ' checked="checked"';
+		}
+
+		return $OBJ->set_checkbox($field, $value, $default);
+	}
+}
+
+// ------------------------------------------------------------------------
+
+/**
+ * Set Radio
+ *
+ * Let's you set the selected value of a radio field via info in the POST array.
+ * If Form Validation is active it retrieves the info from the validation class
+ *
+ * @access	public
+ * @param	string
+ * @param	string
+ * @param	bool
+ * @return	string
+ */
+if ( ! function_exists('set_radio'))
+{
+	function set_radio($field = '', $value = '', $default = FALSE)
+	{
+		$OBJ =& _get_validation_object();
+
+		if ($OBJ === FALSE)
+		{
+			if ( ! isset($_POST[$field]))
+			{
+				if (count($_POST) === 0 AND $default == TRUE)
+				{
+					return ' checked="checked"';
+				}
+				return '';
+			}
+
+			$field = $_POST[$field];
+
+			if (is_array($field))
+			{
+				if ( ! in_array($value, $field))
+				{
+					return '';
+				}
+			}
+			else
+			{
+				if (($field == '' OR $value == '') OR ($field != $value))
 				{
 					return '';
 				}
@@ -814,19 +860,20 @@ if ( ! function_exists('set_radio'))
 
 // ------------------------------------------------------------------------
 
+/**
+ * Form Error
+ *
+ * Returns the error for a specific form field.  This is a helper for the
+ * form validation class.
+ *
+ * @access	public
+ * @param	string
+ * @param	string
+ * @param	string
+ * @return	string
+ */
 if ( ! function_exists('form_error'))
 {
-	/**
-	 * Form Error
-	 *
-	 * Returns the error for a specific form field. This is a helper for the
-	 * form validation class.
-	 *
-	 * @param	string
-	 * @param	string
-	 * @param	string
-	 * @return	string
-	 */
 	function form_error($field = '', $prefix = '', $suffix = '')
 	{
 		if (FALSE === ($OBJ =& _get_validation_object()))
@@ -840,18 +887,19 @@ if ( ! function_exists('form_error'))
 
 // ------------------------------------------------------------------------
 
+/**
+ * Validation Error String
+ *
+ * Returns all the errors associated with a form submission.  This is a helper
+ * function for the form validation class.
+ *
+ * @access	public
+ * @param	string
+ * @param	string
+ * @return	string
+ */
 if ( ! function_exists('validation_errors'))
 {
-	/**
-	 * Validation Error String
-	 *
-	 * Returns all the errors associated with a form submission. This is a helper
-	 * function for the form validation class.
-	 *
-	 * @param	string
-	 * @param	string
-	 * @return	string
-	 */
 	function validation_errors($prefix = '', $suffix = '')
 	{
 		if (FALSE === ($OBJ =& _get_validation_object()))
@@ -865,17 +913,18 @@ if ( ! function_exists('validation_errors'))
 
 // ------------------------------------------------------------------------
 
+/**
+ * Parse the form attributes
+ *
+ * Helper function used by some of the form helpers
+ *
+ * @access	private
+ * @param	array
+ * @param	array
+ * @return	string
+ */
 if ( ! function_exists('_parse_form_attributes'))
 {
-	/**
-	 * Parse the form attributes
-	 *
-	 * Helper function used by some of the form helpers
-	 *
-	 * @param	array	$attributes	List of attributes
-	 * @param	array	$default	Default values
-	 * @return	string
-	 */
 	function _parse_form_attributes($attributes, $default)
 	{
 		if (is_array($attributes))
@@ -899,16 +948,12 @@ if ( ! function_exists('_parse_form_attributes'))
 
 		foreach ($default as $key => $val)
 		{
-			if ($key === 'value')
+			if ($key == 'value')
 			{
-				$val = form_prep($val);
-			}
-			elseif ($key === 'name' && ! strlen($default['name']))
-			{
-				continue;
+				$val = form_prep($val, $default['name']);
 			}
 
-			$att .= $key.'="'.$val.'" ';
+			$att .= $key . '="' . $val . '" ';
 		}
 
 		return $att;
@@ -917,49 +962,50 @@ if ( ! function_exists('_parse_form_attributes'))
 
 // ------------------------------------------------------------------------
 
+/**
+ * Attributes To String
+ *
+ * Helper function used by some of the form helpers
+ *
+ * @access	private
+ * @param	mixed
+ * @param	bool
+ * @return	string
+ */
 if ( ! function_exists('_attributes_to_string'))
 {
-	/**
-	 * Attributes To String
-	 *
-	 * Helper function used by some of the form helpers
-	 *
-	 * @param	mixed
-	 * @param	bool
-	 * @return	string
-	 */
 	function _attributes_to_string($attributes, $formtag = FALSE)
 	{
-		if (is_string($attributes) && strlen($attributes) > 0)
+		if (is_string($attributes) AND strlen($attributes) > 0)
 		{
-			if ($formtag === TRUE && strpos($attributes, 'method=') === FALSE)
+			if ($formtag == TRUE AND strpos($attributes, 'method=') === FALSE)
 			{
 				$attributes .= ' method="post"';
 			}
 
-			if ($formtag === TRUE && strpos($attributes, 'accept-charset=') === FALSE)
+			if ($formtag == TRUE AND strpos($attributes, 'accept-charset=') === FALSE)
 			{
 				$attributes .= ' accept-charset="'.strtolower(config_item('charset')).'"';
 			}
 
-			return ' '.$attributes;
+		return ' '.$attributes;
 		}
 
-		if (is_object($attributes) && count($attributes) > 0)
+		if (is_object($attributes) AND count($attributes) > 0)
 		{
-			$attributes = (array) $attributes;
+			$attributes = (array)$attributes;
 		}
 
-		if (is_array($attributes) && ($formtag === TRUE OR count($attributes) > 0))
+		if (is_array($attributes) AND count($attributes) > 0)
 		{
 			$atts = '';
 
-			if ( ! isset($attributes['method']) && $formtag === TRUE)
+			if ( ! isset($attributes['method']) AND $formtag === TRUE)
 			{
 				$atts .= ' method="post"';
 			}
 
-			if ( ! isset($attributes['accept-charset']) && $formtag === TRUE)
+			if ( ! isset($attributes['accept-charset']) AND $formtag === TRUE)
 			{
 				$atts .= ' accept-charset="'.strtolower(config_item('charset')).'"';
 			}
@@ -976,36 +1022,38 @@ if ( ! function_exists('_attributes_to_string'))
 
 // ------------------------------------------------------------------------
 
+/**
+ * Validation Object
+ *
+ * Determines what the form validation class was instantiated as, fetches
+ * the object and returns it.
+ *
+ * @access	private
+ * @return	mixed
+ */
 if ( ! function_exists('_get_validation_object'))
 {
-	/**
-	 * Validation Object
-	 *
-	 * Determines what the form validation class was instantiated as, fetches
-	 * the object and returns it.
-	 *
-	 * @return	mixed
-	 */
 	function &_get_validation_object()
 	{
 		$CI =& get_instance();
 
 		// We set this as a variable since we're returning by reference.
 		$return = FALSE;
-
+		
 		if (FALSE !== ($object = $CI->load->is_loaded('form_validation')))
 		{
 			if ( ! isset($CI->$object) OR ! is_object($CI->$object))
 			{
 				return $return;
 			}
-
+			
 			return $CI->$object;
 		}
-
+		
 		return $return;
 	}
 }
+
 
 /* End of file form_helper.php */
 /* Location: ./system/helpers/form_helper.php */


### PR DESCRIPTION
This resolves a bug with having multiple forms with the same field names not properly being encoded.
