### PR TITLE
Fixed incorrect documentation for decimal validator

### DIFF
--- a/user_guide/libraries/form_validation.html
+++ b/user_guide/libraries/form_validation.html
@@ -1022,8 +1022,8 @@ POST array:</p>
 
 	<tr>
 		<td class="td"><strong>decimal</strong></td>
-		<td class="td">Yes</td>
-		<td class="td">Returns FALSE if the form element is not exactly the parameter value.</td>
+		<td class="td">No</td>
+		<td class="td">Returns FALSE if the form element contains anything other than a decimal number.</td>
 		<td class="td">&nbsp;</td>
 	</tr>
 


### PR DESCRIPTION
It looks like this was fixed in the develop branch a year ago in #1149 but never was reflected on the 2.1 documentation.
