### PR TITLE
Fix #2560

### DIFF
--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -54,7 +54,7 @@ if ( ! function_exists('form_open'))
 	{
 		$CI =& get_instance();
 
-		if ($attributes === '')
+		if ($attributes === '' || (is_array($attributes) && !key_exists('method', $attributes)))
 		{
 			$attributes = 'method="post"';
 		}


### PR DESCRIPTION
Originally, the form_open method expected an empty string in
$attributes to set the "method='post'"

I changed this to accept empty arrays and arrays that don't have a
"method" key
