### PR TITLE
Fix for extending classes in a subdirectory (e.g. drivers)

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -955,7 +955,7 @@ class CI_Loader {
 		// Is this a class extension request?
 		if (file_exists($subclass))
 		{
-			$baseclass = BASEPATH.'libraries/'.$class.'.php';
+			$baseclass = BASEPATH.'libraries/'.$subdir.$class.'.php';
 
 			if ( ! file_exists($baseclass))
 			{


### PR DESCRIPTION
Hopefully I've got the workflow right this time -- created a branch for the patch.

Using this fix for getting the `$baseclass` of an extended class, items such as extended drivers (which always have subdirectories) are loaded properly. You can for example extend the Session class by placing the extended class in `/application/libraries/Session/MY_Session.php`

Here is a sort of description of the problem and updated logic in `Loader->_ci_load_class()` using pseudo code.

Let's say we are loading the "`session`" driver, and we have overloaded the session class in `/application/libraries/Session/MY_Session.php`

The Loader has passed "`Session/session`" to `Loader->_ci_load_class()` through `Loader->library()` when we called `Loader->driver( 'session' )` . It does this because drivers must be in subdirectories.

Start out by setting `$class`, we don't have ".php" in it or any trailing slashes, so it stays as `Session/session`

Check for a `$subdir`, and there is one, "`Session`", so store it, and remove it from the class name so the class name is now just "`session`" and the `$subdir` is "`Session`".

Capitalize the class name first letter so it's "`Session`"

Check to see if there is a custom application class:
`$subclass = APPPATH.'libraries/'.$subdir.config_item('subclass_prefix').$class.'.php';`

So we are checking: `/application/libraries/Session/MY_Session.php`, which is where we have saved the file, so it exists.

Now check for a corresponding CI base class: **(This is where the previous version fails)**
`$baseclass = BASEPATH.'libraries/'.$subdir.$class.'.php';`

$baseclass becomes "`/system/libraries/Session/Session.php`" which is correct with the update. However, the previous version leaves out `$subdir`:

`$baseclass = BASEPATH.'libraries/'.$class.'.php';`

So it would be impossible for it to match the base class to the application class in the case of a driver/subdirectory! "`/system/libraries/Session.php`" of course does not exist.

From there, it would throw the "`Unable to load the requested class`" error and the application is hosed.

The update just adds the concatenation of `$subdir` to the `$baseclass` path so that it can have a chance to find application driver subclasses.
