### PR TITLE
Escape object strings

### DIFF
--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -997,6 +997,11 @@ abstract class CI_DB_driver {
 		{
 			return 'NULL';
 		}
+		elseif (is_object($str))
+		{
+			$obj =& $str;
+			$str = $this->escape(method_exists($obj, '__toString') ? $obj->__toString() : '');
+		}
 
 		return $str;
 	}


### PR DESCRIPTION
Previously, if I had a class with a __toString method in it and passed
it to a query like this:

$q = $this->db->from('users')
->where('username', 'admin')
->where('password', new A())
->get();

the string returned by A's __toString() method would not be escaped in
the rendered query, allowing me to do sql injection using an object like
this:

class A{
public function __toString(){return "\"\" OR 1=1";}
}

and this would result with this SQL query being run:

SELECT \* FROM users WHERE username = 'admin' AND password ="" OR 1=1

which would cause me to bypass the condition of the query or if I wrote
a bad query an SQL syntax error would occur.
