### PR TITLE
Fixed normalization of headers under Apache

### DIFF
--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -788,7 +788,7 @@ class CI_Input {
 		// take SOME_HEADER and turn it into Some-Header
 		foreach ($headers as $key => $val)
 		{
-			$key = str_replace('_', ' ', strtolower($key));
+			$key = str_replace(array('_', '-'), ' ', strtolower($key));
 			$key = str_replace(' ', '-', ucwords($key));
 
 			$this->headers[$key] = $val;


### PR DESCRIPTION
The existing header normalization routine converts headers provided by Apache (that is, with `-` in the name instead of `_`) to all lowercase, with the exception of the first character.  This is different from the expected result, wherein each word of the header is capitalized.  For example, `CONTENT-LENGTH` would normalize to `Content-length` instead of the expected `Content-Length`.  The reason for this is that the existing code is only converting underscores to spaces, and leaving hyphens untouched.  The fix is to replace hyphens with spaces as well before passing the result through `ucwords()`.

That fix is included here.

Signed-off-by: Daniel Hunsaker danhunsaker@gmail.com
