### PR TITLE
doc: xss_clean() method is in Security, not Input

### DIFF
--- a/user_guide_src/source/libraries/form_validation.rst
+++ b/user_guide_src/source/libraries/form_validation.rst
@@ -911,15 +911,15 @@ Prepping Reference
 The following is a list of all the prepping methods that are available
 to use:
 
-==================== ========= ===================================================================================================
+==================== ========= =======================================================================================================
 Name                 Parameter Description
-==================== ========= ===================================================================================================
+==================== ========= =======================================================================================================
 **xss_clean**        No        Runs the data through the XSS filtering method, described in the :doc:`Security Class <security>` page.
 **prep_for_form**    No        Converts special characters so that HTML data can be shown in a form field without breaking it.
 **prep_url**         No        Adds "\http://" to URLs if missing.
 **strip_image_tags** No        Strips the HTML from image tags leaving the raw URL.
 **encode_php_tags**  No        Converts PHP tags to entities.
-==================== ========= ===================================================================================================
+==================== ========= =======================================================================================================
 
 .. note:: You can also use any native PHP functions that permits one
 	parameter, like ``trim()``, ``htmlspecialchars()``, ``urldecode()``,


### PR DESCRIPTION
The Input doc does talk about xss filtering, but they refer you to Security for details, which is where the function is actually defined.  It gives more detail about what the function is supposed to do, and avoids some irrelevance.

It's probably not a big deal; it just looks wrong.  It _might_ have been responsible for confusion[1] sometimes.

[1] http://stackoverflow.com/questions/13570522/this-input-xss-cleandata-giving-fatal-error-with-codeigniter
