### PR TITLE
Add unicode support in cart product name.

### DIFF
--- a/system/libraries/Cart.php
+++ b/system/libraries/Cart.php
@@ -51,7 +51,7 @@ class CI_Cart {
 	 *
 	 * @var string
 	 */
-	public $product_name_rules	= '\.\:\- \w';
+	public $product_name_rules	= '\w \-\.\:';
 
 	/**
 	 * only allow safe product names


### PR DESCRIPTION
I added the full unicode support for the product cart name if utf8 is enabled in the project.
Issues related: 
https://github.com/EllisLab/CodeIgniter/issues/78
https://github.com/EllisLab/CodeIgniter/issues/57
http://ellislab.com/forums/viewthread/186579

I did not added documentation in the manual because anyway the rule has never been documented.
