### PR TITLE
Fix issue with validation of array _REQUEST input

### DIFF
--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -859,7 +859,7 @@ class CI_Form_validation {
 			return array_shift($this->_field_data[$field]['postdata']);
 		}
 
-		return $this->_field_data[$field]['postdata'];
+		return is_null($this->_field_data[$field]['postdata']) ? $default : $this->_field_data[$field]['postdata'];
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
If you're on a page which doesn't currently contain an input type, for example $_POST['itemno[]'], but sometimes that controller DOES receive a post item of that name, a bug exists.

Since sometimes that controller does receive it you might set a validation rule on it.

When CI initialises the set_rule for that field, it detects if it's an array and hence adds it to the $this->_field_data[$field] array regardless of whether any data was actually submitted.

It sets [$field]['postdata'] to NULL because of course it doesn't actually know if data is submitted while it's still only setting the rules up.

But then when it comes to setting the default value, if you're moving to a page which now DOES have this form element, set_value sets the field to '' because the first check in set_value sees that the element isset in the $this->_field_data[$field] array. Because it sees it isset it assumes that actual postdata has been sent even though we know it hasn't because it only existed so CI could keep track of the fact it's an array type input.

By checking if the postdata was actually NULL, you can hence allow CI to set the appropriate default value for the element, because it's now capable of recognising when the array element only exists because a validation rule was added for it. This works because no data has been submitted if postdata hasn't changed from NULL, so it's safe to allow CI to continue to use a user specified $default value.
