### PR TITLE
Bugfix in _ci_load_class for items in subdirectory

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -955,7 +955,7 @@ class CI_Loader {
 		// Is this a class extension request?
 		if (file_exists($subclass))
 		{
-			$baseclass = BASEPATH.'libraries/'.$class.'.php';
+			$baseclass = BASEPATH.'libraries/'.$subdir.$class.'.php';
 
 			if ( ! file_exists($baseclass))
 			{


### PR DESCRIPTION
Using this fix for getting the $baseclass of an extended class, items such as extended drivers (which always have subdirectories) are loaded properly. You can for example extend the Session class by placing the extended class in /application/libraries/Session/MY_Session.php
