### PR TITLE
Improved extensibility of the URI class

### DIFF
--- a/system/core/URI.php
+++ b/system/core/URI.php
@@ -506,23 +506,13 @@ class CI_URI {
 			return $default;
 		}
 
-		in_array($which, array('segment', 'rsegment'), TRUE) OR $which = 'segment';
-
 		if (isset($this->keyval[$which], $this->keyval[$which][$n]))
 		{
 			return $this->keyval[$which][$n];
 		}
 
-		if ($which === 'segment')
-		{
-			$total_segments = 'total_segments';
-			$segment_array = 'segment_array';
-		}
-		else
-		{
-			$total_segments = 'total_rsegments';
-			$segment_array = 'rsegment_array';
-		}
+		$total_segments = "total_{$which}s";
+		$segment_array = "{$which}_array";
 
 		if ($this->$total_segments() < $n)
 		{


### PR DESCRIPTION
Improved extensibility of the URI class by modifying `_uri_assoc()` to (1) not force a specific list of valid options for `$which`, and (2) build the `$segment_array` and `$total_segments` dynamically regardless of the contents of `$which`.

Signed-off-by: Daniel Hunsaker danhunsaker@gmail.com
