### PR TITLE
DB_driver's trans_complete exception fix

### DIFF
--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -625,7 +625,7 @@ abstract class CI_DB_driver {
 				// if transactions are enabled. If we don't call this here
 				// the error message will trigger an exit, causing the
 				// transactions to remain in limbo.
-				$this->trans_complete();
+				$this->_trans_depth > 0 && $this->trans_complete();
 
 				// Display errors
 				return $this->display_error(array('Error Number: '.$error['code'], $error['message'], $sql));


### PR DESCRIPTION
When not in a transaction, any calls of trans_complete (DB_driver.php, L628) causes exception with message "There is no active transaction" (tested in PDO). So, debugging information passed to consecutive call of display_error has been lost.

It would be useful to test before closing the transaction by
$this->_trans_depth > 0 && $this->trans_complete();
