### PR TITLE
Cleanup DB_forge _process_indexes

### DIFF
--- a/system/database/DB_forge.php
+++ b/system/database/DB_forge.php
@@ -984,6 +984,7 @@ abstract class CI_DB_forge {
 	 */
 	protected function _process_indexes($table)
 	{
+		$table = $this->db->escape_identifiers($table);
 		$sqls = array();
 
 		for ($i = 0, $c = count($this->keys); $i < $c; $i++)
@@ -1008,7 +1009,7 @@ abstract class CI_DB_forge {
 			is_array($this->keys[$i]) OR $this->keys[$i] = array($this->keys[$i]);
 
 			$sqls[] = 'CREATE INDEX '.$this->db->escape_identifiers(implode('_', $this->keys[$i]))
-				.' ON '.$this->db->escape_identifiers($table)
+				.' ON '.$table
 				.' ('.implode(', ', $this->db->escape_identifiers($this->keys[$i])).');';
 		}
 


### PR DESCRIPTION
`$table = $this->db->escape_identifiers($table);` is not needed. `$table` is escaped twice.
