### PR TITLE
Add windows filename rule as an option for upload files

### DIFF
--- a/system/core/Security.php
+++ b/system/core/Security.php
@@ -42,7 +42,7 @@ class CI_Security {
 	 *
 	 * @var	array
 	 */
-	public $sanitize_filename_str =	array(
+	public $filename_bad_chars =	array(
 		'../', '<!--', '-->', '<', '>',
 		"'", '"', '&', '$', '#',
 		'{', '}', '[', ']', '=',
@@ -565,19 +565,6 @@ class CI_Security {
 	// --------------------------------------------------------------------
 
 	/**
-	 * Set Sanitize Filename Strings
-	 *
-	 * @param	array	$strings
-	 * @return	void
-	 */
-	public function set_sanitize_filename_str($strings)
-	{
-		$this->sanitize_filename_str = $strings;
-	}
-
-	// --------------------------------------------------------------------
-
-	/**
 	 * Sanitize Filename
 	 *
 	 * @param	string	$str		Input file name
@@ -586,7 +573,7 @@ class CI_Security {
 	 */
 	public function sanitize_filename($str, $relative_path = FALSE)
 	{
-		$bad = $this->sanitize_filename_str;
+		$bad = $this->filename_bad_chars;
 
 		if ( ! $relative_path)
 		{

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -416,6 +416,7 @@ Release Date: Not Released
       -  Added method ``strip_image_tags()``.
       -  Added ``$config['csrf_regeneration']``, which makes token regeneration optional.
       -  Added ``$config['csrf_exclude_uris']``, which allows you list URIs which will not have the CSRF validation methods run.
+      -  Changed ``sanitize_filename()``, makes filename_bad_chars a public property.
 
    -  :doc:`URI Routing <general/routing>` changes include:
 


### PR DESCRIPTION
In our case, we build cloud file platform for users to upload their files and we will try to keep their original file name. That's why we add a new filename rule as same as windows' and make it an option for CI Upload library.
