### PR TITLE
XSS Vulnerability 

### DIFF
--- a/system/core/Security.php
+++ b/system/core/Security.php
@@ -344,6 +344,14 @@ class CI_Security {
 		 */
 		$str = str_replace("\t", ' ', $str);
 
+		/*
+		* Turn quotes into their appropriate entities
+		* 52aa456eef8b60ad6754b31fbdcc77bb
+		*/
+		
+		$str = str_replace('"', '&#34;', $str);
+		$str = str_replace("'", '&#39;', $str);
+		
 		// Capture converted string for later comparison
 		$converted_string = $str;
 


### PR DESCRIPTION
Single and double quotes are not santized properly leading to an XSS vulnerability.
I personally would disallow all HTML by replacing xss_clean with htmlentities(STR, ENT_QUOTES),
as this will filter all kinds of evil, however you seem to allow some HTML.
My changes will mess up a user trying to enter &lt;img src="http://url/HERE/" /> as the 
" will be changed into the entities, however this will stop the XSS.  
The attack I discovered in my development was:

&lt;nput type="text" value="VALUE_FROM_DB_HERE" name="field" />
If VALUE_FROM_DB_HERE =

d" onmouseover=alert(444); "
or more evil
d" onmouseover=eval($('[name=\'field2\']').html())); "

the input becomes:

&lt;input type="text" value="d" onmouseover=alert(444); "" name="field" />
