### PR TITLE
Detect Windows Phones

### DIFF
--- a/application/config/user_agents.php
+++ b/application/config/user_agents.php
@@ -50,6 +50,7 @@ $platforms = array(
 	'win98'				=> 'Windows 98',
 	'windows 95'		=> 'Windows 95',
 	'win95'				=> 'Windows 95',
+	'windows phone'			=> 'Windows Phone',
 	'windows'			=> 'Unknown Windows OS',
 	'android'			=> 'Android',
 	'blackberry'		=> 'BlackBerry',


### PR DESCRIPTION
Added 1 line to the platforms 'windows phone' => 'Windows Phone', 
This will return the OS of the "new" generation of windows phones instead of "Unknown windows OS"
