### PR TITLE
Added display_startup_errors setting to loader.

### DIFF
--- a/index.php
+++ b/index.php
@@ -56,12 +56,14 @@ switch (ENVIRONMENT)
 {
 	case 'development':
 		error_reporting(-1);
+		ini_set('display_startup_errors', 1);
 		ini_set('display_errors', 1);
 	break;
 
 	case 'testing':
 	case 'production':
 		error_reporting(E_ALL ^ E_NOTICE ^ E_DEPRECATED ^ E_STRICT);
+		ini_set('display_startup_errors', 0);
 		ini_set('display_errors', 0);
 	break;
 


### PR DESCRIPTION
This typically helps me when a white screen shows up even though I am already in development mode. It is almost always caused by a mis-typed class reference or a forgotten parenthesis, so I am thinking that this would make a useful default.
