### PR TITLE
Fix the smilies download URL in the user_guide

### DIFF
--- a/user_guide_src/source/helpers/smiley_helper.rst
+++ b/user_guide_src/source/helpers/smiley_helper.rst
@@ -35,7 +35,7 @@ download and install the smiley images, then create a controller and the
 View as described.
 
 .. important:: Before you begin, please `download the smiley images
-	<http://codeigniter.com/download_files/smileys.zip>`_
+	<http://ellislab.com/asset/ci_download_files/smileys.zip>`_
 	and put them in a publicly accessible place on your server.
 	This helper also assumes you have the smiley replacement array
 	located at `application/config/smileys.php`


### PR DESCRIPTION
As people have noticed, the smilies zip file link is currently incorrect. I didn't see an open PR for this, so I decided to start my journey into helping with CI by attacking some low hanging fruit.

The summary of this is simply to fix the URL where the smilies are downloaded from, commit the work and send a pull request. There was no major changes and it's a single line.
