### PR TITLE
form_open() helper: Fixing an imprecise use of stripos().

### DIFF
--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -80,7 +80,7 @@ if ( ! function_exists('form_open'))
 		$form = '<form action="'.$action.'"'.$attributes.">\n";
 
 		// Add CSRF field if enabled, but leave it out for GET requests and requests to external websites
-		if ($CI->config->item('csrf_protection') === TRUE && ! (strpos($action, $CI->config->base_url()) === FALSE OR stripos($form, 'method="get"')))
+		if ($CI->config->item('csrf_protection') === TRUE && ! (strpos($action, $CI->config->base_url()) === FALSE OR stripos($form, 'method="get"') !== FALSE))
 		{
 			$hidden[$CI->security->get_csrf_token_name()] = $CI->security->get_csrf_hash();
 		}


### PR DESCRIPTION
stripos('method="get"', 'method="get"') is to return integer zero. In this case developer's intention (according to the comment above the current line) would get broken.
