### PR TITLE
Added format characters wrapper function to the typography helper.

### DIFF
--- a/system/helpers/typography_helper.php
+++ b/system/helpers/typography_helper.php
@@ -73,6 +73,25 @@ if ( ! function_exists('auto_typography'))
 	}
 }
 
+// ------------------------------------------------------------------------
+
+if ( ! function_exists('format_characters'))
+{
+	/**
+	 * Format Characters Wrapper Function
+	 *
+	 * @access	public
+	 * @param	string
+	 * @return	string
+	 */
+	function format_characters($str)
+	{
+		$CI =& get_instance();
+		$CI->load->library('typography');
+		return $CI->typography->format_characters($str);
+	}
+}
+
 // --------------------------------------------------------------------
 
 if ( ! function_exists('entity_decode'))


### PR DESCRIPTION
The documentation states that the format_characters method is similar to auto_typography - http://ellislab.com/codeigniter/user-guide/libraries/typography.html

However the format characters function could not be used as a helper.

Signed-off-by: Thomas Welton thomas@clicklabs.co.uk
