### PR TITLE
Remove empty per_page query string from first page URL.

### DIFF
--- a/system/libraries/Pagination.php
+++ b/system/libraries/Pagination.php
@@ -439,8 +439,17 @@ class CI_Pagination {
 		// string. If post, add a trailing slash to the base URL if needed
 		if ($CI->config->item('enable_query_strings') === TRUE OR $this->page_query_string === TRUE)
 		{
+			$this->base_url = rtrim($this->base_url);
+
+			// If a custom first URL is not defined, use the base_url
+			// before the pagination query segment is added.
+			if (empty($this->first_url))
+			{
+				$this->first_url = $this->base_url;
+			}
+
 			$segment = (strpos($this->base_url, '?')) ? '&amp;' : '?';
-			$this->base_url = rtrim($this->base_url).$segment.$this->query_string_segment.'=';
+			$this->base_url = $this->base_url.$segment.$this->query_string_segment.'=';
 		}
 		else
 		{


### PR DESCRIPTION
In response to #2124. The Pagination library adds the `per_page` query string to the `base_url`, but the first page is empty, resulting in a URL like `example.com/welcome?per_page=`. This fix assigns the `base_url` to the `first_url` option, if a custom one does not already exist.

I'm not sure if this fix will affect the `reuse_query_string` feature, since I've never used it. Pretty sure it won't, but if anyone can test and verify, that'd be swell.

Signed-off-by: Eric Roberts eric@cryode.com
