### PR TITLE
Added option for alias in Router.

### DIFF
--- a/system/core/Router.php
+++ b/system/core/Router.php
@@ -148,8 +148,13 @@ class CI_Router {
 			include(APPPATH.'config/routes.php');
 		}
 
+		// Get routes
 		$this->routes = ( ! isset($route) OR ! is_array($route)) ? array() : $route;
 		unset($route);
+
+		// Get alias
+		$this->alias = ( ! isset($alias) OR ! is_array($alias)) ? array() : $alias;
+		unset($alias);
 
 		// Set the default controller so we can display it in the event
 		// the URI doesn't correlated to a valid controller.
@@ -355,6 +360,11 @@ class CI_Router {
 	 */
 	protected function _parse_routes()
 	{
+		// Check for alias
+		if(count($this->uri->segments)>0 && isset($this->alias[$this->uri->segments[0]])){
+			$this->uri->segments[0] = $this->alias[$this->uri->segments[0]];
+		}
+	
 		// Turn the segment array into a URI string
 		$uri = implode('/', $this->uri->segments);
 


### PR DESCRIPTION
Just something i use a lot, because my models and controllers often share name.
So i added an alias option to router that redirect alias/\* -> controller/*

If there already is a way to achieve this sorry for pull request. Just wanted to share this.

Example (application/config/routes.php):
$alias['page'] = 'page_controller';

will route all page/(all segments) requests to page_controller/(all segments)
