### PR TITLE
postgre "unrecognized configuration parameter 'sql_mode'" FIX

### DIFF
--- a/system/database/DB.php
+++ b/system/database/DB.php
@@ -206,7 +206,7 @@ function &DB($params = '', $query_builder_override = NULL)
 		$DB->initialize();
 	}
 
-	if ( ! empty($params['stricton']))
+	if ( ! empty($params['stricton']) && $params['dbdriver'] !== 'postgre')
 	{
 		$DB->query('SET SESSION sql_mode="STRICT_ALL_TABLES"');
 	}


### PR DESCRIPTION
Severity: Warning  --> pg_query() [<a href='function.pg-query'>function.pg-query</a>]: Query failed: ERROR:  unrecognized configuration parameter &quot;sql_mode&quot; 
system/codeigniter/database/drivers/postgre/postgre_driver.php 

Postgres does not have a sql_mode parameter... throws error when set.
