### PR TITLE
Fix PHPUnit & Travis failures due to new version of vfsStream.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,6 @@
 		"php": ">=5.2.4"
 	},
 	"require-dev": {
-		"mikey179/vfsStream": "*"
+		"mikey179/vfsStream": "1.1.*"
 	}
 }


### PR DESCRIPTION
I'm trying to dig and find out what's going on, but vfsStream 1.2.0 breaks CI's unit tests. Basically anything involving the `vfs://` stream no longer works. I did a simple test using `file_exists()` using 1.1.0 (`true`) then 1.2.0 (`false`). So for whatever reason -- maybe file permissions or something similar -- this is the reason Travis builds are failing.

I'm trying to go through vfsStream's commit history and see what has changed to see if I can pinpoint something related, so I can actually fix the test or related bug. But in the mean time, updating Composer's requirements _should_ make Travis behave for the time being. PHPUnit runs perfectly on my local machine using 1.1.0.
