### PR TITLE
change default uri_protocol configruation

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -60,7 +60,7 @@ $config['index_page'] = 'index.php';
 |--------------------------------------------------------------------------
 |
 | This item determines which server global should be used to retrieve the
-| URI string.  The default setting of 'AUTO' works for most servers.
+| URI string.  The setting of 'REQUEST_URI' works for most servers.
 | If your links do not seem to work, try one of the other delicious flavors:
 |
 | 'AUTO'		Default - auto detects


### PR DESCRIPTION
The default setting of 'AUTO'  doesn't work well on Apache with rewrite_mod.
There is a problem using "PATH_INFO" to _set _uri_string.
https://github.com/EllisLab/CodeIgniter/blob/develop/system/core/URI.php#L106

The default setting of 'AUTO'  works well on CI 2.1.4, because it checks 'REQUEST_URI' first:
https://github.com/EllisLab/CodeIgniter/blob/2.1.4/system/core/URI.php#L97

And I find that there is a simple question on stackoverflow:
http://stackoverflow.com/questions/12483659/htaccess-broke-serverpath-info
