### PR TITLE
Issue with empty posts and min_length rules

### DIFF
--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -583,7 +583,7 @@ class CI_Form_validation {
 
 		// If the field is blank, but NOT required, no further tests are necessary
 		$callback = FALSE;
-		if ( ! in_array('required', $rules) && ($postdata === NULL OR $postdata === ''))
+		if ( ! in_array('required', $rules) && ! in_array('min_length', $rules) && ($postdata === NULL OR $postdata === ''))
 		{
 			// Before we bail out, does the rule contain a callback?
 			if (preg_match('/(callback_\w+(\[.*?\])?)/', implode(' ', $rules), $match))


### PR DESCRIPTION
If user set at validation that field is not required but he sets min_length there is problem.
Validation is successful even if min_length check is not valid, when string is empty.
After that the validation data has this empty (not valid) field..
