### PR TITLE
Fixed the Migration library update

### DIFF
--- a/system/libraries/Migration.php
+++ b/system/libraries/Migration.php
@@ -104,6 +104,12 @@ class CI_Migration {
 	 */
 	public function __construct($config = array())
 	{
+		# Only run this constructor on main library load
+		if (get_parent_class($this) !== FALSE && get_class($this) !== config_item('subclass_prefix').'Migration' )
+		{
+			return;
+		}
+		
 		foreach ($config as $key => $val)
 		{
 			$this->{'_'.$key} = $val;


### PR DESCRIPTION
Fixed the Migration library update by allowing the constructor initialization only when it is called from MY_Migration
