### PR TITLE
class_exists before loading model

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -290,8 +290,12 @@ class CI_Loader {
 
 			require_once($mod_path.'models/'.$path.$model.'.php');
 
-			$CI->$name = new $model();
-			$this->_ci_models[] = $name;
+			if (class_exists($model)) {
+				$CI->$name = new $model();
+				$this->_ci_models[] = $name;
+			}else{
+				log_message('Error', 'Model Attachment to CI failed: '.$model);
+			}
 			return $this;
 		}
 


### PR DESCRIPTION
skip attaching model if model could not be found after requiring class file.
useful in case class was under namespace, as it avoid fatal error from unfound class.
Side effect : loading a model file that does not contain a class, will not produce fatal error.
