### PR TITLE
Return default ip address for command line invokation

### DIFF
--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -390,6 +390,11 @@ class CI_Input {
 			return $this->ip_address;
 		}
 
+		if (php_sapi_name == 'cli')
+		{
+			return '127.0.0.1';
+		}
+
 		$proxy_ips = config_item('proxy_ips');
 		if ( ! empty($proxy_ips) && ! is_array($proxy_ips))
 		{


### PR DESCRIPTION
I ran into the warning `Undefined index: REMOTE_ADDR in Input.php` when I invoked a controller's method from the command line, e.g. `php index.php mycontroller/myfunction`

My proposed solution simply returns the default localhost ip address `127.0.0.1` when the php process is cli.
