### PR TITLE
Upload library, clean_file_name function: Fix xss bug.

### DIFF
--- a/system/libraries/Upload.php
+++ b/system/libraries/Upload.php
@@ -1012,7 +1012,7 @@ class CI_Upload {
 		}
 		while ($old_filename !== $filename);
 
-		return stripslashes(str_replace($bad, '', $filename));
+		return stripslashes($filename);
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
For example: If you clear this string "%%3f3f" according to the $bad array will fail. The result will be "%3f"
Because str_replace() replaces left to right.

Signed-off-by: xeptor servetozkan@live.com
