### PR TITLE
Updates to JS/JQ libraries. New trigger event, native JS events sent to ...

### DIFF
--- a/system/libraries/Javascript.php
+++ b/system/libraries/Javascript.php
@@ -81,17 +81,49 @@ class CI_Javascript {
 	// --------------------------------------------------------------------
 
 	/**
+	 * Add Event
+	 *
+	 * Outputs a javascript library blur event
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	The code to execute
+	 * @param	string	The event to pass
+	 * @param	bool	Whether to trigger the event immediately after declaring it
+	 * @param	bool	Whether or not to return false/prevent default
+	 * @return	string
+	 */
+	public function add_event($element, $js, $event, $trigger = FALSE, $prevent_default = FALSE)
+	{
+		return $this->js->_add_event($element, $js, $event, $trigger, $prevent_default);
+	}
+
+	/**
+	 * Trigger Event
+	 *
+	 * Constructs the syntax for triggering an event, and adds to into the array for compilation if applicable
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	The event to trigger
+	 * @return	string
+	 */
+	protected function trigger_event($element = 'this', $event)
+	{
+		return $this->js->_trigger_event($element, $event);
+	}
+
+	/**
 	 * Blur
 	 *
 	 * Outputs a javascript library blur event
 	 *
 	 * @param	string	The element to attach the event to
 	 * @param	string	The code to execute
+	 * @param	bool	Whether to trigger the event immediately after declaring it
 	 * @return	string
 	 */
-	public function blur($element = 'this', $js = '')
+	public function blur($element = 'this', $js = '', $trigger = FALSE)
 	{
-		return $this->js->_blur($element, $js);
+		return $this->add_event($element, $js, 'blur', $trigger);
 	}
 
 	// --------------------------------------------------------------------
@@ -103,11 +135,12 @@ class CI_Javascript {
 	 *
 	 * @param	string	The element to attach the event to
 	 * @param	string	The code to execute
+	 * @param	bool	Whether to trigger the event immediately after declaring it
 	 * @return	string
 	 */
-	public function change($element = 'this', $js = '')
+	public function change($element = 'this', $js = '', $trigger = FALSE)
 	{
-		return $this->js->_change($element, $js);
+		return $this->add_event($element, $js, 'change', $trigger);
 	}
 
 	// --------------------------------------------------------------------
@@ -119,12 +152,13 @@ class CI_Javascript {
 	 *
 	 * @param	string	The element to attach the event to
 	 * @param	string	The code to execute
-	 * @param	bool	whether or not to return false
+	 * @param	bool	Whether or not to return false (prevent the link from being opened immediately)
+	 * @param	bool	Whether to trigger the event immediately after declaring it
 	 * @return	string
 	 */
-	public function click($element = 'this', $js = '', $ret_false = TRUE)
+	public function click($element = 'this', $js = '', $prevent_default = TRUE, $trigger = FALSE)
 	{
-		return $this->js->_click($element, $js, $ret_false);
+		return $this->add_event($element, $js, 'click', $trigger, $prevent_default);
 	}
 
 	// --------------------------------------------------------------------
@@ -136,11 +170,12 @@ class CI_Javascript {
 	 *
 	 * @param	string	The element to attach the event to
 	 * @param	string	The code to execute
+	 * @param	bool	Whether to trigger the event immediately after declaring it
 	 * @return	string
 	 */
-	public function dblclick($element = 'this', $js = '')
+	public function dblclick($element = 'this', $js = '', $trigger = FALSE)
 	{
-		return $this->js->_dblclick($element, $js);
+		return $this->add_event($element, $js, 'dblclick', $trigger);
 	}
 
 	// --------------------------------------------------------------------
@@ -152,11 +187,12 @@ class CI_Javascript {
 	 *
 	 * @param	string	The element to attach the event to
 	 * @param	string	The code to execute
+	 * @param	bool	Whether to trigger the event immediately after declaring it
 	 * @return	string
 	 */
-	public function error($element = 'this', $js = '')
+	public function error($element = 'this', $js = '', $trigger = FALSE)
 	{
-		return $this->js->_error($element, $js);
+		return $this->js->_error($element, $js, $trigger);
 	}
 
 	// --------------------------------------------------------------------
@@ -168,11 +204,12 @@ class CI_Javascript {
 	 *
 	 * @param	string	The element to attach the event to
 	 * @param	string	The code to execute
+	 * @param	bool	Whether to trigger the event immediately after declaring it
 	 * @return	string
 	 */
-	public function focus($element = 'this', $js = '')
+	public function focus($element = 'this', $js = '', $trigger = FALSE)
 	{
-		return $this->js->__add_event($focus, $js);
+		return $this->add_event($element, $js, 'focus', $trigger);
 	}
 
 	// --------------------------------------------------------------------
@@ -189,7 +226,7 @@ class CI_Javascript {
 	 */
 	public function hover($element = 'this', $over, $out)
 	{
-		return $this->js->__hover($element, $over, $out);
+		return $this->js->_hover($element, $over, $out);
 	}
 
 	// --------------------------------------------------------------------
@@ -201,11 +238,12 @@ class CI_Javascript {
 	 *
 	 * @param	string	The element to attach the event to
 	 * @param	string	The code to execute
+	 * @param	bool	Whether to trigger the event immediately after declaring it
 	 * @return	string
 	 */
-	public function keydown($element = 'this', $js = '')
+	public function keydown($element = 'this', $js = '', $trigger = FALSE)
 	{
-		return $this->js->_keydown($element, $js);
+		return $this->add_event($element, $js, 'keydown', $trigger);
 	}
 
 	// --------------------------------------------------------------------
@@ -217,11 +255,12 @@ class CI_Javascript {
 	 *
 	 * @param	string	The element to attach the event to
 	 * @param	string	The code to execute
+	 * @param	bool	Whether to trigger the event immediately after declaring it
 	 * @return	string
 	 */
-	public function keyup($element = 'this', $js = '')
+	public function keyup($element = 'this', $js = '', $trigger = FALSE)
 	{
-		return $this->js->_keyup($element, $js);
+		return $this->add_event($element, $js, 'keyup', $trigger);
 	}
 
 	// --------------------------------------------------------------------
@@ -233,11 +272,12 @@ class CI_Javascript {
 	 *
 	 * @param	string	The element to attach the event to
 	 * @param	string	The code to execute
+	 * @param	bool	Whether to trigger the event immediately after declaring it
 	 * @return	string
 	 */
-	public function load($element = 'this', $js = '')
+	public function load($element = 'this', $js = '', $trigger = FALSE)
 	{
-		return $this->js->_load($element, $js);
+		return $this->js->add_event($element, 'load', $js, $trigger);
 	}
 
 	// --------------------------------------------------------------------
@@ -249,11 +289,12 @@ class CI_Javascript {
 	 *
 	 * @param	string	The element to attach the event to
 	 * @param	string	The code to execute
+	 * @param	bool	Whether to trigger the event immediately after declaring it
 	 * @return	string
 	 */
-	public function mousedown($element = 'this', $js = '')
+	public function mousedown($element = 'this', $js = '', $trigger = FALSE)
 	{
-		return $this->js->_mousedown($element, $js);
+		return $this->add_event($element, $js, 'mousedown', $trigger);
 	}
 
 	// --------------------------------------------------------------------
@@ -265,11 +306,12 @@ class CI_Javascript {
 	 *
 	 * @param	string	The element to attach the event to
 	 * @param	string	The code to execute
+	 * @param	bool	Whether to trigger the event immediately after declaring it
 	 * @return	string
 	 */
-	public function mouseout($element = 'this', $js = '')
+	public function mouseout($element = 'this', $js = '', $trigger = FALSE)
 	{
-		return $this->js->_mouseout($element, $js);
+		return $this->add_event($element, $js, 'mouseout', $trigger);
 	}
 
 	// --------------------------------------------------------------------
@@ -281,11 +323,12 @@ class CI_Javascript {
 	 *
 	 * @param	string	The element to attach the event to
 	 * @param	string	The code to execute
+	 * @param	bool	Whether to trigger the event immediately after declaring it
 	 * @return	string
 	 */
-	public function mouseover($element = 'this', $js = '')
+	public function mouseover($element = 'this', $js = '', $trigger = FALSE)
 	{
-		return $this->js->_mouseover($element, $js);
+		return $this->add_event($element, $js, 'mouseover', $trigger);
 	}
 
 	// --------------------------------------------------------------------
@@ -297,11 +340,12 @@ class CI_Javascript {
 	 *
 	 * @param	string	The element to attach the event to
 	 * @param	string	The code to execute
+	 * @param	bool	Whether to trigger the event immediately after declaring it
 	 * @return	string
 	 */
-	public function mouseup($element = 'this', $js = '')
+	public function mouseup($element = 'this', $js = '', $trigger = FALSE)
 	{
-		return $this->js->_mouseup($element, $js);
+		return $this->add_event($element, $js, 'mouseup', $trigger);
 	}
 
 	// --------------------------------------------------------------------
@@ -343,11 +387,12 @@ class CI_Javascript {
 	 *
 	 * @param	string	The element to attach the event to
 	 * @param	string	The code to execute
+	 * @param	bool	Whether to trigger the event immediately after declaring it
 	 * @return	string
 	 */
-	public function resize($element = 'this', $js = '')
+	public function resize($element = 'this', $js = '', $trigger = FALSE)
 	{
-		return $this->js->_resize($element, $js);
+		return $this->add_event($element, $js, 'resize', $trigger);
 	}
 
 	// --------------------------------------------------------------------
@@ -359,11 +404,12 @@ class CI_Javascript {
 	 *
 	 * @param	string	The element to attach the event to
 	 * @param	string	The code to execute
+	 * @param	bool	Whether to trigger the event immediately after declaring it
 	 * @return	string
 	 */
-	public function scroll($element = 'this', $js = '')
+	public function scroll($element = 'this', $js = '', $trigger = FALSE)
 	{
-		return $this->js->_scroll($element, $js);
+		return $this->js->add_event($element, $js, 'scroll', $trigger);
 	}
 
 	// --------------------------------------------------------------------
@@ -375,11 +421,12 @@ class CI_Javascript {
 	 *
 	 * @param	string	The element to attach the event to
 	 * @param	string	The code to execute
+	 * @param	bool	Whether to trigger the event immediately after declaring it
 	 * @return	string
 	 */
-	public function unload($element = 'this', $js = '')
+	public function unload($element = 'this', $js = '', $trigger = FALSE)
 	{
-		return $this->js->_unload($element, $js);
+		return $this->js->add_event($element, $js, 'unload', $trigger);
 	}
 
 	// --------------------------------------------------------------------
@@ -545,11 +592,13 @@ class CI_Javascript {
 	 * Outputs a javascript library toggle event
 	 *
 	 * @param	string	- element
+	 * @param	mixed 	- blank to toggle, true or false to force toggle state,
+	 *                  string for custom jquery JS
 	 * @return	string
 	 */
-	public function toggle($element = 'this')
+	public function toggle($element = 'this', $show_or_hide = '')
 	{
-		return $this->js->_toggle($element);
+		return $this->js->_toggle($element, $show_or_hide);
 
 	}
 
@@ -562,11 +611,13 @@ class CI_Javascript {
 	 *
 	 * @param	string	$element = 'this'
 	 * @param	string	$class = ''
+	 * @param	mixed   $switch = blank to toggle, true or false to force toggle state,
+	 *                  string for custom jquery JS
 	 * @return	string
 	 */
-	public function toggleClass($element = 'this', $class = '')
+	public function toggleClass($element = 'this', $class = '', $switch = '')
 	{
-		return $this->js->_toggleClass($element, $class);
+		return $this->js->_toggleClass($element, $class, $switch);
 	}
 
 	// --------------------------------------------------------------------

--- a/system/libraries/Javascript/Jquery.php
+++ b/system/libraries/Javascript/Jquery.php
@@ -31,7 +31,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  *
  * @package		CodeIgniter
  * @subpackage	Libraries
- * @category	Loader
+ * @category	Javascript
  * @author		EllisLab Dev Team
  * @link		http://codeigniter.com/user_guide/libraries/javascript.html
  */
@@ -112,105 +112,18 @@ class CI_Jquery extends CI_Javascript {
 	// --------------------------------------------------------------------
 
 	/**
-	 * Blur
-	 *
-	 * Outputs a jQuery blur event
-	 *
-	 * @param	string	The element to attach the event to
-	 * @param	string	The code to execute
-	 * @return	string
-	 */
-	protected function _blur($element = 'this', $js = '')
-	{
-		return $this->_add_event($element, $js, 'blur');
-	}
-
-	// --------------------------------------------------------------------
-
-	/**
-	 * Change
-	 *
-	 * Outputs a jQuery change event
-	 *
-	 * @param	string	The element to attach the event to
-	 * @param	string	The code to execute
-	 * @return	string
-	 */
-	protected function _change($element = 'this', $js = '')
-	{
-		return $this->_add_event($element, $js, 'change');
-	}
-
-	// --------------------------------------------------------------------
-
-	/**
-	 * Click
-	 *
-	 * Outputs a jQuery click event
-	 *
-	 * @param	string	The element to attach the event to
-	 * @param	string	The code to execute
-	 * @param	bool	whether or not to return false
-	 * @return	string
-	 */
-	protected function _click($element = 'this', $js = '', $ret_false = TRUE)
-	{
-		is_array($js) OR $js = array($js);
-
-		if ($ret_false)
-		{
-			$js[] = 'return false;';
-		}
-
-		return $this->_add_event($element, $js, 'click');
-	}
-
-	// --------------------------------------------------------------------
-
-	/**
-	 * Double Click
-	 *
-	 * Outputs a jQuery dblclick event
-	 *
-	 * @param	string	The element to attach the event to
-	 * @param	string	The code to execute
-	 * @return	string
-	 */
-	protected function _dblclick($element = 'this', $js = '')
-	{
-		return $this->_add_event($element, $js, 'dblclick');
-	}
-
-	// --------------------------------------------------------------------
-
-	/**
 	 * Error
 	 *
 	 * Outputs a jQuery error event
 	 *
 	 * @param	string	The element to attach the event to
 	 * @param	string	The code to execute
+	 * @param	bool	Whether to trigger the event immediately after declaring it
 	 * @return	string
 	 */
-	protected function _error($element = 'this', $js = '')
+	protected function _error($element = 'this', $js = '', $trigger = FALSE)
 	{
-		return $this->_add_event($element, $js, 'error');
-	}
-
-	// --------------------------------------------------------------------
-
-	/**
-	 * Focus
-	 *
-	 * Outputs a jQuery focus event
-	 *
-	 * @param	string	The element to attach the event to
-	 * @param	string	The code to execute
-	 * @return	string
-	 */
-	protected function _focus($element = 'this', $js = '')
-	{
-		return $this->_add_event($element, $js, 'focus');
+		return $this->_add_event($element, $js, 'error', $trigger);
 	}
 
 	// --------------------------------------------------------------------
@@ -227,123 +140,11 @@ class CI_Jquery extends CI_Javascript {
 	 */
 	protected function _hover($element = 'this', $over, $out)
 	{
-		$event = "\n\t$(".$this->_prep_element($element).").hover(\n\t\tfunction()\n\t\t{\n\t\t\t{$over}\n\t\t}, \n\t\tfunction()\n\t\t{\n\t\t\t{$out}\n\t\t});\n";
+		$event = "\t".$this->_prep_element($element).".hover(\n\t\tfunction()\n\t\t{\n\t\t\t{$over}\n\t\t}, \n\t\tfunction()\n\t\t{\n\t\t\t{$out}\n\t\t});";
 
 		$this->jquery_code_for_compile[] = $event;
 
 		return $event;
-	}
-
-	// --------------------------------------------------------------------
-
-	/**
-	 * Keydown
-	 *
-	 * Outputs a jQuery keydown event
-	 *
-	 * @param	string	The element to attach the event to
-	 * @param	string	The code to execute
-	 * @return	string
-	 */
-	protected function _keydown($element = 'this', $js = '')
-	{
-		return $this->_add_event($element, $js, 'keydown');
-	}
-
-	// --------------------------------------------------------------------
-
-	/**
-	 * Keyup
-	 *
-	 * Outputs a jQuery keydown event
-	 *
-	 * @param	string	The element to attach the event to
-	 * @param	string	The code to execute
-	 * @return	string
-	 */
-	protected function _keyup($element = 'this', $js = '')
-	{
-		return $this->_add_event($element, $js, 'keyup');
-	}
-
-	// --------------------------------------------------------------------
-
-	/**
-	 * Load
-	 *
-	 * Outputs a jQuery load event
-	 *
-	 * @param	string	The element to attach the event to
-	 * @param	string	The code to execute
-	 * @return	string
-	 */
-	protected function _load($element = 'this', $js = '')
-	{
-		return $this->_add_event($element, $js, 'load');
-	}
-
-	// --------------------------------------------------------------------
-
-	/**
-	 * Mousedown
-	 *
-	 * Outputs a jQuery mousedown event
-	 *
-	 * @param	string	The element to attach the event to
-	 * @param	string	The code to execute
-	 * @return	string
-	 */
-	protected function _mousedown($element = 'this', $js = '')
-	{
-		return $this->_add_event($element, $js, 'mousedown');
-	}
-
-	// --------------------------------------------------------------------
-
-	/**
-	 * Mouse Out
-	 *
-	 * Outputs a jQuery mouseout event
-	 *
-	 * @param	string	The element to attach the event to
-	 * @param	string	The code to execute
-	 * @return	string
-	 */
-	protected function _mouseout($element = 'this', $js = '')
-	{
-		return $this->_add_event($element, $js, 'mouseout');
-	}
-
-	// --------------------------------------------------------------------
-
-	/**
-	 * Mouse Over
-	 *
-	 * Outputs a jQuery mouseover event
-	 *
-	 * @param	string	The element to attach the event to
-	 * @param	string	The code to execute
-	 * @return	string
-	 */
-	protected function _mouseover($element = 'this', $js = '')
-	{
-		return $this->_add_event($element, $js, 'mouseover');
-	}
-
-	// --------------------------------------------------------------------
-
-	/**
-	 * Mouseup
-	 *
-	 * Outputs a jQuery mouseup event
-	 *
-	 * @param	string	The element to attach the event to
-	 * @param	string	The code to execute
-	 * @return	string
-	 */
-	protected function _mouseup($element = 'this', $js = '')
-	{
-		return $this->_add_event($element, $js, 'mouseup');
 	}
 
 	// --------------------------------------------------------------------
@@ -370,54 +171,6 @@ class CI_Jquery extends CI_Javascript {
 	}
 
 	// --------------------------------------------------------------------
-
-	/**
-	 * Resize
-	 *
-	 * Outputs a jQuery resize event
-	 *
-	 * @param	string	The element to attach the event to
-	 * @param	string	The code to execute
-	 * @return	string
-	 */
-	protected function _resize($element = 'this', $js = '')
-	{
-		return $this->_add_event($element, $js, 'resize');
-	}
-
-	// --------------------------------------------------------------------
-
-	/**
-	 * Scroll
-	 *
-	 * Outputs a jQuery scroll event
-	 *
-	 * @param	string	The element to attach the event to
-	 * @param	string	The code to execute
-	 * @return	string
-	 */
-	protected function _scroll($element = 'this', $js = '')
-	{
-		return $this->_add_event($element, $js, 'scroll');
-	}
-
-	// --------------------------------------------------------------------
-
-	/**
-	 * Unload
-	 *
-	 * Outputs a jQuery unload event
-	 *
-	 * @param	string	The element to attach the event to
-	 * @param	string	The code to execute
-	 * @return	string
-	 */
-	protected function _unload($element = 'this', $js = '')
-	{
-		return $this->_add_event($element, $js, 'unload');
-	}
-
-	// --------------------------------------------------------------------
 	// Effects
 	// --------------------------------------------------------------------
 
@@ -433,7 +186,7 @@ class CI_Jquery extends CI_Javascript {
 	protected function _addClass($element = 'this', $class = '')
 	{
 		$element = $this->_prep_element($element);
-		return '$('.$element.').addClass("'.$class.'");';
+		return $element.'.addClass("'.$class.'");';
 	}
 
 	// --------------------------------------------------------------------
@@ -473,7 +226,7 @@ class CI_Jquery extends CI_Javascript {
 			$extra = ', '.$extra;
 		}
 
-		return "$({$element}).animate({\n$animations\n\t\t}".$speed.$extra.');';
+		return "{$element}.animate({\n$animations\n\t\t}".$speed.$extra.');';
 	}
 
 	// --------------------------------------------------------------------
@@ -498,7 +251,7 @@ class CI_Jquery extends CI_Javascript {
 			$callback = ", function(){\n{$callback}\n}";
 		}
 
-		return "$({$element}).fadeIn({$speed}{$callback});";
+		return "{$element}.fadeIn({$speed}{$callback});";
 	}
 
 	// --------------------------------------------------------------------
@@ -523,7 +276,7 @@ class CI_Jquery extends CI_Javascript {
 			$callback = ", function(){\n{$callback}\n}";
 		}
 
-		return '$('.$element.').fadeOut('.$speed.$callback.');';
+		return $element.'.fadeOut('.$speed.$callback.');';
 	}
 
 	// --------------------------------------------------------------------
@@ -548,7 +301,7 @@ class CI_Jquery extends CI_Javascript {
 			$callback = ", function(){\n{$callback}\n}";
 		}
 
-		return "$({$element}).hide({$speed}{$callback});";
+		return "{$element}.hide({$speed}{$callback});";
 	}
 
 	// --------------------------------------------------------------------
@@ -565,7 +318,7 @@ class CI_Jquery extends CI_Javascript {
 	protected function _removeClass($element = 'this', $class = '')
 	{
 		$element = $this->_prep_element($element);
-		return '$('.$element.').removeClass("'.$class.'");';
+		return $element.'.removeClass("'.$class.'");';
 	}
 
 	// --------------------------------------------------------------------
@@ -590,7 +343,7 @@ class CI_Jquery extends CI_Javascript {
 			$callback = ", function(){\n{$callback}\n}";
 		}
 
-		return '$('.$element.').slideUp('.$speed.$callback.');';
+		return $element.'.slideUp('.$speed.$callback.');';
 	}
 
 	// --------------------------------------------------------------------
@@ -615,7 +368,7 @@ class CI_Jquery extends CI_Javascript {
 			$callback = ", function(){\n{$callback}\n}";
 		}
 
-		return '$('.$element.').slideDown('.$speed.$callback.');';
+		return $element.'.slideDown('.$speed.$callback.');';
 	}
 
 	// --------------------------------------------------------------------
@@ -640,7 +393,7 @@ class CI_Jquery extends CI_Javascript {
 			$callback = ", function(){\n{$callback}\n}";
 		}
 
-		return '$('.$element.').slideToggle('.$speed.$callback.');';
+		return $element.'.slideToggle('.$speed.$callback.');';
 	}
 
 	// --------------------------------------------------------------------
@@ -651,12 +404,19 @@ class CI_Jquery extends CI_Javascript {
 	 * Outputs a jQuery toggle event
 	 *
 	 * @param	string	- element
+	 * @param	mixed - blank to toggle, true or false to force toggle state,
+	 *                  string for custom JS to evaluate
 	 * @return	string
 	 */
-	protected function _toggle($element = 'this')
+	protected function _toggle($element = 'this', $show_or_hide = '')
 	{
+		if (is_bool($show_or_hide))
+		{
+			$show_or_hide = $show_or_hide ? 'true' : 'false';
+		}
+
 		$element = $this->_prep_element($element);
-		return '$('.$element.').toggle();';
+		return $element.'.toggle('.$show_or_hide.');';
 	}
 
 	// --------------------------------------------------------------------
@@ -668,12 +428,24 @@ class CI_Jquery extends CI_Javascript {
 	 *
 	 * @param	string	$element
 	 * @param	string	$class
+	 * @param	mixed - blank to toggle, true or false to force toggle state,
+	 *                  string for custom jquery JS
 	 * @return	string
 	 */
-	protected function _toggleClass($element = 'this', $class = '')
+	protected function _toggleClass($element = 'this', $class = '', $switch = '')
 	{
+		if (is_bool($switch))
+		{
+			$switch = ($switch ? 'true' : 'false');
+		}
+
+		if (!empty($switch))
+		{
+			$switch = ', '.$switch;
+		}
+
 		$element = $this->_prep_element($element);
-		return '$('.$element.').toggleClass("'.$class.'");';
+		return $element.'.toggleClass("'.$class.'"'.$switch.');';
 	}
 
 	// --------------------------------------------------------------------
@@ -698,7 +470,7 @@ class CI_Jquery extends CI_Javascript {
 			$callback = ", function(){\n{$callback}\n}";
 		}
 
-		return '$('.$element.').show('.$speed.$callback.');';
+		return $element.'.show('.$speed.$callback.');';
 	}
 
 	// --------------------------------------------------------------------
@@ -730,8 +502,8 @@ class CI_Jquery extends CI_Javascript {
 			$loading_notifier = '<img src="'.$this->CI->config->slash_item('base_url').$this->CI->config->item('javascript_ajax_img').'" alt="Loading" />';
 		}
 
-		$updater = '$('.$container.").empty();\n" // anything that was in... get it out
-			."\t\t$(".$container.').prepend("'.$loading_notifier."\");\n"; // to replace with an image
+		$updater = $container.".empty();\n" // anything that was in... get it out
+			."\t\t".$container.'.prepend("'.$loading_notifier."\");\n"; // to replace with an image
 
 		$request_options = '';
 		if ($options !== '')
@@ -741,7 +513,7 @@ class CI_Jquery extends CI_Javascript {
 					.'}';
 		}
 
-		return $updater."\t\t$($container).load('$controller'$request_options);";
+		return $updater."\t\t{$container}.load('$controller'$request_options);";
 	}
 
 	// --------------------------------------------------------------------
@@ -793,7 +565,7 @@ class CI_Jquery extends CI_Javascript {
 			$corner_style = '"'.$corner_style.'"';
 		}
 
-		return '$('.$this->_prep_element($element).').corner('.$corner_style.');';
+		return $this->_prep_element($element).'.corner('.$corner_style.');';
 	}
 
 	// --------------------------------------------------------------------
@@ -887,7 +659,7 @@ class CI_Jquery extends CI_Javascript {
 			$sort_options = '';
 		}
 
-		return '$('.$this->_prep_element($element).').sortable({'.$sort_options."\n\t});";
+		return $this->_prep_element($element).'.sortable({'.$sort_options."\n\t});";
 	}
 
 	// --------------------------------------------------------------------
@@ -901,7 +673,7 @@ class CI_Jquery extends CI_Javascript {
 	 */
 	public function tablesorter($table = '', $options = '')
 	{
-		$this->jquery_code_for_compile[] = "\t$(".$this->_prep_element($table).').tablesorter('.$options.");\n";
+		$this->jquery_code_for_compile[] = "\t".$this->_prep_element($table).'.tablesorter('.$options.");\n";
 	}
 
 	// --------------------------------------------------------------------
@@ -916,18 +688,51 @@ class CI_Jquery extends CI_Javascript {
 	 * @param	string	The element to attach the event to
 	 * @param	string	The code to execute
 	 * @param	string	The event to pass
+	 * @param	bool	Whether to trigger the event immediately after declaring it
+	 * @param	bool	Whether or not to return false/prevent default
 	 * @return	string
 	 */
-	protected function _add_event($element, $js, $event)
+	protected function _add_event($element, $js, $event, $trigger = FALSE, $prevent_default = FALSE)
 	{
-		if (is_array($js))
-		{
-			$js = implode("\n\t\t", $js);
+		is_array($js) OR $js = array($js);
 
+		if ($prevent_default)
+		{
+			$js[] = 'event.preventDefault();';
 		}
 
-		$event = "\n\t$(".$this->_prep_element($element).').'.$event."(function(){\n\t\t{$js}\n\t});\n";
-		$this->jquery_code_for_compile[] = $event;
+		$js = implode("\n\t\t", $js);
+
+		$event = '.on("'.$event . '"'.", (function(event){\n\t\t{$js}\n\t}))".($trigger ? $this->_trigger_event(FALSE, $event) : '');
+
+		if ( $element )
+		{
+			$event = "\t".$this->_prep_element($element).$event.';';
+			$this->jquery_code_for_compile[] = $event;
+		}
+
+		return $event;
+	}
+
+	/**
+	 * Trigger Event
+	 *
+	 * Constructs the syntax for triggering an event, and adds to into the array for compilation if applicable
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	The event to trigger
+	 * @return	string
+	 */
+	protected function _trigger_event($element = 'this', $event)
+	{
+		$event = '.trigger("'.$event.'")';
+
+		if ($element)
+		{
+			$event = "\t".$this->_prep_element($element).$event.';';
+			$this->jquery_code_for_compile[] = $event;
+		}
+
 		return $event;
 	}
 
@@ -957,7 +762,7 @@ class CI_Jquery extends CI_Javascript {
 
 		// Inline references
 		$script = '$(document).ready(function() {'."\n"
-			.implode('', $this->jquery_code_for_compile)
+			.implode("\n\n", $this->jquery_code_for_compile)
 			.'});';
 
 		$output = ($script_tags === FALSE) ? $script : $this->inline($script);
@@ -1029,14 +834,26 @@ class CI_Jquery extends CI_Javascript {
 	 * @param	string
 	 * @return	string
 	 */
-	protected function _prep_element($element)
+	protected function _prep_element($element = 'this')
 	{
-		if ($element !== 'this')
+		if (is_string($element))
 		{
-			$element = '"'.$element.'"';
+			if ($element === 'this')
+			{
+				return '$('.$element.')';
+			}
+
+			if (isset($element[0]) && $element[0] == '$')
+			{
+				return $element;
+			}
+			else
+			{
+				return '$(\'' . $element . '\')';
+			}
 		}
 
-		return $element;
+		return '';
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
...base add_event() instead of driver method, update element prep, bugfixes

None of these JavaScript/jQuery updates should affect existing implementations, only improve where applicable.

JavaScript/jQuery changes:

An `add_event()` function was added to the base library, since it should be possible to emulate adding events in any library or native JavaScript for most events. `_add_event()` is already in the jQuery library, but did not have a corresponding method in the parent class.

A couple bugfixes, where there were two underscores in child class (jQuery) methods, they have been changed to one (there were calls to non-existent methods such as "__hover").

All events that have a native JavaScript equivalent are changed in the base library to be, e.g. for "blur":
`$this->add_event($element, $js, 'blur', $trigger);`

Events such as "hover" do not have a native equivalent, so they remain calling the child library in the base library, e.g.:
`$this->js->_hover($element, $over, $out);`

A `trigger_event()` method was added to the base library, and a protected child equivalent. A `$trigger` option was added to all native events, to determine whether the event should be triggered as soon as it is declared. It is common to do that, especially with something like `onchange` to immediately update the view state.

Any methods that "toggle", such as `toggle()` and `toggleClass()` now have a last parameter that will force whether to show or hide the element (toggle state). This is native to jQuery, and should be easy to implement in any other library including native JS.

Updated `_prep_element($element = 'this')` to be more fitting for jQuery. If the first character is "$", it is assumed to be a JQ selector and returned directly. Otherwise if it is "this" it returns "`$(this)`" else it returns `'$(\'' . $element . '\')';`. Methods that call it are updated accordingly.
