### PR TITLE
Fix and optimize auto_link() URL helper function.

### DIFF
--- a/system/helpers/url_helper.php
+++ b/system/helpers/url_helper.php
@@ -384,7 +384,7 @@ if ( ! function_exists('auto_link'))
 	function auto_link($str, $type = 'both', $popup = FALSE)
 	{
 		// Find and replace any URLs.
-		if ($type !== 'email' && preg_match_all('#\b(([\w-]+://?|www[.])[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|/)))#', $str, $matches, PREG_OFFSET_CAPTURE))
+		if ($type !== 'email' && preg_match_all('#\b(([\w-]+://?|www\.)[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|/)))#', $str, $matches, PREG_OFFSET_CAPTURE))
 		{
 			// Set our target HTML if using popup links.
 			$target = ($popup) ? 'target="_blank"' : '';


### PR DESCRIPTION
Utilizes a fix for #2160 and #2161, and elaborates / optimizes:
- Uses the `PREG_OFFSET_CAPTURE` and `substr_replace()` solution for URLs, also, since they are susceptible to the same `str_replace()` bug.
- Uses a better regular expression for URLs, and optimize the regex for emails.
- Uses an easier to read `foreach()` loop instead of `for()`, and forgoes the use of the ugly `$matches[1][$i][1]` style variable. Also commented throughout to explain what the function is doing for easy reference.
- Unnecessary punctuation `preg_match()` removed.
- URL replace uses the `anchor()` function to generate the URL instead of by hand (why reinvent the wheel?).
- About 25% faster according to a real quick, basic benchmark test.

**Known caveat / bug:** The URL regex will match an FTP URL, such as `ftp://username:password@example.com`, but if the email auto link is turned on, it will also match the `password@example.com` portion, and the output will be all garbled with the javascript from `safe_mailto()`. I couldn't figure out a good way to prevent that without a bunch of extra code.

Signed-off-by: Eric Roberts eric@cryode.com
