### PR TITLE
Enable HTTP Verb in Routing

### DIFF
--- a/system/core/Router.php
+++ b/system/core/Router.php
@@ -349,38 +349,34 @@ class CI_Router {
 		$http_verb = strtolower($_SERVER['REQUEST_METHOD']);
 
 		// Is there a literal match?  If so we're done
-		if (isset($this->routes[$uri][$http_verb]))
+		if (isset($this->routes[$uri]))
 		{
-			return $this->_set_request(explode('/', $this->routes[$uri][$http_verb]));
-		}
-		else if (isset($this->routes[$uri]['(:any)']))
-		{
-			return $this->_set_request(explode('/', $this->routes[$uri]['(:any)']));
-		}
-		// Fallback to default routing
-		else if (isset($this->routes[$uri]) && is_string($this->routes[$uri]))
-		{
-			return $this->_set_request(explode('/', $this->routes[$uri]));
+			// Check default routes format
+			if (is_string($this->routes[$uri]))
+			{
+				return $this->_set_request(explode('/', $this->routes[$uri]));
+			}
+			// Is there any matching http verb?
+			elseif (is_array($this->routes[$uri]) && isset($this->routes[$uri][$http_verb]))
+			{
+				return $this->_set_request(explode('/', $this->routes[$uri][$http_verb]));
+			}
 		}
 
 		// Loop through the route array looking for wildcards
 		foreach ($this->routes as $key => $val)
 		{
-			// Check if HTTP Verb is exist
+			// Check if route format is using http verb
 			if (is_array($val))
 			{
-				// HTTP verb included in routes
+				// Does the http verb match?
 				if (isset($val[$http_verb]))
 				{
 					$val = $val[$http_verb];
 				}
-				else if (isset($val['(:any)']))
-				{
-					$val = $val['(:any)'];
-				}
+				// No match, skip to next rule
 				else
 				{
-					// HTTP Verb not found
 					continue;
 				}
 			}

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -420,6 +420,7 @@ Release Date: Not Released
 
    -  :doc:`URI Routing <general/routing>` changes include:
 
+      -  Added possibility to route requests using HTTP Verb
       -  Added possibility to route requests using callbacks.
       -  Added a new reserved route (*translate_uri_dashes*) to allow usage of dashes in the controller and method URI segments.
       -  Deprecated methods ``fetch_directory()``, ``fetch_class()`` and ``fetch_method()`` in favor of their respective public properties.

--- a/user_guide_src/source/general/routing.rst
+++ b/user_guide_src/source/general/routing.rst
@@ -142,6 +142,42 @@ routing rules to process the back-references. Example::
 		return 'catalog/product_edit/' . strtolower($product_type) . '/' . $id;
 	};
 
+Using HTTP Verb in Routes
+=========================
+
+If you prefer you can use HTTP Verb (or method) to define your routing rules.
+This is particularly useful when building RESTful application. You can use standard HTTP
+Verb (GET, PUT, POST, DELETE) or custom HTTP Verb (e.g: PURGE). HTTP Verb rule is case 
+insensitive. All you need to do is add array index using HTTP Verb rule. Example::
+
+	$route['products']['put'] = 'product/insert';
+
+In the above example, a PUT request to URI "products" would call the "product" controller
+class and "insert" method
+
+::
+
+	$route['products/(:num)']['DELETE'] = 'product/delete/$1';
+
+A DELETE request to URL with "products" as first segment and a number in the second will be
+remapped to the "product" class and "delete" method passing in the match as a variable to
+the method.
+
+::
+
+	$route['products/([a-z]+)/(\d+)']['get'] = 'product/$1/$2';
+
+A GET request to a URI similar to products/shirts/123 would call the "product" controller
+class and "shirt" method with number as method parameter
+
+Using HTTP Verb is optional, so if you want any HTTP Verb to be handled in one rule
+You could just write your routing rule without HTTP Verb. Example::
+
+	$route['product'] = 'product';
+
+This way, all incoming request using any HTTP method containing the word "product"
+in the first segment will be remapped to "product" class
+
 Reserved Routes
 ===============
 


### PR DESCRIPTION
Using array in `config/routes.php` for HTTP Verb. HTTP Verb is case-insensitive

e.g:
`$route['(:any)']['POST'] = "controller/any_post_method";`
`$route['path']['get'] = "controller/path_get_method";`
`$route['path']['(:any)'] = "controller/path_any_method";`

Using `(:any)` or not using http verb at all will produce same result
e.g: `$route['path']['(:any)']` is the same as `$route['path']`

So it won't break any existing routes
