### PR TITLE
Flashdata newline bug

### DIFF
--- a/system/libraries/Session/Session.php
+++ b/system/libraries/Session/Session.php
@@ -304,7 +304,7 @@ class CI_Session extends CI_Driver_Library {
 		{
 			foreach ($newdata as $key => $val)
 			{
-				$val = str_replace("\r", "", $val);
+				$val = str_replace("\r", "\n", $val);
 				$this->userdata[$key] = $val;
 			}
 		}


### PR DESCRIPTION
Putting \r characters to flashdata causes hash_hmac() under _sess_read() in the file Session_cookie line 385 to produce a different hash. Fixed by replacing \r characters to \n in set_userdata()
