### PR TITLE
Moved $_error load statement lower.

### DIFF
--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -587,9 +587,7 @@ if ( ! function_exists('_exception_handler'))
 		if ($is_error)
 		{
 			set_status_header(500);
-		}
-
-		$_error =& load_class('Exceptions', 'core');
+		}		
 
 		// Should we ignore the error? We'll get the current error_reporting
 		// level and add its bits with the severity bits to find out.
@@ -598,6 +596,7 @@ if ( ! function_exists('_exception_handler'))
 			return;
 		}
 
+		$_error =& load_class('Exceptions', 'core');
 		$_error->log_exception($severity, $message, $filepath, $line);
 
 		// Should we display the error?


### PR DESCRIPTION
This prevents a possible recursion when an error is trigerred by one of the config file.
Also since the variable is used only later in the code it makes sense to move it lower.
