### PR TITLE
Don't throw in mock autoloader

### DIFF
--- a/tests/mocks/autoloader.php
+++ b/tests/mocks/autoloader.php
@@ -89,21 +89,7 @@ function autoload($class)
 
 	if ( ! file_exists($file))
 	{
-		$trace = debug_backtrace();
-
-		if ($trace[2]['function'] === 'class_exists' OR $trace[2]['function'] === 'file_exists')
-		{
-			// If the autoload call came from `class_exists` or `file_exists`,
-			// we skipped and return FALSE
-			return FALSE;
-		}
-		elseif (($autoloader = spl_autoload_functions()) && end($autoloader) !== __FUNCTION__)
-		{
-			// If there was other custom autoloader, passed away
-			return FALSE;
-		}
-
-		throw new InvalidArgumentException("Unable to load {$class}.");
+    return FALSE;
 	}
 
 	include_once($file);


### PR DESCRIPTION
This behavior doesn't appear to be used at all.

This fixes HHVM compatibility: HHVM optimizes class_exists() to a
dedicated bytecode - as it's not a function call, it doesn't show up
in the backtrace. 100% of the tests pass with this change.
