### PR TITLE
Fixed is_https() to avoid incorrect detection.

### DIFF
--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -713,5 +713,4 @@ if ( ! function_exists('function_usable'))
 }
 
 /* End of file Common.php */
-/* Location: ./system/core/Common.php 
-*/
+/* Location: ./system/core/Common.php */


### PR DESCRIPTION
Updated is_https() to avoid "NULL" or "0" values in $_SERVER['HTTPS'] to enable HTTPS when base_url is not set.
