### PR TITLE
Fix this use case: load->vars('foobar', '')

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -459,7 +459,7 @@ class CI_Loader {
 	 */
 	public function vars($vars = array(), $val = '')
 	{
-		if ($val !== '' && is_string($vars))
+		if (is_string($vars))
 		{
 			$vars = array($vars => $val);
 		}


### PR DESCRIPTION
Previously, only the other syntax was working: `load->vars(array('foobar' => ''))`
