### PR TITLE
Supress ini_set errors.

### DIFF
--- a/index.php
+++ b/index.php
@@ -56,13 +56,13 @@ switch (ENVIRONMENT)
 {
 	case 'development':
 		error_reporting(-1);
-		ini_set('display_errors', 1);
+		@ini_set('display_errors', 1);
 	break;
 
 	case 'testing':
 	case 'production':
 		error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT);
-		ini_set('display_errors', 0);
+		@ini_set('display_errors', 0);
 	break;
 
 	default:


### PR DESCRIPTION
stop showing 'ini_set() is disabled for security reasons' error, if it fails we cannot do anything about it.
