### PR TITLE
fixed typo in guide/lib/xmlrpc.rst

### DIFF
--- a/user_guide_src/source/libraries/xmlrpc.rst
+++ b/user_guide_src/source/libraries/xmlrpc.rst
@@ -423,7 +423,7 @@ the Server.
 	$parameters = $request->output_parameters();
 	$name = $parameters[0]['name'];
 	$size = $parameters[1]['size'];
-	$size = $parameters[1]['shape'];
+	$shape = $parameters[1]['shape'];
 
 **************************
 XML-RPC Function Reference


### PR DESCRIPTION
$size = $parameters[1]['shape'];
replaced by:
$shape = $parameters[1]['shape'];
