### PR TITLE
Remove trailing delimiters from csv_from_result

### DIFF
--- a/system/database/DB_utility.php
+++ b/system/database/DB_utility.php
@@ -238,7 +238,7 @@ abstract class CI_DB_utility {
 			$out .= $enclosure.str_replace($enclosure, $enclosure.$enclosure, $name).$enclosure.$delim;
 		}
 
-		$out = substr(rtrim($out),0,-strlen($delim)); // Remove the trailing delimiter character(s) at the end of the column names
+		$out = substr(rtrim($out), 0, -strlen($delim)); // Remove the trailing delimiter character(s) at the end of the column names
 		$out = $out.$newline;
 
 		// Next blast through the result array and build out the rows
@@ -248,7 +248,7 @@ abstract class CI_DB_utility {
 			{
 				$out .= $enclosure.str_replace($enclosure, $enclosure.$enclosure, $item).$enclosure.$delim;
 			}
-			$out = substr(rtrim($out),0,-strlen($delim)); // Remove the trailing delimiter character(s) at the end of the row lines
+			$out = substr(rtrim($out), 0, -strlen($delim)); // Remove the trailing delimiter character(s) at the end of the row lines
 			$out = rtrim($out).$newline;
 		}
 


### PR DESCRIPTION
When using the csv_from_result function, the returned string includes an
extra delimiter at the end of every line, usually a comma unless another
delimiter is specified.  A simple addition of a couple of lines to
remove the extra delimiter from the column names and the data rows is
included. (Lines 241 and 251)
