### PR TITLE
Fixes issue with emulated prepared statements not returning false if failed

### DIFF
--- a/system/database/drivers/pdo/pdo_driver.php
+++ b/system/database/drivers/pdo/pdo_driver.php
@@ -190,9 +190,9 @@ class CI_DB_pdo_driver extends CI_DB {
 	{
 		$sql = $this->_prep_query($sql);
 		$result_id = $this->conn_id->prepare($sql);
-		$result_id->execute();
+		$exec_result = $result_id->execute();
 		
-		if (is_object($result_id))
+		if ($exec_result !== FALSE && is_object($result_id))
 		{
 			if (is_numeric(stripos($sql, 'SELECT')))
 			{
@@ -209,7 +209,7 @@ class CI_DB_pdo_driver extends CI_DB {
 			$this->affect_rows = 0;
 		}
 		
-		return $result_id;
+		return $exec_result === FALSE ? FALSE : $result_id;
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
We had an issue with a SQL Statement that failed, silently even when
db_debug was set to true. We digged and find it was a bug in CodeIgniter
PDO driver (we actually use to for PostgreSQL 8.4). When using prepared
statements, the statement is not actually validated against the DB (it's
emulated) and PDO's prepare function returns the actual statement (as
$result_id in the code), even if it's bogus. Then this $result_id is
returned by the _execute function and make it to CI_DB_driver class
which uses the returned result to test it against FALSE, and the trigger
an error. This modification should fix that issue and be compatible with
other PDO drivers.
