### PR TITLE
Disable HHVM mysqli and pgsql tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,11 @@ script: phpunit --coverage-text --configuration tests/travis/$DB.phpunit.xml
 matrix:
   allow_failures:
     - php: hhvm
+  exclude:
+    - php: hhvm
+      env: DB=mysqli
+      env: DB=pgsql
+      env: DB=pdo/pgsql
 
 branches:
   only:


### PR DESCRIPTION
mysqli and PostGre support isn't going to be in a good state for a
while.

Sorry, didn't realize in previous pull request that the DB tests weren't run in the default phpunit config.

Fixes for SQLite and MySQL are being merged into HHVM.
