### PR TITLE
Improved Removing Multi-line Comments in _minify_script_style, Fixes #2637

### DIFF
--- a/system/core/Output.php
+++ b/system/core/Output.php
@@ -891,7 +891,8 @@ class CI_Output {
 						if ($in_comment)
 						{
 							// Remove Multi-line Comment
-							if ($comment_start_line === $line_number){
+							if ($comment_start_line === $line_number)
+							{
 								$comment_length = $i + 2 - $comment_start_position;
 								$line = substr_replace($line, '', $comment_start_position, $comment_length);
 								$len -= $comment_length;


### PR DESCRIPTION
I tried to resolve #2637.
I think removing multi-line JavaScript comments in a perfect way, cannot be done easily using regex. Because we need to find out that the comment is in a js string or not. I did it using the `pointer` approach which is used in removing JavaScript inline comments.
