### PR TITLE
fix a typo in index.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -64,8 +64,8 @@ if (defined('ENVIRONMENT'))
  *---------------------------------------------------------------
  *
  * If you want this front controller to use a different "application"
- * folder then the default one you can set its name here. The folder
- * can also be renamed or relocated anywhere on your server.  If
+ * folder than the default one you can set its name here. The folder
+ * can also be renamed or relocated anywhere on your server. If
  * you do, use a full server path. For more info please see the user guide:
  * http://codeigniter.com/user_guide/general/managing_apps.html
  *


### PR DESCRIPTION
"Than" is a comparator.
"Then" is a connector between two or more sequential events.

"foo rather than bar" makes sense. "foo rather then bar" does not.

Change also made in develop.

(There is a minor conflict in some spacing of the next line; I'm not sure I have resolved it correctly or not, I'm still new to git).
