### PR TITLE
Migration lib update for easy use of MY_Migration

### DIFF
--- a/system/libraries/Migration.php
+++ b/system/libraries/Migration.php
@@ -104,12 +104,6 @@ class CI_Migration {
 	 */
 	public function __construct($config = array())
 	{
-		# Only run this constructor on main library load
-		if (get_parent_class($this) !== FALSE)
-		{
-			return;
-		}
-
 		foreach ($config as $key => $val)
 		{
 			$this->{'_'.$key} = $val;


### PR DESCRIPTION
Update: removed the code from **CI_Migration** that skipped the ___construct()_ execution when **MY_Migration** was present.

Reasoning:
- The user can avoid the original ___construct()_ in **MY_Migration** by not calling _parent::__construct()_ in his own constructor.
- On the other hand, an user who did not intend any modification on **CI_Migration::__construct()** in his **MY_Migration** library was forced to copy-paste the original constructor in his own library just to simulate the default functionality.
