### PR TITLE
Style guide

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -307,7 +307,7 @@ $config['sess_encrypt_cookie']	= FALSE;
 $config['sess_use_database']	= FALSE;
 $config['sess_table_name']		= 'ci_sessions';
 $config['sess_match_ip']		= FALSE;
-$config['sess_match_useragent']	= FALSE;
+$config['sess_match_useragent']	= TRUE;
 $config['sess_time_to_update']	= 300;
 
 /*
@@ -351,7 +351,7 @@ $config['standardize_newlines'] = TRUE;
 | COOKIE data is encountered
 |
 */
-$config['global_xss_filtering'] = TRUE;
+$config['global_xss_filtering'] = FALSE;
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
Logical Operators
Use of || is discouraged as its clarity on some output devices is low
(looking like the number 11 for instance). && is preferred over AND but
either are acceptable, and a space should always precede and follow !
