### PR TITLE
form_dropdown array as first param fix

### DIFF
--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -311,8 +311,7 @@ if ( ! function_exists('form_dropdown'))
 	 */
 	function form_dropdown($data = '', $options = array(), $selected = array(), $extra = '')
 	{
-		$name = ! is_array($data) ? $data : '';
-		$defaults = array('name' => $name);
+		$defaults = array('name' => is_array($data) ? '' : $data);
 
 		if (is_array($data) && isset($data['selected']))
 		{
@@ -336,11 +335,11 @@ if ( ! function_exists('form_dropdown'))
 
 		is_array($options) OR $options = array($options);
 
-                $extra = _attributes_to_string($extra);
+		$extra = _attributes_to_string($extra);
 
 		$multiple = (count($selected) > 1 && strpos($extra, 'multiple') === FALSE) ? ' multiple="multiple"' : '';
 
-		$form = '<select '.trim(_parse_form_attributes($data, $defaults)).$extra.$multiple.">\n";
+		$form = '<select '.rtrim(_parse_form_attributes($data, $defaults)).$extra.$multiple.">\n";
 
 		foreach ($options as $key => $val)
 		{


### PR DESCRIPTION
Form_dropdown was previously incompatible with most other form_ helper methods. This patch fixes that and now allows arrays to be passed in just as the other functions support:

```
$type_ids = array(1,2,3,4,5)
$dropdown = array(
            'name' => 'product[type_id]',
            'id' => 'product_type_id',
            'class' => 'form-control',
            'selected' => $this->form_validation->set_value('product[type_id]', $product->type_id),
            'options' => $type_ids,
);

echo form_dropdown($dropdown);
```

Will produce:

```
<select name="product[type_id]" id="product_type_id" class="form-control">
    <option value="1">1</option>
    <option value="2">2</option>
    <option value="3">3</option>
    <option value="4">4</option>
    <option value="5">5</option>
</select>
```
