### PR TITLE
Remove unneeded manual escaping of session data

### DIFF
--- a/system/libraries/Session/drivers/Session_cookie.php
+++ b/system/libraries/Session/drivers/Session_cookie.php
@@ -397,7 +397,7 @@ class CI_Session_cookie extends CI_Session_driver {
 		}
 
 		// Unserialize the session array
-		$session = $this->_unserialize($session);
+		$session = @unserialize($session);
 
 		// Is the session data we unserialized an array with the correct format?
 		if ( ! is_array($session) OR ! isset($session['session_id'], $session['ip_address'], $session['user_agent'], $session['last_activity']))
@@ -472,7 +472,7 @@ class CI_Session_cookie extends CI_Session_driver {
 			$row = $query->row();
 			if ( ! empty($row->user_data))
 			{
-				$custom_data = $this->_unserialize($row->user_data);
+				$custom_data = unserialize(trim($row->user_data));
 
 				if (is_array($custom_data))
 				{
@@ -608,7 +608,7 @@ class CI_Session_cookie extends CI_Session_driver {
 			if ( ! empty($userdata))
 			{
 				// Serialize the custom data array so we can store it
-				$set['user_data'] = $this->_serialize($userdata);
+				$set['user_data'] = serialize($userdata);
 			}
 
 			// Reset query builder values.
@@ -696,7 +696,7 @@ class CI_Session_cookie extends CI_Session_driver {
 				: $this->userdata;
 
 		// Serialize the userdata for the cookie
-		$cookie_data = $this->_serialize($cookie_data);
+		$cookie_data = serialize($cookie_data);
 
 		if ($this->sess_encrypt_cookie === TRUE)
 		{
@@ -732,36 +732,6 @@ class CI_Session_cookie extends CI_Session_driver {
 	protected function _setcookie($name, $value = '', $expire = 0, $path = '', $domain = '', $secure = FALSE, $httponly = FALSE)
 	{
 		setcookie($name, $value, $expire, $path, $domain, $secure, $httponly);
-	}
-
-	// ------------------------------------------------------------------------
-
-	/**
-	 * Serialize an array
-	 *
-	 * This function serializes an array
-	 *
-	 * @param	mixed	Data to serialize
-	 * @return	string	Serialized data
-	 */
-	protected function _serialize($data)
-	{
-		return serialize($data);
-	}
-
-	// ------------------------------------------------------------------------
-
-	/**
-	 * Unserialize
-	 *
-	 * This function unserializes a data string
-	 *
-	 * @param	mixed	Data to unserialize
-	 * @return	mixed	Unserialized data
-	 */
-	protected function _unserialize($data)
-	{
-		return @unserialize(trim($data));
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
After spending some time debugging and researching how session data is serialized and stored, @neldredge and myself have come to the conclusion that this code is unnecessary and should be removed. 

Firstly because it introduces a small bug where the string `{{slash}}` cannot be stored in the session without getting replaced with `\`, but perhaps more importantly because it is confusing.

We cannot see any reason why the code would be needed, and have established a plausible history for how such unnecessary code ended up in the project in the first place. We have explained that history below for the curious:
## History

In the initial import of CodeIgniter into git, session data was stored in the user's cookies. In that day, Magic Quotes would have added slashes to the session cookie value. To balance that, CI stripped slashes from the session data before unserializing it.

https://github.com/EllisLab/CodeIgniter/blob/b0dd10/system/libraries/Session.php#L189

In 2008 @rickellis808, presumably with Magic Quotes turned off, noticed that backslashes in session data were being removed. Not realizing that this was being caused the now unnecessary `strip_slashes()`, he wrote his own solution which replaced backslashes with `{{slash}}` before serializing the session. Now backslashes could slip through the unnecessary `strip_slashes()` without being removed which appeared to fix the problem.

https://github.com/EllisLab/CodeIgniter/commit/c23ed7

In 2011 @blasto333 found a shortcoming in @rickellis808's solution; it only dealt with session values that were strings. Strings in arrays, or multi-dimensional arrays, would not be dealt with. He proposed a solution, spread across a few commits, which applied @rickellis808's fix to arrays as well.
- https://github.com/EllisLab/CodeIgniter/commit/959334
- https://github.com/EllisLab/CodeIgniter/commit/3ad350
- https://github.com/EllisLab/CodeIgniter/commit/3e414f

In 2012, after a slight architectural change which moved the logic into a different file, @narfbg fixed the actual problem which had been there all along. He removed the unnecessary `strip_slashes()`. This removes the need for the workaround provided by @rickellis808 and expanded on by @blasto33

https://github.com/EllisLab/CodeIgniter/commit/ca20d8

Note that the `trim()` was added in a previous commit to address a separate issue. https://github.com/EllisLab/CodeIgniter/commit/6b8312
