### PR TITLE
DB call_function() bug : funny typo -or- smart autocomplete?

### DIFF
--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -1483,7 +1483,7 @@ abstract class CI_DB_driver {
 		}
 
 		return (func_num_args() > 1)
-			? call_user_func_array($function, array_splice(func_get_args(), 1))
+			? call_user_func_array($function, array_slice(func_get_args(), 1))
 			: call_user_func($function);
 	}
 


### PR DESCRIPTION
Round 2.
Using array_splice() one gets "Only variables should be passed by reference" notices. I agree with myself, it should be replaced with array_slice(). It is assumed to be _array_slice()_ here (just to drop the first element of the array), not the sPlice.
