### PR TITLE
Add a requirement in tests installation instructions

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -17,6 +17,7 @@ format to facilitate clean api design. [see http://arrenbrecht.ch/testing/]
 PHP Unit >= 3.5.6
 
 	pear channel-discover pear.phpunit.de
+	pear channel-discover pear.symfony.com
 	pear install phpunit/PHPUnit
 
 vfsStream


### PR DESCRIPTION
PHPUnit requires Yaml package from pear.symfony.com channel.
