### PR TITLE
A config file that's shared across all environments

### DIFF
--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -234,6 +234,7 @@ if ( ! function_exists('get_config'))
 			exit('The configuration file does not exist.');
 		}
 
+		include(APPPATH.'config/all/config.php');
 		require($file_path);
 
 		// Does the $config array exist in the file?


### PR DESCRIPTION
Small commit, but it was helpful to us to move all the common configuration from development/config.php, staging/config.php, production/config.php into a single all/config.php that's loaded for every environment, in addition to the environment-specific settings.
