### PR TITLE
update log.php

### DIFF
--- a/system/core/Log.php
+++ b/system/core/Log.php
@@ -174,8 +174,14 @@ class CI_Log {
 		{
 			return FALSE;
 		}
-
-		$message .= $level.' '.($level === 'INFO' ? ' -' : '-').' '.date($this->_date_fmt).' --> '.$msg."\n";
+		
+		$input = array(
+			'level' => $level,
+			'date' => date($this->_date_fmt),
+			'message' => $msg,
+		);
+		
+		$message .= json_encode($input)."\n";
 
 		flock($fp, LOCK_EX);
 		fwrite($fp, $message);


### PR DESCRIPTION
removed ($level === 'INFO' ? ' -' : '-'). not sure what the point of the space or no space was, seems unnecessary. please correct me if there was a reason.

used `json_encode()` to encode the `$level`, `$date`, and `$message` to make it easier to parse the log file. this way users can extract the text, `explode("\n")`, and then `json_decode()` and get a nice array of the data.

The reason for the change is I have a controller and view to be able to view the log on my Admin backend, rather than open up the files. currently it is difficult (impossible) to do this because of the variable info in `$msg`. json_encode()ing the whole `$message` will make this simple.

this is my first time ever doing a pull request, so if I've messed something up or need more info, please let me know. thanks!
