### PR TITLE
mcrypt support for database cache files

### DIFF
--- a/application/config/database.php
+++ b/application/config/database.php
@@ -91,8 +91,8 @@ $db['default'] = array(
 	'db_debug' => TRUE,
 	'cache_on' => FALSE,
 	'cachedir' => '',
-        'cache_encrypt_cipher' => FALSE, # uses mcrypt extension, see http://php.net/manual/en/mcrypt.ciphers.php 
-        'cache_encryption_key' => 'your-secret-key', # this should be different for each application
+	'cache_encrypt_cipher' => FALSE,
+        'cache_encryption_key' => 'your-secret-key',
 	'char_set' => 'utf8',
 	'dbcollat' => 'utf8_general_ci',
 	'swap_pre' => '',
@@ -105,3 +105,4 @@ $db['default'] = array(
 
 /* End of file database.php */
 /* Location: ./application/config/database.php */
+

--- a/system/core/Utf8.php
+++ b/system/core/Utf8.php
@@ -132,19 +132,8 @@ class CI_Utf8 {
 	 * @param	string	$encoding	Input encoding
 	 * @return	string	$str encoded in UTF-8 or FALSE on failure
 	 */
-	public function convert_to_utf8($str, $encoding = FALSE)
+	public function convert_to_utf8($str, $encoding)
 	{
-                if ($encoding === FALSE)
-                {
-                  if (MB_ENABLED === TRUE)
-                  {
-                    $encoding = @mb_detect_encoding($str, 'auto');
-                  }
-                  else
-                  {
-                    $encoding = 'ASCII';
-                  }
-                }
 		if (function_exists('iconv'))
 		{
 			return @iconv($encoding, 'UTF-8', $str);

--- a/system/database/DB_cache.php
+++ b/system/database/DB_cache.php
@@ -74,17 +74,18 @@ class CI_DB_Cache {
         
         /**
          * Get initialization vector (IV) for mcrypt extension encryption
+	 *
          * @return string
          */
-        private function get_encryption_iv()
+        private function _get_encryption_iv() 
         {
-          if ($this->db->cache_encrypt)
-          {
-            $size = mcrypt_get_iv_size($this->db->cache_encrypt_cipher, MCRYPT_MODE_CBC);
-            $iv = mcrypt_create_iv($size, MCRYPT_RAND);
-            return $iv;
-          }
-          return FALSE;
+		if ($this->db->cache_encrypt)
+		{
+			$size = mcrypt_get_iv_size($this->db->cache_encrypt_cipher, MCRYPT_MODE_CBC);
+			$iv = mcrypt_create_iv($size, MCRYPT_RAND);
+			return $iv;
+		}
+		return FALSE;
         }
 
 	/**
@@ -150,10 +151,10 @@ class CI_DB_Cache {
 		{
 			return FALSE;
 		}                
-                if ($this->db->cache_encrypt !== FALSE)
-                {
-                        $cachedata = @mcrypt_decrypt($this->db->cache_encrypt_cipher, $this->db->cache_encryption_key, $cachedata, MCRYPT_MODE_CBC, $this->get_encryption_iv);
-                }
+		if ($this->db->cache_encrypt !== FALSE)
+		{
+			$cachedata = @mcrypt_decrypt($this->db->cache_encrypt_cipher, $this->db->cache_encryption_key, $cachedata, MCRYPT_MODE_CBC, $this->get_encryption_iv);
+		}
 		return unserialize($cachedata);
 	}
 
@@ -182,11 +183,11 @@ class CI_DB_Cache {
 
 			@chmod($dir_path, DIR_WRITE_MODE);
 		}
-                $object_serialized = serialize($object);
-                if ($this->db->cache_encrypt)
-                {
-                        $object_serialized = @mcrypt_encrypt($this->db->cache_encrypt_cipher, $this->db->cache_encryption_key, $object_serialized, MCRYPT_MODE_CBC, $this->get_encryption_iv);
-                }
+		$object_serialized = serialize($object);
+		if ($this->db->cache_encrypt) 
+		{
+			$object_serialized = @mcrypt_encrypt($this->db->cache_encrypt_cipher, $this->db->cache_encryption_key, $object_serialized, MCRYPT_MODE_CBC, $this->_get_encryption_iv);
+		}
 		if (write_file($dir_path.$filename, $object_serialized) === FALSE)
 		{
 			return FALSE;

--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -281,26 +281,26 @@ abstract class CI_DB_driver {
 	 */
 	public $cache_autodel		= FALSE;
 
-        /**
-         * Cache encryption cipher algorithm
-         *
-         * @var string|bool
-         */         
-        public $cache_encrypt_cipher    = FALSE;
+	/**
+	 * Cache encryption cipher algorithm
+	 *
+	 * @var string|bool
+	 */         
+	public $cache_encrypt_cipher    = FALSE;
 
-        /**
-         * Cache encryption flag
-         *
-         * @var bool
-         */
-        public $cache_encrypt           = FALSE;
-        
-        /**
-         * Cache encryption key
-         *
-         * @var string
-         */
-        public $cache_encryption_key    = 'your-secret-key'; 
+	/**
+	 * Cache encryption flag
+	 *
+	 * @var bool
+	 */
+	public $cache_encrypt           = FALSE;
+
+	/**
+	 * Cache encryption key
+	 *
+	 * @var string
+	 */
+	public $cache_encryption_key    = 'your-secret-key'; 
 
 	/**
 	 * DB Cache object
@@ -381,7 +381,7 @@ abstract class CI_DB_driver {
 				$this->$key = $val;
 			}
 		}
-                $this->cache_encrypt = ($this->cache_encrypt_cipher !== FALSE) && extension_loaded('mcrypt');
+		$this->cache_encrypt = ($this->cache_encrypt_cipher !== FALSE) && extension_loaded('mcrypt');
 		log_message('debug', 'Database Driver Class Initialized');
 	}
 


### PR DESCRIPTION
**DB cache files** should be (optionally) **encrypted**. I added the corresponding settings in **application/config/database.php** where you can set the encryption key and the cipher. 

It should be noted that encryption/decryption processes will consume extra CPU resources, also depending on the selected cipher.
