### PR TITLE
Email library: htmlspecialchars for _header_str

### DIFF
--- a/system/libraries/Email.php
+++ b/system/libraries/Email.php
@@ -1954,7 +1954,7 @@ class CI_Email {
 			}
 		}
 
-		$msg .= "<pre>".$this->_header_str."\n".htmlspecialchars($this->_subject)."\n".htmlspecialchars($this->_finalbody).'</pre>';
+		$msg .= "<pre>".htmlspecialchars($this->_header_str)."\n".htmlspecialchars($this->_subject)."\n".htmlspecialchars($this->_finalbody).'</pre>';
 		return $msg;
 	}
 


### PR DESCRIPTION
All parts but the header where htmlspecialchar'ed. The problem was, that mail adresses in unescaped <angle brackets> where not shown by the browser.
