### PR TITLE
Fixes Issue #2637

### DIFF
--- a/system/core/Output.php
+++ b/system/core/Output.php
@@ -847,7 +847,7 @@ class CI_Output {
 		}
 
 		// Remove CSS comments
-		$output = preg_replace('!/\*[^*]*\*+([^/][^*]*\*+)*/(?!.*?("|\'))!i', '', $output);
+		$output = preg_replace('!/\*([^/][^*]*\*)*/(?!.+?["\'])!i', '', $output);
 
 		// Remove Javascript inline comments
 		if ($has_tags === TRUE && strpos(strtolower($open_tag), 'script') !== FALSE)


### PR DESCRIPTION
resolves #2637
more elegant way to make sure that the comment is not in a js string var
using a simple lookahead to check
