### PR TITLE
Solution to "The action you have requested is not allowed" Error

### DIFF
--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -87,7 +87,7 @@ if ( ! function_exists('form_open'))
 
 		if (is_array($hidden) && count($hidden) > 0)
 		{
-			$form .= form_hidden($hidden);
+			$form .= form_input(array('name' => key($hidden), 'value' => reset($hidden), 'type' => 'hidden', 'style' =>'display:none;'));
 		}
 
 		return $form;


### PR DESCRIPTION
Removing the display:none div surrounding the hidden input of the csrf_protection solved the problem with "The action you have requested is not allowed" which occurs on some devices such as smartphones and tablets.
