### PR TITLE
Fixed incorrect array_diff handling in query builder caching mechanism

### DIFF
--- a/user_guide_src/source/database/caching.rst
+++ b/user_guide_src/source/database/caching.rst
@@ -112,7 +112,7 @@ object:
 
 Also, the two database resources (result_id and conn_id) are not
 available when caching, since result resources only pertain to run-time
-operations. This means that query results can not be returned as a custom class objects.
+operations.
 
 ******************
 Function Reference


### PR DESCRIPTION
In query builder there is a function _merge_cache to merge cached filters with actual db filters. It utilizes array_diff() to find the diff between arrays of filters. As I researched, almost all the filters (except join filter) are not just arrays of strings (which array_diff() expects to accept) but nested arrays. This situation causing incorrect behavior and PHP warnings because array_diff() is trying to cast array to string. 
I wrote custom array diff function to check for nested arrays.

Signed-off-by: Kakysha ezhikvdele@gmail.com
