### PR TITLE
Inserting CLI verification in 'application/core/Exceptions.php'

### DIFF
--- a/system/core/Exceptions.php
+++ b/system/core/Exceptions.php
@@ -141,6 +141,17 @@ class CI_Exceptions {
 
 		$message = '<p>'.implode('</p><p>', is_array($message) ? $message : array($message)).'</p>';
 
+		//	Verification CLI Requests (for unit test)
+		if (PHP_SAPI == 'cli')
+		{
+			$message = str_replace(array('<p>', '</p>'), '', $message);
+			echo <<<EOT
+\n{$heading}\n
+Message: {$message}\n
+EOT;
+			return;
+		}
+
 		if (ob_get_level() > $this->ob_level + 1)
 		{
 			ob_end_flush();
@@ -167,6 +178,19 @@ class CI_Exceptions {
 	{
 		$severity = isset($this->levels[$severity]) ? $this->levels[$severity] : $severity;
 		$filepath = str_replace('\\', '/', $filepath);
+
+		//	Verification CLI Requests (for unit test)
+		if (PHP_SAPI == 'cli')
+		{
+			echo <<<EOT
+\nA PHP Error was encountered\n
+Severity: {$severity}\n
+Message: {$message}\n
+Filename: {$filepath}\n
+Line Number: {$line}\n
+EOT;
+			return;
+		}
 
 		// For safety reasons we do not show the full file path
 		if (FALSE !== strpos($filepath, '/'))


### PR DESCRIPTION
Inserting CLI verification in 'application/core/Exceptions.php'. 

I integrated Codeigniter with PHPUnit via hooks and if file don't exists the error output print the html error view file.

Because of this i insert the verification in method for optimize the output in CLI and implements a integration Codeigniter + PHPUnit via hooks example.

Link with a example explained:
http://willmendesnetoprojects.wordpress.com/2013/02/24/usando-phpunit-no-codeigniter-via-hooks/
