### PR TITLE
Do not trigger a possible custom autoloader, as it is irrelevant here

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -658,7 +658,7 @@ class CI_Loader {
 			return FALSE;
 		}
 
-		if ( ! class_exists('CI_Driver_Library'))
+		if ( ! class_exists('CI_Driver_Library', FALSE))
 		{
 			// We aren't instantiating an object here, just making the base class available
 			require BASEPATH.'libraries/Driver.php';

--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -704,7 +704,7 @@ abstract class CI_DB_driver {
 	{
 		$driver = 'CI_DB_'.$this->dbdriver.'_result';
 
-		if ( ! class_exists($driver))
+		if ( ! class_exists($driver, FALSE))
 		{
 			include_once(BASEPATH.'database/DB_result.php');
 			include_once(BASEPATH.'database/drivers/'.$this->dbdriver.'/'.$this->dbdriver.'_result.php');


### PR DESCRIPTION
These were the last two calls of class_exists() without the $autoloader = FALSE argument.
