### PR TITLE
Fix newline standardization.

### DIFF
--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -720,9 +720,9 @@ class CI_Input {
 		}
 
 		// Standardize newlines if needed
-		if ($this->_standardize_newlines === TRUE && strpos($str, "\r") !== FALSE)
+		if ($this->_standardize_newlines === TRUE)
 		{
-			return str_replace(array("\r\n", "\r", "\r\n\n"), PHP_EOL, $str);
+			return preg_replace('/(?:\r\n|[\r\n])/', PHP_EOL, $str);
 		}
 
 		return $str;


### PR DESCRIPTION
See #377 for more specific details. This implements the same fix, but without requiring a temporary string (which, as unlikely as it may be, can possibly goof things up). It's also up-to-date instead of being a year behind the core. :)

Signed-off-by: Eric Roberts eric@cryode.com
