### PR TITLE
Only start session if hasn't already been started

### DIFF
--- a/system/libraries/Session/drivers/Session_native.php
+++ b/system/libraries/Session/drivers/Session_native.php
@@ -109,7 +109,10 @@ class CI_Session_native extends CI_Session_driver {
 		session_set_cookie_params($config['sess_expire_on_close'] ? 0 : $expire, $path, $domain, $secure, $http_only);
 
 		// Start session
-		session_start();
+		if ( ! session_id())
+		{
+			session_start();
+		}
 
 		// Check session expiration, ip, and agent
 		$now = time();


### PR DESCRIPTION
On 3.0-dev I get a notice warning that a session has already been started, even though the only call to `session_start()` in the app is the one in the `Session_native.php` file.

This will only call `session_start()` if the session does not exist, to prevent a warning.

Signed-off-by: Dwight Watson dwight@studentservices.com.au
