### PR TITLE
add autoload alia function

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -1248,7 +1248,10 @@ class CI_Loader {
 			// Load all other libraries
 			foreach ($autoload['libraries'] as $item)
 			{
-				$this->library($item);
+				$items_pieces = explode(" as ", $item);
+				$item_name = $items_pieces['0'];
+				$item_alia = isset($items_pieces['1']) ? $items_pieces['1'] : NULL;
+				$this->library(trim($item_name), NULL, trim($item_alia));
 			}
 		}
 


### PR DESCRIPTION
Signed-off-by: Louis hotmailgotohell@gmail.com
### What's new

This patch helps developers use library alias in autoload.
### How to do

To use alias in autoload, simply add a " as \* " in the autoload config item.

<code>$autoload['libraries'] = array('my_lib1','my_lib2 as my2');</code>

as you can see in the case, it's totally downward compatibility.
