### PR TITLE
Use the set_cookie method from Input class

### DIFF
--- a/system/libraries/Session/drivers/Session_cookie.php
+++ b/system/libraries/Session/drivers/Session_cookie.php
@@ -722,7 +722,7 @@ class CI_Session_cookie extends CI_Session_driver {
 	 */
 	protected function _setcookie($name, $value = '', $expire = 0, $path = '', $domain = '', $secure = FALSE, $httponly = FALSE)
 	{
-		setcookie($name, $value, $expire, $path, $domain, $secure, $httponly);
+		$this->CI->input->set_cookie($name, $value, $expire, $domain, $path, '', $secure, $httponly);
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
Any reason to not do this? The cookie() method is used to read it...
