### PR TITLE
Removed extra from $name, since it does not follow the format of other f...

### DIFF
--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -316,9 +316,8 @@ if ( ! function_exists('form_dropdown'))
 		{
 			isset($name['options']) OR $name['options'] = array();
 			isset($name['selected']) OR $name['selected'] = array();
-			isset($name['extra']) OR $name['extra'] = array();
 
-			return form_dropdown($name['name'], $name['options'], $name['selected'], $name['extra']);
+			return form_dropdown($name['name'], $name['options'], $name['selected'], $extra);
 		}
 
 		is_array($selected) OR $selected = array($selected);


### PR DESCRIPTION
...orm_ helpers. Form helpers use $extra as a string. On the form_input for example, the $extra is a string but placing extra in the first parameter results in an attribute on the resulting element called 'extra', whereas the drop down it does not. $extra is now passed along as works just as all other form_ methods do.
