### PR TITLE
allow route overriding of root URI

### DIFF
--- a/system/core/Router.php
+++ b/system/core/Router.php
@@ -174,8 +174,8 @@ class CI_Router {
 		// Fetch the complete URI string
 		$this->uri->_fetch_uri_string();
 
-		// Is there a URI string? If not, the default controller specified in the "routes" file will be shown.
-		if ($this->uri->uri_string == '')
+		// Is there a URI string and no route set for a blank URI string? If not, the default controller specified in the "routes" file will be shown.
+		if ($this->uri->uri_string == '' && !array_key_exists('', $this->routes))
 		{
 			return $this->_set_default_controller();
 		}


### PR DESCRIPTION
To cover the case where you want `example.com/` to use a non-default controller. For example:

```
$route[''] = 'blog/tagged/php';
```

If you want `example.com/` to be a page of blog posts tagged as php
