### PR TITLE
Fix list_fields seek bug

### DIFF
--- a/system/database/drivers/mssql/mssql_result.php
+++ b/system/database/drivers/mssql/mssql_result.php
@@ -74,6 +74,7 @@ class CI_DB_mssql_result extends CI_DB_result {
 	public function list_fields()
 	{
 		$field_names = array();
+		mssql_field_seek($this->result_id, 0);
 		while ($field = mssql_fetch_field($this->result_id))
 		{
 			$field_names[] = $field->name;

--- a/system/database/drivers/mysql/mysql_result.php
+++ b/system/database/drivers/mysql/mysql_result.php
@@ -89,6 +89,7 @@ class CI_DB_mysql_result extends CI_DB_result {
 	public function list_fields()
 	{
 		$field_names = array();
+		mysql_field_seek($this->result_id, 0);
 		while ($field = mysql_fetch_field($this->result_id))
 		{
 			$field_names[] = $field->name;

--- a/system/database/drivers/mysqli/mysqli_result.php
+++ b/system/database/drivers/mysqli/mysqli_result.php
@@ -74,6 +74,7 @@ class CI_DB_mysqli_result extends CI_DB_result {
 	public function list_fields()
 	{
 		$field_names = array();
+		$this->result_id->field_seek(0);
 		while ($field = $this->result_id->fetch_field())
 		{
 			$field_names[] = $field->name;


### PR DESCRIPTION
On the first list_fields call, the field pointer is moved to the end
of the list of fields. This change ensures that the pointer is
positioned at the start of the field list before grabbing the names.
