### PR TITLE
Removed slash from URI helper doc

### DIFF
--- a/user_guide_src/source/helpers/url_helper.rst
+++ b/user_guide_src/source/helpers/url_helper.rst
@@ -110,7 +110,7 @@ For example, if your URL was this::
 
 The function would return::
 
-	/blog/comments/123
+	blog/comments/123
 
 This function is an alias for ``CI_Config::uri_string()``. For more info,
 please see the :doc:`Config Library <../libraries/config>` documentation.


### PR DESCRIPTION
In my current projects I don't see '/controller/method' but 'controller/method' when calling uri_string().
