### PR TITLE
Correct variable in get_filenames method.

### DIFF
--- a/system/helpers/file_helper.php
+++ b/system/helpers/file_helper.php
@@ -157,7 +157,7 @@ if ( ! function_exists('get_filenames'))
 	 */
 	function get_filenames($source_dir, $include_path = FALSE, $_recursion = FALSE)
 	{
-		static $_filedata = array();
+		$_filedata = array();
 
 		if ($fp = @opendir($source_dir))
 		{


### PR DESCRIPTION
Removed static keyword. When using this function multiple times, the variable collects filenames from the previous iterations.
