### PR TITLE
Fix Form Validation issue with text inputs which have array as name

### DIFF
--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -583,7 +583,7 @@ class CI_Form_validation {
 
 		// If the field is blank, but NOT required, no further tests are necessary
 		$callback = FALSE;
-		if ( ! in_array('required', $rules) && ($postdata === NULL OR empty($postdata)))
+		if ( ! in_array('required', $rules) && ($postdata === NULL OR $postdata === ''))
 		{
 			// Before we bail out, does the rule contain a callback?
 			if (preg_match('/(callback_\w+(\[.*?\])?)/', implode(' ', $rules), $match))
@@ -598,7 +598,7 @@ class CI_Form_validation {
 		}
 
 		// Isset Test. Typically this rule will only apply to checkboxes.
-		if (($postdata === NULL OR empty($postdata)) && $callback === FALSE)
+		if (($postdata === NULL OR $postdata === '') && $callback === FALSE)
 		{
 			if (in_array('isset', $rules, TRUE) OR in_array('required', $rules))
 			{


### PR DESCRIPTION
According to the user guide, **text** `input`s could have `array`s as name.

``` HTML
<input type="text" name="arrayName[]" value="">
<input type="text" name="arrayName[]" value="">
<input type="text" name="arrayName[]" value="">
```

If when the form is submitted these inputs were blank, the `$postdata` would be an empty string (unlike `checkbox` type).
So, rules that need a non-empty string such as: `numeric`, would return `FALSE`, whether `required` rule is added or not.

Signed-off-by: Hashem Qolami hashem@qolami.com
