### PR TITLE
Fixed validation bug that treated "not set" and "set but empty string" the same

### DIFF
--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -332,7 +332,7 @@ class CI_Form_validation {
 			}
 			else
 			{
-				if (isset($_POST[$field]) AND $_POST[$field] != "")
+				if (isset($_POST[$field]))
 				{
 					$this->_field_data[$field]['postdata'] = $_POST[$field];
 				}


### PR DESCRIPTION
Fixed validation bug that treated "not set" and "set but empty string" the same

See forum thread for more details http://ellislab.com/forums/viewthread/237094/
