### PR TITLE
Making a performance modification to DB_driver list_fields()

### DIFF
--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -1208,13 +1208,8 @@ abstract class CI_DB_driver {
 				}
 				else
 				{
-					/* We have no other choice but to just get the first element's key.
-					 * Due to array_shift() accepting it's argument by reference, if
-					 * E_STRICT is on, this would trigger a warning. So we'll have to
-					 * assign it first.
-					 */
-					$key = array_keys($row);
-					$key = array_shift($key);
+					// We have no other choice but to just get the first element's key.
+					$key = key($row);
 				}
 			}
 


### PR DESCRIPTION
Correct me if I'm wrong, but there is no reason to put an entire row's keys into an array, and then shift it to get the first element. Using `key()` is for sure more memory and time efficient. I know it's a small change, but it doesn't hurt to have more efficient code in places especially when it's simpler to understand.
