### PR TITLE
Fix various typos

### DIFF
--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -74,7 +74,7 @@ Release Date: Not Released
       - :func:`anchor_popup()` will now fill the *href* attribute with the URL and its JS code will return FALSE instead.
       - Added JS window name support to the :func:`anchor_popup()` function.
       - Added support (auto-detection) for HTTP/1.1 response code 303 in :func:`redirect()`.
-      - Changed :func:`redirect()` to only choose the **refresh** method only on IIS servers, instead of all servers on Windows (when **auto** is used).
+      - Changed :func:`redirect()` to choose the **refresh** method only on IIS servers, instead of all servers on Windows (when **auto** is used).
       - Changed :func:`anchor()`, :func:`anchor_popup()`, and :func:`redirect()` to support protocol-relative URLs (e.g. *//ellislab.com/codeigniter*).
       - Added an optional second parameter to both :func:`base_url()` and :func:`site_url()` that allows enforcing of a protocol different than the one in the *base_url* configuration setting.
 
@@ -403,7 +403,7 @@ Release Date: Not Released
    -  :doc:`Config Library <libraries/config>` changes include:
 
       -  Changed ``site_url()`` method  to accept an array as well.
-      -  Removed internal method ``_assign_to_config()`` and moved it's implementation in *CodeIgniter.php* instead.
+      -  Removed internal method ``_assign_to_config()`` and moved its implementation in *CodeIgniter.php* instead.
 
    -  :doc:`Security Library <libraries/security>` changes include:
 
@@ -508,7 +508,7 @@ Bug fixes for 3.0
 -  Fixed a bug (#784, #861) - :doc:`Database Forge <database/forge>` method ``create_table()`` used to accept constraints for MSSQL/SQLSRV integer-type columns.
 -  Fixed a bug (#706) - SQLSRV/MSSSQL didn't escape field names.
 -  Fixed a bug (#1452) - ``protect_identifiers()`` didn't properly detect identifiers with spaces in their names.
--  Fixed a bug where ``protect_identifiers()`` ignored it's extra arguments when the value passed to it is an array.
+-  Fixed a bug where ``protect_identifiers()`` ignored its extra arguments when the value passed to it is an array.
 -  Fixed a bug where ``_has_operator()`` didn't detect BETWEEN.
 -  Fixed a bug in :doc:`Query Builder <database/query_builder>`'s ``join()`` method where it failed with identifiers containing dashes.
 -  Fixed a bug (#1264) - :doc:`Database Forge <database/forge>` and :doc:`Database Utilities <database/utilities>` didn't update/reset the databases and tables list cache when a table or a database is created, dropped or renamed.
@@ -548,7 +548,7 @@ Bug fixes for 3.0
 -  Fixed a bug where the :doc:`Session Library <libraries/sessions>` accepted cookies with *last_activity* values being in the future.
 -  Fixed a bug (#1897) - :doc:`Email Library <libraries/email>` triggered PHP E_WARNING errors when *mail* protocol used and ``to()`` is never called.
 -  Fixed a bug (#1409) - :doc:`Email Library <libraries/email>` didn't properly handle multibyte characters when applying Q-encoding to headers.
--  Fixed a bug where :doc:`Email Library <libraries/email>` didn't honor it's *wordwrap* setting while handling alternative messages.
+-  Fixed a bug where :doc:`Email Library <libraries/email>` didn't honor its *wordwrap* setting while handling alternative messages.
 -  Fixed a bug (#1476, #1909) - :doc:`Pagination Library <libraries/pagination>` didn't take into account actual routing when determining the current page.
 -  Fixed a bug (#1766) - :doc:`Query Builder <database/query_builder>` didn't always take into account the *dbprefix* setting.
 -  Fixed a bug (#779) - :doc:`URI Class <libraries/uri>` didn't always trim slashes from the *uri_string* as shown in the documentation.
@@ -674,7 +674,7 @@ Bug fixes for 2.1.1
 -  Fixed a bug (#538) - Windows paths were ignored when using the :doc:`Image Manipulation Library <libraries/image_lib>` to create a new file.
 -  Fixed a bug - When database caching was enabled, $this->db->query() checked the cache before binding variables which resulted in cached queries never being found.
 -  Fixed a bug - CSRF cookie value was allowed to be any (non-empty) string before being written to the output, making code injection a risk.
--  Fixed a bug (#726) - PDO put a 'dbname' argument in it's connection string regardless of the database platform in use, which made it impossible to use SQLite.
+-  Fixed a bug (#726) - PDO put a 'dbname' argument in its connection string regardless of the database platform in use, which made it impossible to use SQLite.
 -  Fixed a bug - ``CI_DB_pdo_driver::num_rows()`` was not returning properly value with SELECT queries, cause it was relying on ``PDOStatement::rowCount()``.
 -  Fixed a bug (#1059) - ``CI_Image_lib::clear()`` was not correctly clearing all necessary object properties, namely width and height.
 

--- a/user_guide_src/source/helpers/smiley_helper.rst
+++ b/user_guide_src/source/helpers/smiley_helper.rst
@@ -22,7 +22,7 @@ This helper is loaded using the following code::
 Overview
 ========
 
-The Smiley helper has a renderer that takes plain text simileys, like
+The Smiley helper has a renderer that takes plain text smileys, like
 :-) and turns them into a image representation, like |smile!|
 
 It also lets you display a set of smiley images that when clicked will
@@ -49,7 +49,7 @@ The Controller
 --------------
 
 In your `application/controllers/` folder, create a file called
-smileys.php and place the code below in it.
+Smileys.php and place the code below in it.
 
 .. important:: Change the URL in the :func:`get_clickable_smileys()`
 	function below so that it points to your smiley folder.
@@ -157,7 +157,7 @@ Available Functions
 
 	Example::
 
-		$str = 'Here are some simileys: :-)  ;-)';
+		$str = 'Here are some smileys: :-)  ;-)';
 		$str = parse_smileys($str, "http://example.com/images/smileys/");
 		echo $str;
 

--- a/user_guide_src/source/installation/upgrade_300.rst
+++ b/user_guide_src/source/installation/upgrade_300.rst
@@ -162,7 +162,7 @@ If your application relies on IF EXISTS, you'll have to change its usage.
 	// Produces DROP TABLE IF EXISTS `table_name`
 	$this->dbforge->drop_table('table_name', TRUE);
 
-.. note:: The given example users MySQL-specific syntax, but it should work across
+.. note:: The given example uses MySQL-specific syntax, but it should work across
 	all drivers with the exception of ODBC.
 
 ***********************************************************


### PR DESCRIPTION
Backport from #2586. Helps a little bit to reduce the current merge conflicts.

@derekjones It's a followup from [my previous message](https://github.com/EllisLab/CodeIgniter/commit/c9bf303220f90b0e71acd54d150fafc87df3df81#commitcomment-3737451)
