### PR TITLE
Fix too verbose error logging on default production environment

### DIFF
--- a/index.php
+++ b/index.php
@@ -61,7 +61,7 @@ switch (ENVIRONMENT)
 
 	case 'testing':
 	case 'production':
-		error_reporting(E_ALL ^ E_NOTICE ^ E_DEPRECATED ^ E_STRICT);
+		error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT);
 		ini_set('display_errors', 0);
 	break;
 


### PR DESCRIPTION
The intent always has been to remove `E_STRICT`, but as `E_ALL` was not including it before PHP 5.4, the XOR made it to be logged.
