### PR TITLE
Removal of object references

### DIFF
--- a/system/core/CodeIgniter.php
+++ b/system/core/CodeIgniter.php
@@ -105,7 +105,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  *  Start the timer... tick tock tick tock...
  * ------------------------------------------------------
  */
-	$BM =& load_class('Benchmark', 'core');
+	$BM = load_class('Benchmark', 'core');
 	$BM->mark('total_execution_time_start');
 	$BM->mark('loading_time:_base_classes_start');
 
@@ -114,7 +114,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  *  Instantiate the hooks class
  * ------------------------------------------------------
  */
-	$EXT =& load_class('Hooks', 'core');
+	$EXT = load_class('Hooks', 'core');
 
 /*
  * ------------------------------------------------------
@@ -128,7 +128,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  *  Instantiate the config class
  * ------------------------------------------------------
  */
-	$CFG =& load_class('Config', 'core');
+	$CFG = load_class('Config', 'core');
 
 	// Do we have any manually set config items in the index.php file?
 	if (isset($assign_to_config) && is_array($assign_to_config))
@@ -150,21 +150,21 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  * after the Config class is instantiated.
  *
  */
-	$UNI =& load_class('Utf8', 'core');
+	$UNI = load_class('Utf8', 'core');
 
 /*
  * ------------------------------------------------------
  *  Instantiate the URI class
  * ------------------------------------------------------
  */
-	$URI =& load_class('URI', 'core');
+	$URI = load_class('URI', 'core');
 
 /*
  * ------------------------------------------------------
  *  Instantiate the routing class and set the routing
  * ------------------------------------------------------
  */
-	$RTR =& load_class('Router', 'core');
+	$RTR = load_class('Router', 'core');
 	$RTR->_set_routing();
 
 	// Set any routing overrides that may exist in the main index file
@@ -178,7 +178,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  *  Instantiate the output class
  * ------------------------------------------------------
  */
-	$OUT =& load_class('Output', 'core');
+	$OUT = load_class('Output', 'core');
 
 /*
  * ------------------------------------------------------
@@ -196,21 +196,21 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  * Load the security class for xss and csrf support
  * -----------------------------------------------------
  */
-	$SEC =& load_class('Security', 'core');
+	$SEC = load_class('Security', 'core');
 
 /*
  * ------------------------------------------------------
  *  Load the Input class and sanitize globals
  * ------------------------------------------------------
  */
-	$IN	=& load_class('Input', 'core');
+	$IN	= load_class('Input', 'core');
 
 /*
  * ------------------------------------------------------
  *  Load the Language class
  * ------------------------------------------------------
  */
-	$LANG =& load_class('Lang', 'core');
+	$LANG = load_class('Lang', 'core');
 
 /*
  * ------------------------------------------------------
@@ -228,7 +228,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 	 *
 	 * @return object
 	 */
-	function &get_instance()
+	function get_instance()
 	{
 		return CI_Controller::get_instance();
 	}

--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -129,7 +129,7 @@ if ( ! function_exists('load_class'))
 	 * @param	string	the class name prefix
 	 * @return	object
 	 */
-	function &load_class($class, $directory = 'libraries', $prefix = 'CI_')
+	function load_class($class, $directory = 'libraries', $prefix = 'CI_')
 	{
 		static $_classes = array();
 
@@ -197,7 +197,7 @@ if ( ! function_exists('is_loaded'))
 	 * @param	string
 	 * @return	array
 	 */
-	function &is_loaded($class = '')
+	function is_loaded($class = '')
 	{
 		static $_is_loaded = array();
 
@@ -223,7 +223,7 @@ if ( ! function_exists('get_config'))
 	 * @param	array
 	 * @return	array
 	 */
-	function &get_config($replace = array())
+	function get_config($replace = array())
 	{
 		static $_config;
 
@@ -290,7 +290,7 @@ if ( ! function_exists('config_item'))
 
 		if ( ! isset($_config_item[$item]))
 		{
-			$config =& get_config();
+			$config = get_config();
 
 			if ( ! isset($config[$item]))
 			{
@@ -312,7 +312,7 @@ if ( ! function_exists('get_mimes'))
 	 *
 	 * @return	array
 	 */
-	function &get_mimes()
+	function get_mimes()
 	{
 		static $_mimes = array();
 
@@ -367,7 +367,7 @@ if ( ! function_exists('show_error'))
 	 */
 	function show_error($message, $status_code = 500, $heading = 'An Error Was Encountered')
 	{
-		$_error =& load_class('Exceptions', 'core');
+		$_error = load_class('Exceptions', 'core');
 		echo $_error->show_error($heading, $message, 'error_general', $status_code);
 		exit;
 	}
@@ -390,7 +390,7 @@ if ( ! function_exists('show_404'))
 	 */
 	function show_404($page = '', $log_error = TRUE)
 	{
-		$_error =& load_class('Exceptions', 'core');
+		$_error = load_class('Exceptions', 'core');
 		$_error->show_404($page, $log_error);
 		exit;
 	}
@@ -427,7 +427,7 @@ if ( ! function_exists('log_message'))
 
 		if ($_log === NULL)
 		{
-			$_log =& load_class('Log', 'core');
+			$_log = load_class('Log', 'core');
 		}
 		
 		$_log->write_log($level, $message, $php_error);
@@ -546,7 +546,7 @@ if ( ! function_exists('_exception_handler'))
 	 */
 	function _exception_handler($severity, $message, $filepath, $line)
 	{
-		$_error =& load_class('Exceptions', 'core');
+		$_error = load_class('Exceptions', 'core');
 
 		// Should we ignore the error? We'll get the current error_reporting
 		// level and add its bits with the severity bits to find out.

--- a/system/core/Config.php
+++ b/system/core/Config.php
@@ -70,7 +70,7 @@ class CI_Config {
 	 */
 	public function __construct()
 	{
-		$this->config =& get_config();
+		$this->config = get_config();
 		log_message('debug', 'Config Class Initialized');
 
 		// Set the base_url automatically if none was provided

--- a/system/core/Controller.php
+++ b/system/core/Controller.php
@@ -54,17 +54,17 @@ class CI_Controller {
 	 */
 	public function __construct()
 	{
-		self::$instance =& $this;
+		self::$instance = $this;
 
 		// Assign all the class objects that were instantiated by the
 		// bootstrap file (CodeIgniter.php) to local class variables
 		// so that CI can run as one big super object.
 		foreach (is_loaded() as $var => $class)
 		{
-			$this->$var =& load_class($class);
+			$this->$var = load_class($class);
 		}
 
-		$this->load =& load_class('Loader', 'core');
+		$this->load = load_class('Loader', 'core');
 		$this->load->initialize();
 		log_message('debug', 'Controller Class Initialized');
 	}

--- a/system/core/Hooks.php
+++ b/system/core/Hooks.php
@@ -69,7 +69,7 @@ class CI_Hooks {
 	 */
 	public function __construct()
 	{
-		$CFG =& load_class('Config', 'core');
+		$CFG = load_class('Config', 'core');
 
 		log_message('debug', 'Hooks Class Initialized');
 

--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -147,7 +147,7 @@ class CI_Loader {
 	 */
 	public function initialize()
 	{
-		$this->_base_classes =& is_loaded();
+		$this->_base_classes = is_loaded();
 		$this->_ci_autoloader();
 	}
 
@@ -599,7 +599,7 @@ class CI_Loader {
 	 */
 	public function language($files = array(), $lang = '')
 	{
-		$CI =& get_instance();
+		$CI = get_instance();
 
 		is_array($files) OR $files = array($files);
 
@@ -624,7 +624,7 @@ class CI_Loader {
 	 */
 	public function config($file = '', $use_sections = FALSE, $fail_gracefully = FALSE)
 	{
-		$CI =& get_instance();
+		$CI = get_instance();
 		return $CI->config->load($file, $use_sections, $fail_gracefully);
 	}
 
@@ -702,7 +702,7 @@ class CI_Loader {
 		$this->_ci_view_paths = array($path.'views/' => $view_cascade) + $this->_ci_view_paths;
 
 		// Add config file path
-		$config =& $this->_ci_get_component('config');
+		$config = $this->_ci_get_component('config');
 		$config->_config_paths[] = $path;
 	}
 
@@ -834,12 +834,12 @@ class CI_Loader {
 
 		// This allows anything loaded using $this->load (views, files, etc.)
 		// to become accessible from within the Controller and Model functions.
-		$_ci_CI =& get_instance();
+		$_ci_CI = get_instance();
 		foreach (get_object_vars($_ci_CI) as $_ci_key => $_ci_var)
 		{
 			if ( ! isset($this->$_ci_key))
 			{
-				$this->$_ci_key =& $_ci_CI->$_ci_key;
+				$this->$_ci_key = $_ci_CI->$_ci_key;
 			}
 		}
 
@@ -971,7 +971,7 @@ class CI_Loader {
 				// return a new instance of the object
 				if ($object_name !== NULL)
 				{
-					$CI =& get_instance();
+					$CI = get_instance();
 					if ( ! isset($CI->$object_name))
 					{
 						return $this->_ci_init_class($class, config_item('subclass_prefix'), $params, $object_name);
@@ -1001,7 +1001,7 @@ class CI_Loader {
 				// return a new instance of the object
 				if ($object_name !== NULL)
 				{
-					$CI =& get_instance();
+					$CI = get_instance();
 					if ( ! isset($CI->$object_name))
 					{
 						return $this->_ci_init_class($class, '', $params, $object_name);
@@ -1133,7 +1133,7 @@ class CI_Loader {
 		$this->_ci_classes[$class] = $classvar;
 
 		// Instantiate the class
-		$CI =& get_instance();
+		$CI = get_instance();
 		if ($config !== NULL)
 		{
 			$CI->$classvar = new $name($config);
@@ -1182,7 +1182,7 @@ class CI_Loader {
 		// Load any custom config file
 		if (count($autoload['config']) > 0)
 		{
-			$CI =& get_instance();
+			$CI = get_instance();
 			foreach ($autoload['config'] as $key => $val)
 			{
 				$CI->config->load($val);
@@ -1257,9 +1257,9 @@ class CI_Loader {
 	 * @param 	string	$component	Component name
 	 * @return	bool
 	 */
-	protected function &_ci_get_component($component)
+	protected function _ci_get_component($component)
 	{
-		$CI =& get_instance();
+		$CI = get_instance();
 		return $CI->$component;
 	}
 

--- a/system/core/Output.php
+++ b/system/core/Output.php
@@ -116,7 +116,7 @@ class CI_Output {
 		$this->_zlib_oc = (bool) @ini_get('zlib.output_compression');
 
 		// Get mime types for later
-		$this->mimes =& get_mimes();
+		$this->mimes = get_mimes();
 
 		log_message('debug', 'Output Class Initialized');
 	}
@@ -222,7 +222,7 @@ class CI_Output {
 			// Is this extension supported?
 			if (isset($this->mimes[$extension]))
 			{
-				$mime_type =& $this->mimes[$extension];
+				$mime_type = $this->mimes[$extension];
 
 				if (is_array($mime_type))
 				{
@@ -397,7 +397,7 @@ class CI_Output {
 		// Grab the super object if we can.
 		if (class_exists('CI_Controller'))
 		{
-			$CI =& get_instance();
+			$CI = get_instance();
 		}
 
 		// --------------------------------------------------------------------
@@ -405,7 +405,7 @@ class CI_Output {
 		// Set the output data
 		if ($output === '')
 		{
-			$output =& $this->final_output;
+			$output = $this->final_output;
 		}
 
 		// --------------------------------------------------------------------
@@ -520,7 +520,7 @@ class CI_Output {
 	 */
 	public function _write_cache($output)
 	{
-		$CI =& get_instance();
+		$CI = get_instance();
 		$path = $CI->config->item('cache_path');
 		$cache_path = ($path === '') ? APPPATH.'cache/' : $path;
 
@@ -577,11 +577,11 @@ class CI_Output {
 	 * @uses	CI_Config
 	 * @uses	CI_URI
 	 *
-	 * @param	object	&$CFG	CI_Config class instance
-	 * @param	object	&$URI	CI_URI class instance
+	 * @param	object	$CFG	CI_Config class instance
+	 * @param	object	$URI	CI_URI class instance
 	 * @return	bool	TRUE on success or FALSE on failure
 	 */
-	public function _display_cache(&$CFG, &$URI)
+	public function _display_cache($CFG, $URI)
 	{
 		$cache_path = ($CFG->item('cache_path') === '') ? APPPATH.'cache/' : $CFG->item('cache_path');
 

--- a/system/core/Router.php
+++ b/system/core/Router.php
@@ -90,8 +90,8 @@ class CI_Router {
 	 */
 	public function __construct()
 	{
-		$this->config =& load_class('Config', 'core');
-		$this->uri =& load_class('URI', 'core');
+		$this->config = load_class('Config', 'core');
+		$this->uri = load_class('URI', 'core');
 		log_message('debug', 'Router Class Initialized');
 	}
 

--- a/system/core/URI.php
+++ b/system/core/URI.php
@@ -80,7 +80,7 @@ class CI_URI {
 	 */
 	public function __construct()
 	{
-		$this->config =& load_class('Config', 'core');
+		$this->config = load_class('Config', 'core');
 		log_message('debug', 'URI Class Initialized');
 	}
 

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -55,6 +55,7 @@ Release Date: Not Released
    -  Updated *ip_address* database field lengths from 16 to 45 for supporting IPv6 address on :doc:`Trackback Library <libraries/trackback>` and :doc:`Captcha Helper <helpers/captcha_helper>`.
    -  Removed *cheatsheets* and *quick_reference* PDFs from the documentation.
    -  Added availability checks where usage of dangerous functions like ``eval()`` and ``exec()`` is required.
+   -  Removed references to core objects as objects are passed by reference by default in PHP5
 
 -  Helpers
 


### PR DESCRIPTION
Signed-off-by: Timothy Warren tim@timshomepage.net

Removes references to objects, to update to PHP5 style.

Simple test case to prove the default PHP5 behavior similar to current references:

```
class foo {
var $blah = 5;
}

$foo = new foo();
$bar = $foo;

$foo->blah = 6;
$bar->blah = 7;
echo $foo->blah."<br />";
echo $bar->blah."<br />";
```

This is, so far, just based on the core folder. 
