### PR TITLE
Model loader can load multiple models with alternate name

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -233,11 +233,20 @@ class CI_Loader {
 		}
 		elseif (is_array($model))
 		{
-			foreach ($model as $class)
+			foreach ($model as $single_model)
 			{
-				$this->model($class);
+				if (is_array($single_model))
+				{
+					list($class, $name) = $single_model;
+					$this->model($class, $name);
+					return;
+				}
+				else
+				{
+					$this->model($single_model);
+					return;
+				}
 			}
-			return;
 		}
 
 		$path = '';

--- a/user_guide_src/source/general/models.rst
+++ b/user_guide_src/source/general/models.rst
@@ -129,6 +129,13 @@ specify it via the second parameter of the loading method::
 
 	$this->foobar->method();
 
+You can also load multiple models at the same time, and choose to use
+a different object name if you like.
+
+	$this->load->model(array('model_name', 'another_model_name'));
+	
+	$this->load->model(array(array('model_name', 'foobar'), 'another_model_name'));
+
 Here is an example of a controller, that loads a model, then serves a
 view::
 


### PR DESCRIPTION
This allows users to load multiple models at the same time while using alternate names for the object if they like. 

```
$this->load->model(array('model_one', 'model_two'));

$this->load->model(array(array('model_one', 'foobar'), 'model_two'));
```
