### PR TITLE
Enable HHVM on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,10 @@ before_script:
 
 script: phpunit --coverage-text --configuration tests/travis/$DB.phpunit.xml
 
+matrix:
+  allow_failures:
+    - php: hhvm
+
 branches:
   only:
     - develop


### PR DESCRIPTION
Now that #2815 is merged, all tests pass on hhvm (excluding the ones that are also skipped on Zend).
