### PR TITLE
Logging functions: level parameter is not optional

### DIFF
--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -424,12 +424,12 @@ if ( ! function_exists('log_message'))
 	 * We use this as a simple mechanism to access the logging
 	 * class and send messages to be logged.
 	 *
-	 * @param	string
-	 * @param	string
-	 * @param	bool
+	 * @param	string	the error level: 'error', 'debug' or 'info'
+	 * @param	string	the error message
+	 * @param	bool	whether the error is a native PHP error
 	 * @return	void
 	 */
-	function log_message($level = 'error', $message, $php_error = FALSE)
+	function log_message($level, $message, $php_error = FALSE)
 	{
 		static $_log, $_log_threshold;
 

--- a/system/core/Log.php
+++ b/system/core/Log.php
@@ -138,12 +138,12 @@ class CI_Log {
 	 *
 	 * Generally this function will be called using the global log_message() function
 	 *
-	 * @param	string	the error level
+	 * @param	string	the error level: 'error', 'debug' or 'info'
 	 * @param	string	the error message
 	 * @param	bool	whether the error is a native PHP error
 	 * @return	bool
 	 */
-	public function write_log($level = 'error', $msg, $php_error = FALSE)
+	public function write_log($level, $msg, $php_error = FALSE)
 	{
 		if ($this->_enabled === FALSE)
 		{

--- a/tests/mocks/core/common.php
+++ b/tests/mocks/core/common.php
@@ -178,7 +178,7 @@ if ( ! function_exists('is_loaded'))
 
 if ( ! function_exists('log_message'))
 {
-	function log_message($level = 'error', $message, $php_error = FALSE)
+	function log_message($level, $message, $php_error = FALSE)
 	{
 		return TRUE;
 	}

--- a/user_guide_src/source/general/common_functions.rst
+++ b/user_guide_src/source/general/common_functions.rst
@@ -100,11 +100,11 @@ please see the :doc:`Error Handling <errors>` documentation.
 log_message()
 =============
 
-.. php:function:: log_message($level = 'error', $message, $php_error = FALSE)
+.. php:function:: log_message($level, $message, $php_error = FALSE)
 
-	:param	string	$level: Log level
+	:param	string	$level: Log level: 'error', 'debug' or 'info'
 	:param	string	$message: Message to log
-	:param	bool	$php_error: Whether we're loggin a native PHP error message
+	:param	bool	$php_error: Whether we're logging a native PHP error message
 	:returns:	void
 
 This function is an alias for ``CI_Log::write_log()``. For more info,

--- a/user_guide_src/source/general/errors.rst
+++ b/user_guide_src/source/general/errors.rst
@@ -77,11 +77,11 @@ optional second parameter to FALSE will skip logging.
 log_message()
 =============
 
-.. php:function:: log_message($level = 'error', $message, $php_error = FALSE)
+.. php:function:: log_message($level, $message, $php_error = FALSE)
 
-	:param	string	$level: Log level
+	:param	string	$level: Log level: 'error', 'debug' or 'info'
 	:param	string	$message: Message to log
-	:param	bool	$php_error: Whether we're loggin a native PHP error message
+	:param	bool	$php_error: Whether we're logging a native PHP error message
 	:returns:	void
 
 This function lets you write messages to your log files. You must supply


### PR DESCRIPTION
This parameter cannot be optional, as the following parameter is mandatory.

Also completed the corresponding documentation.
