### PR TITLE
do not remove suffix if a forward slash

### DIFF
--- a/system/core/URI.php
+++ b/system/core/URI.php
@@ -353,7 +353,7 @@ class CI_URI {
 	{
 		$suffix = (string) $this->config->item('url_suffix');
 
-		if ($suffix !== '' && ($offset = strrpos($this->uri_string, $suffix)) !== FALSE)
+		if ($suffix !== '' && $suffix !== '/' && ($offset = strrpos($this->uri_string, $suffix)) !== FALSE)
 		{
 			$this->uri_string = substr_replace($this->uri_string, '', $offset, strlen($suffix));
 		}


### PR DESCRIPTION
If a site is configured with `$config['uri_suffix'] = '/';`, the new URI::_remove_url_suffix() mistakenly removes the last separating slash. This fix bypasses the remove if the url_suffix config is a slash.

This config value may be sent mistakenly or intentionally, but would cause site breakage by this function because the last separating slash would be removed.

`blog/post/34` would become `blog/post34` and would result in a 404.
