### PR TITLE
added newlines to end of email header when send_multipart === false

### DIFF
--- a/system/libraries/Email.php
+++ b/system/libraries/Email.php
@@ -1275,7 +1275,7 @@ class CI_Email {
 				if ($this->send_multipart === FALSE)
 				{
 					$hdr .= 'Content-Type: text/html; charset='.$this->charset.$this->newline
-						.'Content-Transfer-Encoding: quoted-printable';
+						.'Content-Transfer-Encoding: quoted-printable'.$this->newline.$this->newline;
 				}
 				else
 				{


### PR DESCRIPTION
When using class CI_Email to send an SMTP message, if the config settings are `'mailtype' === 'html'` and `'send_multipart' === FALSE`, no whitespace is inserted between the message header and the message body. There should be two newlines. With Amazon SES (and presumably with other SMTP services), this causes a failure, as the server interprets the message as if it was more header data.

This PR just appends newlines at the end of the header in the same fashion that they're appended in the case of `'send_multipart' === TRUE`. 
