### PR TITLE
re-fixes #2637

### DIFF
--- a/system/core/Output.php
+++ b/system/core/Output.php
@@ -847,7 +847,7 @@ class CI_Output {
 		}
 
 		// Remove CSS comments
-		$output = preg_replace('!/\*([^/][^*]*\*)*/(?!.+?["\'])!i', '', $output);
+		$output = preg_replace('@/\*([^/][^*]*\*)*/(?!.+?["\'])@i', '', $output);
 
 		// Remove Javascript inline comments
 		if ($has_tags === TRUE && strpos(strtolower($open_tag), 'script') !== FALSE)


### PR DESCRIPTION
delimiter used for regex bounds found in neg. lookahead
causes error using @ delimiter now for this expression
