### PR TITLE
partial fix #2667

### DIFF
--- a/system/core/Security.php
+++ b/system/core/Security.php
@@ -603,7 +603,7 @@ class CI_Security {
 	 */
 	public function strip_image_tags($str)
 	{
-		return preg_replace(array('#<img\s+.*?src\s*=\s*["\'](.+?)["\'].*?\>#', '#<img\s+.*?src\s*=\s*(.+?).*?\>#'), '\\1', $str);
+		return preg_replace(array('#<img[\s/]+.*?src\s*=\s*["\'](.+?)["\'].*?\>#', '#<img[\s/]+.*?src\s*=\s*(.+?).*?\>#'), '\\1', $str);
 	}
 
 	// ----------------------------------------------------------------


### PR DESCRIPTION
this fixes the ability to replace a space with a /
and skip the XSS filtering

specifically this :

```
    <div/style=content:url(data:image/svg+xml);visibility:visible onmouseover=confirm(1)>Bring-Mouse-Over-Me</div>
```

would allow a potential XSS site
