### PR TITLE
apache_request_headers need not go through recapitalization of incoming headers

### DIFF
--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -802,7 +802,7 @@ class CI_Input {
 			return $this->headers = apache_request_headers();
 		}
 
-		$_SERVER['HTTP_CONTENT_TYPE'] = isset($_SERVER['CONTENT_TYPE']) ? $_SERVER['CONTENT_TYPE'] : @getenv('CONTENT_TYPE');
+		$this->headers['Content-Type'] = isset($_SERVER['CONTENT_TYPE']) ? $_SERVER['CONTENT_TYPE'] : @getenv('CONTENT_TYPE');
 
 		foreach ($_SERVER as $key => $val)
 		{


### PR DESCRIPTION
apache_request_headers need not go through recapitalization of incoming headers and should be pass through as is.
This is a follow up on #2107 (c82b57b) by @danhunsaker;
