### PR TITLE
Only send the session cookie once

### DIFF
--- a/system/libraries/Session.php
+++ b/system/libraries/Session.php
@@ -46,6 +46,7 @@ class CI_Session {
 	var $userdata					= array();
 	var $CI;
 	var $now;
+	var $unique_cookies				= array();
 
 	/**
 	 * Session Constructor
@@ -651,6 +652,15 @@ class CI_Session {
 
 		// Serialize the userdata for the cookie
 		$cookie_data = $this->_serialize($cookie_data);
+
+		$unique_cookie = md5($cookie_data);
+		if (in_array($unique_cookie, $this->unique_cookies))
+		{
+			// don't send the same cookie twice
+			return;
+		}
+
+		$this->unique_cookies[] = $unique_cookie;
 
 		if ($this->sess_encrypt_cookie == TRUE)
 		{


### PR DESCRIPTION
From time to time we saw the Session library send the same ci_session cookie multiple times. It once sent it 6 times. Not sure why, but we wanted to reduce the duplication and make sure the header size didn't balloon unnecessarily. 
