### PR TITLE
Set transaction enabled flag default to TRUE

### DIFF
--- a/system/database/drivers/pdo/pdo_driver.php
+++ b/system/database/drivers/pdo/pdo_driver.php
@@ -53,7 +53,7 @@ class CI_DB_pdo_driver extends CI_DB {
 	 *
 	 * @var	bool
 	 */
-	public $trans_enabled = FALSE;
+	public $trans_enabled = TRUE;
 
 	/**
 	 * PDO Options


### PR DESCRIPTION
Is there any reason not to be TRUE by default?
