### PR TITLE
Store Hooks objects

### DIFF
--- a/system/core/Hooks.php
+++ b/system/core/Hooks.php
@@ -58,7 +58,7 @@ class CI_Hooks {
 	 *
 	 * @var array
 	 */
-	public $class = array();
+	protected $_objects = array();
 
 	/**
 	 * In progress flag
@@ -203,31 +203,29 @@ class CI_Hooks {
 		if ($class !== FALSE)
 		{
 			// The object is stored?
-			if (isset($this->class[$class]) && method_exists($this->class[$class], $function))
+			if (isset($this->_objects[$class]))
 			{
-				$this->class[$class]->$function($params);
+				if (method_exists($this->_objects[$class], $function))
+				{
+					$this->_objects[$class]->$function($params);
+				}
+				else
+				{
+					return $this->_in_progress = FALSE;
+				}
 			}
 			else
-			{	
+			{
 				class_exists($class, FALSE) OR require_once($filepath);
 
 				if ( ! class_exists($class, FALSE) OR ! method_exists($class, $function))
 				{
 					return $this->_in_progress = FALSE;
 				}
-				
-				// If the developer wants the object to be stored
-				if (isset($data['store_object']) && $data['store_object'] === TRUE)
-				{
-					$this->class[$class] = new $class();
-					$HOOK =& $this->class[$class];
-				}
-				else
-				{
-					$HOOK = new $class();
-				}
-				
-				$HOOK->$function($params);
+
+				// Store the object and execute the method
+				$this->_objects[$class] = new $class();
+				$this->_objects[$class]->$function($params);
 			}
 		}
 		else


### PR DESCRIPTION
In some apps I store want the finals hooks (like post_controller or post_system) to execute an action based on the first hooks. So I write a Hook class and set properties to do this, but the CI initializes a new hook object for every call. This edition makes hook objects storable. When I use this definition in the config/hooks.php

``` php
$hook['trigger'] = array(
    'class' => 'class',
    'function' => 'function',
    ...
    'store_object' => TRUE
);
```

The same object will execute all hooks for this class.
