### PR TITLE
Fixed problem for transaction test mode.

### DIFF
--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -816,7 +816,7 @@ abstract class CI_DB_driver {
 		}
 
 		// The query() function will set this flag to FALSE in the event that a query failed
-		if ($this->_trans_status === FALSE or $this->_trans_failure === TRUE)
+		if ($this->_trans_status === FALSE OR $this->_trans_failure === TRUE)
 		{
 			$this->trans_rollback();
 


### PR DESCRIPTION
trans_complete function is committed in test mode.
Because any database drivers are set _trans_failure in test_mode,
And trans_complete function is not evaluate _trans_failure.
