### PR TITLE
Change array_merge into array_merge_recursive

### DIFF
--- a/system/core/Config.php
+++ b/system/core/Config.php
@@ -145,7 +145,7 @@ class CI_Config {
 			{
 				if (isset($this->config[$file]))
 				{
-					$this->config[$file] = array_merge($this->config[$file], $config);
+					$this->config[$file] = array_merge_recursive($this->config[$file], $config);
 				}
 				else
 				{
@@ -154,7 +154,7 @@ class CI_Config {
 			}
 			else
 			{
-				$this->config = array_merge($this->config, $config);
+				$this->config = array_merge_recursive($this->config, $config);
 			}
 
 			$this->is_loaded[] = $file_path;


### PR DESCRIPTION
If I loaded two configs with the following config item:

config1.php

```
$config['default']['config1']   = TRUE;
```

config2.php

```
$config['default']['config2']   = TRUE;
```

The second config will replace the first config, since the merging uses array_merge, thus the first $config['default'] will be replaced with the second.
