### PR TITLE
Proper directory_map test skip

### DIFF
--- a/tests/codeigniter/helpers/directory_helper_test.php
+++ b/tests/codeigniter/helpers/directory_helper_test.php
@@ -29,7 +29,7 @@ class Directory_helper_test extends CI_TestCase {
 		vfsStream::create($structure, $this->_test_dir);
 
 		// is_dir(), opendir(), etc. seem to fail on Windows + vfsStream when there are trailing backslashes in directory names
-		if (DIRECTORY_SEPARATOR === '\\' && ! is_dir(vfsStream::url('testDir').'\\'))
+		if ( ! is_dir(vfsStream::url('testDir').DIRECTORY_SEPARATOR))
 		{
 			$this->markTestSkipped();
 			return;


### PR DESCRIPTION
- added the needed trailing backslash
- use is_dir() instead of opendir() as it doesn't throw error on failure
