### PR TITLE
Fix MSIE conditionals regex in minify output

### DIFF
--- a/system/core/Output.php
+++ b/system/core/Output.php
@@ -739,7 +739,7 @@ class CI_Output {
 				$output = preg_replace('!\s{2,}!', ' ', $output);
 
 				// Remove comments (non-MSIE conditionals)
-				$output = preg_replace('{\s*<!--[^\[].*-->\s*}msU', '', $output);
+				$output = preg_replace('{\s*<!--[^\[<>].*(?<!!)-->\s*}msU', '', $output);
 
 				// Remove spaces around block-level elements.
 				$output = preg_replace('/\s*(<\/?(html|head|title|meta|script|link|style|body|h[1-6]|div|p|br)[^>]*>)\s*/is', '$1', $output);


### PR DESCRIPTION
Allows IE conditionals like the following to remain unmodified (from html5boilerplate):

``` html
<!--[if gt IE 8]><!--> <html class="no-js"> <!--<![endif]-->
```

Without the change, the comment is not fully removed, remains unclosed, and the entire document is treated as commented!

Credit to joebert - regex from
http://www.sitepoint.com/forums/showthread.php?696559-Regex-pattern-to-strip-HTML-comments-but-leave-conditonals&s=3eef4ceb0a59b2fdb946fa56220fb6fd&p=4678083&viewfull=1#post4678083
