### PR TITLE
Enable pagination for post results

### DIFF
--- a/system/libraries/Pagination.php
+++ b/system/libraries/Pagination.php
@@ -450,7 +450,7 @@ class CI_Pagination {
 		// Are we using query strings?
 		if ($CI->config->item('enable_query_strings') === TRUE OR $this->page_query_string === TRUE)
 		{
-			$this->cur_page = $CI->input->get($this->query_string_segment);
+			$this->cur_page = $CI->input->get_post($this->query_string_segment);
 		}
 		else
 		{


### PR DESCRIPTION
When using pagination library on a page from post search form, $this->cur_page should be getting the value from post() not get()
