### PR TITLE
Fix Session cookie driver storing untrimmed user agent string in the dat...

### DIFF
--- a/system/libraries/Session/drivers/Session_cookie.php
+++ b/system/libraries/Session/drivers/Session_cookie.php
@@ -494,7 +494,7 @@ class CI_Session_cookie extends CI_Session_driver {
 		$this->userdata = array(
 			'session_id'	=> $this->_make_sess_id(),
 			'ip_address'	=> $this->CI->input->ip_address(),
-			'user_agent'	=> substr($this->CI->input->user_agent(), 0, 120),
+			'user_agent'	=> trim(substr($this->CI->input->user_agent(), 0, 120)),
 			'last_activity'	=> $this->now,
 		);
 


### PR DESCRIPTION
...abase causing set_userdata() calls to fail when $config['sess_match_useragent'] = TRUE

Signed-off-by: Daniel Robbins github@danieljrobbins.com

Spent the better part of tonight debugging the session class. It's always the smallest thing... 

This fixes the cookie session driver storing an untrimmed user agent string in the database which will cause any set_userdata() call to fail if $config['sess_match_useragent'] = TRUE; 
