### PR TITLE
Add headers to Output class cache files.

### DIFF
--- a/system/core/Output.php
+++ b/system/core/Output.php
@@ -58,21 +58,21 @@ class CI_Output {
 	 *
 	 * @var	array
 	 */
-	public $headers = array();
+	public $headers =	array();
 
 	/**
 	 * List of mime types
 	 *
 	 * @var	array
 	 */
-	public $mimes = array();
+	public $mimes =		array();
 
 	/**
 	 * Mime-type for the current page
 	 *
 	 * @var	string
 	 */
-	protected $mime_type = 'text/html';
+	protected $mime_type	= 'text/html';
 
 	/**
 	 * Enable Profiler flag
@@ -86,14 +86,14 @@ class CI_Output {
 	 *
 	 * @var	bool
 	 */
-	protected $_zlib_oc = FALSE;
+	protected $_zlib_oc =		FALSE;
 
 	/**
 	 * List of profiler sections
 	 *
 	 * @var	array
 	 */
-	protected $_profiler_sections = array();
+	protected $_profiler_sections =	array();
 
 	/**
 	 * Parse markers flag
@@ -102,7 +102,7 @@ class CI_Output {
 	 *
 	 * @var	bool
 	 */
-	public $parse_exec_vars = TRUE;
+	public $parse_exec_vars =	TRUE;
 
 	/**
 	 * Class constructor


### PR DESCRIPTION
Headers are serialized and retained on cached files.

Original idea from #964, I translated it to include _all_ headers instead of just the specified mime type. I don't know for sure how this will impact cached files; there may be different header conflicts when it comes to cache-control and whatnot. If there is any feedback that suggests this is a problem, we can easily revert it to only look for content / mime type.
