### PR TITLE
Update system/core/Common.php

### DIFF
--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -343,7 +343,7 @@ if ( ! function_exists('is_https'))
 	 */
 	function is_https()
 	{
-		return ( ! empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) !== 'off');
+		return (  ( ! empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) !== 'off' ) || ($_SERVER["SERVER_PORT"] === '443') );
 	}
 }
 


### PR DESCRIPTION
If using nginx instead of apache by default nginx will not populate the $_SERVER['HTTPS'] value.  This change allows falling back to checking the port number of the request to determine if your on SSL or not.

The other option is adding the following to your nginx config.

fastcgi_param HTTPS on; #some php apps require this to detent https
