### PR TITLE
Update sqlsrv_forge.php

### DIFF
--- a/system/database/drivers/sqlsrv/sqlsrv_forge.php
+++ b/system/database/drivers/sqlsrv/sqlsrv_forge.php
@@ -60,7 +60,7 @@ class CI_DB_sqlsrv_forge extends CI_DB_forge {
 	 */
 	function _drop_table($table)
 	{
-    return = "IF (EXISTS (SELECT * 
+    return "IF (EXISTS (SELECT * 
             FROM INFORMATION_SCHEMA.TABLES 
             WHERE TABLE_SCHEMA = 'dbo' 
             AND  TABLE_NAME = '".$table."')) DROP TABLE [dbo].[".$table."]";


### PR DESCRIPTION
Removing the equals sign from the return statement. Throws a parse error with PHP 5.3
