### PR TITLE
Multiple pagination bug fixes & optimizations.

### DIFF
--- a/system/libraries/Pagination.php
+++ b/system/libraries/Pagination.php
@@ -449,7 +449,8 @@ class CI_Pagination {
 		// Are we using query strings?
 		if ($CI->config->item('enable_query_strings') === TRUE OR $this->page_query_string === TRUE)
 		{
-			$this->cur_page = (int) $CI->input->get($this->query_string_segment);
+			// Cast as string for use in ctype_digit() later.
+			$this->cur_page = (string) $CI->input->get($this->query_string_segment);
 		}
 		else
 		{
@@ -459,18 +460,24 @@ class CI_Pagination {
 				$this->uri_segment = count($CI->uri->segment_array());
 			}
 
-			$this->cur_page = $CI->uri->segment($this->uri_segment);
+			$this->cur_page = (string) $CI->uri->segment($this->uri_segment);
 
 			// Remove any specified prefix/suffix from the segment.
-			$this->cur_page = ($this->prefix !== '' OR $this->suffix !== '')
-				? (int) str_replace(array($this->prefix, $this->suffix), '', $this->cur_page)
-				: (int) $this->cur_page;
+			if ($this->prefix !== '' OR $this->suffix !== '')
+			{
+				$this->cur_page = str_replace(array($this->prefix, $this->suffix), '', $this->cur_page);
+			}
 		}
 
 		// If something isn't quite right, back to the default base page.
-		if ( ! is_numeric($this->cur_page) OR ($this->use_page_numbers && $this->cur_page === 0))
+		if ( ! ctype_digit($this->cur_page) OR ($this->use_page_numbers && (int) $this->cur_page === 0))
 		{
 			$this->cur_page = $base_page;
+		}
+		else
+		{
+			// Make sure we're using integers for comparisons later.
+			$this->cur_page = (int) $this->cur_page;
 		}
 
 		// Is the page number beyond the result range?


### PR DESCRIPTION
I was unable to come up with a way to fix various Pagination library issues through multiple pull requests. Since a few issues are closely related in how they interact with each other, separating them was tedious, and I ended up starting over repeatedly. I'll document everything here as best as possible for future reference.

---

One bug unmentioned so far is the inconsistent handling of the first URL -- in most scenarios, the `< First` link did not match the links for page one, or `Previous` when it pointed to page one. That is fixed in this update.

Here's a list of everything modified in the Pagination library, in roughly top to bottom order, to help follow the diff:
1. Moved the `_parse_attributes()` call into the `if` check to see if any attributes have been set. No point in calling it if none exist. _No related bug._
2. Moved the `$this->num_links` check to the top of the method. Anything that will error out should be checked as soon as possible. _No related bug._
3. `reuse_query_string` is now checked first, and a `$get` array is put together of any existing values. This array will be used to generate the appropriate query strings in a bit, including the query string for page numbers. _Part of fix for #2166 & inconsistent handling of query strings._
4. `base_url` and `first_url` are then sanitized / assigned.
   - If `page_query_string = TRUE` and `first_url` is empty, the first URL inherits the base URL, and reused query strings when applicable. `per_page` is then appended to the base_url only. _Part of fix for #2166 & inconsistent handling of query strings._
   - For segment-based URLs, any reused query strings are appended after the page number and any user-defined suffix. (Prefixes and suffixes are not used for the first URL. _See: #1414_)
   - If the `first_url` config option is ever set by the dev, it will be used as-is; no query strings or prefix/suffix will be added.
5. `Pagination::$uri_segment` is set to `0`, and the method defaults to the number of the last URI segment from `URI::segment_array()`. _Fixes: #2124, #1909; Discussed: #2166 (which is now outdated)_
6. The `Render the Pages` part was reorganized a bit, remove some unnecessary nested `if`'s and whatnot.
7. A bunch of comment updates, for both grammar and prevent redundancy.

---
##### Related:
- CI's `$config['url_suffix']` is not used at all by the class, and I'm not sure if it should (see #1887). First, it could mean weird URLs. If you have _ci.dev/controller/method.html_, you could end up with any of these depending on how things were set up:
  - ci.dev/controller/method.html/10
  - ci.dev/controller/method/10.html
  - ci.dev/controller/method.html/10.html
  
  A lot of this boils down to developer preference. And since you can generate suffixed URLs easily with the pagination library, I'd consider it a non-issue for the time being. Making the class play nice with CI's suffix brings in a whole new ball game.
- Language files (see #1589) -- I'm not overly concerned with implementing this now, but I think it's a good idea. It makes i18n a little easier, and prevents needing to pass the language through all the config options upon init.

---

I did my best to throw whatever use cases I could think of at this. In some situations it did produce some funny results, but it was usually because things like `page_query_string` and `suffix` were mixed together - a _highly_ unlikely scenario that anyone would want that, and similar to using CI's suffix, a pain in the ass to "fix". Testing is always appreciated -- you should be able to throw this into a 2.1.x application and have it work out of the box (at least I think so). With a lot of rearranging like this, a bug is probably inevitable. Let's squash it early, yo.

If this looks good and doesn't have any arguments, I will update the documentation and change log to accompany it.

Cheers! :beers:
