### PR TITLE
cleanup warnings

### DIFF
--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -591,7 +591,7 @@ Bug fixes for 3.0
 -  Fixed a bug (#2380) - :doc:`URI Routing <general/routing>` method ``fetch_method()`` returned 'index' if the requested method name matches its controller name.
 -  Fixed a bug (#2388) - :doc:`Email Library <libraries/email>` used to ignore attachment errors, resulting in broken emails being sent.
 -  Fixed a bug (#2498) - :doc:`Form Validation Library <libraries/form_validation>` rule **valid_base64** only checked characters instead of actual validity.
--  Fixed a bug (#2425) - OCI8 :doc:`database <database>` driver's method ``stored_procedure()`` didn't log an error unless **db_debug** was set to TRUE.
+-  Fixed a bug (#2425) - OCI8 :doc:`database <database/index>` driver's method ``stored_procedure()`` didn't log an error unless **db_debug** was set to TRUE.
 -  Fixed a bug (#2490) - :doc:`Database Class <database/queries>` method ``query()`` returning boolean instead of a result object for PostgreSQL-specific *INSERT INTO ... RETURNING* statements.
 -  Fixed a bug (#249) - :doc:`Cache Library <libraries/caching>` didn't properly handle Memcache(d) configurations with missing options.
 -  Fixed a bug (#180) - :func:`config_item()` didn't take into account run-time configuration changes.

--- a/user_guide_src/source/general/common_functions.rst
+++ b/user_guide_src/source/general/common_functions.rst
@@ -66,7 +66,7 @@ loading any libraries or helpers.
 	to retrieve single keys. See :doc:`Config Library <../libraries/config>`
 	documentation for more information.
 
-.. function:: show_error($message, $status_code, $heading = 'An Error Was Encountered')
+.. :noindex: function:: show_error($message, $status_code, $heading = 'An Error Was Encountered')
 
 	:param	mixed	$message: Error message
 	:param	int	$status_code: HTTP Response status code
@@ -76,7 +76,7 @@ loading any libraries or helpers.
 	This function calls ``CI_Exception::show_error()``. For more info,
 	please see the :doc:`Error Handling <errors>` documentation.
 
-.. function:: show_404($page = '', $log_error = TRUE)
+.. :noindex: function:: show_404($page = '', $log_error = TRUE)
 
 	:param	string	$page: URI string
 	:param	bool	$log_error: Whether to log the error
@@ -85,7 +85,7 @@ loading any libraries or helpers.
 	This function calls ``CI_Exception::show_404()``. For more info,
 	please see the :doc:`Error Handling <errors>` documentation.
 
-.. function:: log_message($level, $message, $php_error = FALSE)
+.. :noindex: function:: log_message($level, $message, $php_error = FALSE)
 
 	:param	string	$level: Log level: 'error', 'debug' or 'info'
 	:param	string	$message: Message to log

--- a/user_guide_src/source/libraries/image_lib.rst
+++ b/user_guide_src/source/libraries/image_lib.rst
@@ -164,7 +164,7 @@ If you prefer not to set preferences using the above method, you can
 instead put them into a config file. Simply create a new file called
 image_lib.php, add the $config array in that file. Then save the file
 in *config/image_lib.php* and it will be used automatically. You will
-NOT need to use the ``$this->image_lib->initialize()``method if you save
+NOT need to use the ``$this->image_lib->initialize()`` method if you save
 your preferences in a config file.
 
 ******************
@@ -330,8 +330,7 @@ Class Reference
 		All preferences listed in the :ref:`processing-preferences` table are available for this
 		method except these three: *rotation_angle*, *x_axis* and *y_axis*.
 
-		Creating a Thumbnail
-		--------------------
+		**Creating a Thumbnail**
 
 		The resizing method will create a thumbnail file (and preserve the
 		original) if you set this preference to TRUE::
@@ -340,8 +339,7 @@ Class Reference
 
 		This single preference determines whether a thumbnail is created or not.
 
-		Creating a Copy
-		---------------
+		**Creating a Copy**
 
 		The resizing method will create a copy of the image file (and preserve
 		the original) if you set a path and/or a new filename using this
@@ -358,8 +356,7 @@ Class Reference
 		-  If both the path and image name are specified it will placed in its
 		   own destination and given the new name.
 
-		Resizing the Original Image
-		---------------------------
+		**Resizing the Original Image**
 
 		If neither of the two preferences listed above (create_thumb, and
 		new_image) are used, the resizing method will instead target the

--- a/user_guide_src/source/libraries/input.rst
+++ b/user_guide_src/source/libraries/input.rst
@@ -215,8 +215,7 @@ Class Reference
 		pass information to this method so that a cookie can be set: Array
 		Method, and Discrete Parameters:
 
-		Array Method
-		^^^^^^^^^^^^
+		**Array Method**
 
 		Using this method, an associative array is passed to the first
 		parameter::
@@ -255,8 +254,7 @@ Class Reference
 		The secure boolean is only needed if you want to make it a secure cookie
 		by setting it to TRUE.
 
-		Discrete Parameters
-		^^^^^^^^^^^^^^^^^^^
+		**Discrete Parameters**
 
 		If you prefer, you can set the cookie by passing data using individual
 		parameters::

--- a/user_guide_src/source/libraries/loader.rst
+++ b/user_guide_src/source/libraries/loader.rst
@@ -116,8 +116,7 @@ Class Reference
 
 			$this->load->library(array('email', 'table'));
 
-		Setting options
-		---------------
+		**Setting options**
 
 		The second (optional) parameter allows you to optionally pass
 		configuration setting. You will typically pass these as an array::
@@ -137,8 +136,7 @@ Class Reference
 		Please take note, when multiple libraries are supplied in an array for
 		the first parameter, each will receive the same parameter information.
 
-		Assigning a Library to a different object name
-		----------------------------------------------
+		**Assigning a Library to a different object name**
 
 		If the third (optional) parameter is blank, the library will usually be
 		assigned to an object with the same name as the library. For example, if
@@ -184,8 +182,7 @@ Class Reference
 
 			$this->load->driver(array('session', 'cache'));
 
-		Setting options
-		---------------
+		**Setting options**
 
 		The second (optional) parameter allows you to optionally pass
 		configuration settings. You will typically pass these as an array::
@@ -202,8 +199,7 @@ Class Reference
 		is explained in detail in its own page, so please read the information
 		regarding each one you would like to use.
 
-		Assigning a Driver to a different object name
-		---------------------------------------------
+		**Assigning a Driver to a different object name**
 
 		If the third (optional) parameter is blank, the library will be assigned
 		to an object with the same name as the parent class. For example, if

--- a/user_guide_src/source/libraries/sessions.rst
+++ b/user_guide_src/source/libraries/sessions.rst
@@ -509,7 +509,6 @@ your config.php file to an array including your driver name::
 
 	$config['sess_valid_drivers'] = array('sess_driver');
 
-
 ***************
 Class Reference
 ***************
@@ -536,7 +535,7 @@ Class Reference
 
 		.. note:: This method should be the last one called, and even flash
 			variables will no longer be available after it is used.
-			 If you only want some items destroyed and not all, use
+			If you only want some items destroyed and not all, use
 			``unset_userdata()``.
 
 	.. method:: sess_regenerate([$destroy = FALSE])

--- a/user_guide_src/source/libraries/table.rst
+++ b/user_guide_src/source/libraries/table.rst
@@ -241,11 +241,11 @@ Class Reference
 		Permits you to set your template. You can submit a full or partial template.
 		::
 
-		$template = array(
-			'table_open'  => '<table border="1" cellpadding="2" cellspacing="1" class="mytable">'
-		);
-
-		$this->table->set_template($template);
+			$template = array(
+				'table_open'  => '<table border="1" cellpadding="2" cellspacing="1" class="mytable">'
+			);
+		
+			$this->table->set_template($template);
 
 	.. method:: set_empty($value)
 

--- a/user_guide_src/source/libraries/trackback.rst
+++ b/user_guide_src/source/libraries/trackback.rst
@@ -8,7 +8,7 @@ receive Trackback data.
 If you are not familiar with Trackbacks you'll find more information
 `here <http://en.wikipedia.org/wiki/Trackback>`_.
 
-.. content::
+.. contents::
   :local:
 
 .. raw:: html
@@ -64,10 +64,11 @@ Description of array data:
 -  **url** - The URL to YOUR site where the weblog entry can be seen.
 -  **title** - The title of your weblog entry.
 -  **excerpt** - The content of your weblog entry.
-   .. note:: the Trackback class will automatically send only the first 500 characters of your
-  	entry. It will also strip all HTML.
 -  **blog_name** - The name of your weblog.
 -  **charset** - The character encoding your weblog is written in. If omitted, UTF-8 will be used.
+
+.. note:: the Trackback class will automatically send only the first 500 characters of your 
+	entry. It will also strip all HTML.
 
 The Trackback sending method returns TRUE/FALSE (boolean) on success
 or failure. If it fails, you can retrieve the error message using::

--- a/user_guide_src/source/libraries/typography.rst
+++ b/user_guide_src/source/libraries/typography.rst
@@ -4,7 +4,7 @@ Typography Class
 
 The Typography Class provides methods that help you format text.
 
-.. content::
+.. contents::
   :local:
 
 .. raw:: html
@@ -35,7 +35,7 @@ Class Reference
 
 	.. attribute:: $protect_braced_quotes = FALSE
 
-		When using the Typography library in conjunction with the :doc:`Template Parser library <../parser>`
+		When using the Typography library in conjunction with the :doc:`Template Parser library <parser>`
 		it can often be desirable to protect single and double quotes within curly braces.
 		To enable this, set the ``protect_braced_quotes`` class property to TRUE.
 

--- a/user_guide_src/source/libraries/xmlrpc.rst
+++ b/user_guide_src/source/libraries/xmlrpc.rst
@@ -551,7 +551,7 @@ Class Reference
 		First parameter is the error number while the second parameter is the error message.
 		::
 
-		return $this->xmlrpc->send_error_message(123, 'Requested data not available');
+			return $this->xmlrpc->send_error_message(123, 'Requested data not available');
 
 	.. method send_response($response)
 


### PR DESCRIPTION
I encountered many errors due to "nested" headers/text (the changes where headers were replaced with `*`). Asterisks don't seem to care how nested they are and work no matter what.

 You can see here an example: http://connortumbleson.com/ci/ci3/libraries/image_lib.html#CI_Image_lib.resize of the sub-headers using asterisks. I don't think it impacts the flow at all.

```
source/libraries/sessions.rst:513: SEVERE: Title level inconsistent:
source/libraries/language.rst:102: SEVERE: Title level inconsistent:
```

Could not fix these two above errors. They are `SEVERE` so the titles are stripped from the HTML, so they do need to be fixed, but since the documentation uses `***` for Class Reference everywhere else it doesn't make sense to use a separate header. I found changing around all the text above (indentation wise) fixed this, but it became a HUGE commit, I'd rather you do it / comment on it.

All other errors are misspellings, poor indentation or bad links.
