### PR TITLE
Add an array to Form Validation to log which rules caused errors

### DIFF
--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -66,6 +66,13 @@ class CI_Form_validation {
 	protected $_error_array		= array();
 
 	/**
+	 * Array of validation errors defined by rule type
+	 *
+	 * @var array
+	 */
+	protected $_error_rule_array		= array();
+
+	/**
 	 * Array of custom error messages
 	 *
 	 * @var array
@@ -343,6 +350,18 @@ class CI_Form_validation {
 		return $this->_error_array;
 	}
 
+	/**
+	 * Get Array of Error Rules
+	 *
+	 * Returns the error rule types as an array
+	 *
+	 * @return	array
+	 */
+	public function error_rule_array()
+	{
+		return $this->_error_rule_array;
+	}
+	
 	// --------------------------------------------------------------------
 
 	/**
@@ -604,6 +623,7 @@ class CI_Form_validation {
 			{
 				// Set the message type
 				$type = in_array('required', $rules) ? 'required' : 'isset';
+				$this->_error_rule_array[$row['field']] = $type;
 
 				if (isset($this->_error_messages[$type]))
 				{
@@ -780,6 +800,8 @@ class CI_Form_validation {
 				{
 					$this->_error_array[$row['field']] = $message;
 				}
+				
+				$this->_error_rule_array[$row['field']] = $rule;
 
 				return;
 			}
@@ -1516,6 +1538,7 @@ class CI_Form_validation {
 		$this->_field_data = array();
 		$this->_config_rules = array();
 		$this->_error_array = array();
+		$this->_error_rule_array = array();
 		$this->_error_messages = array();
 		$this->error_string = '';
 	}


### PR DESCRIPTION
I sometimes need to know which rule/s broke Form Validation and utilize
that info. It is a very small addition that I believe could be useful
to others.
