### PR TITLE
Added option to memcached db queries. Also falls back to file caching

### DIFF
--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -342,6 +342,18 @@ abstract class CI_DB_driver {
 	 * @var	string
 	 */
 	protected $_count_string = 'SELECT COUNT(*) AS ';
+	
+	/**
+	 * Flag to make use of Memcached in db-queries
+	 * @var bool
+	 */
+	public $cache_mc	= FALSE;
+	
+	/**
+	 * Lifetime of memcached db queries in seconds
+	 * @var int
+	 */	
+	public $cache_mc_time_sec	= 10;
 
 	// --------------------------------------------------------------------
 


### PR DESCRIPTION
This will use memcached to cache queries.
Can also fallback to file cache.

To enable:
../config/database.php
 $db['foobar']['cache_mc']=TRUE;
 $db['foobar']['cache_mc_time_sec']=10;
