### PR TITLE
fixes warnings

### DIFF
--- a/user_guide_src/source/libraries/form_validation.rst
+++ b/user_guide_src/source/libraries/form_validation.rst
@@ -497,7 +497,7 @@ The above code would use the ``valid_username()`` method from your
 This is just an example of course, and callbacks aren't limited to models.
 You can use any object/method that accepts the field value as its' first
 parameter. Or if you're running PHP 5.3+, you can also use an anonymous
-function:
+function::
 
 	$this->form_validation->set_rules(
 		'username', 'Username',


### PR DESCRIPTION
```
/home/ibotpeaches/Projects/CodeIgniter/user_guide_src/source/libraries/form_validation.rst:505: ERROR: Unexpected indentation.
/home/ibotpeaches/Projects/CodeIgniter/user_guide_src/source/libraries/form_validation.rst:508: ERROR: Unexpected indentation.
/home/ibotpeaches/Projects/CodeIgniter/user_guide_src/source/libraries/form_validation.rst:509: WARNING: Block quote ends without a blank line; unexpected unindent.
/home/ibotpeaches/Projects/CodeIgniter/user_guide_src/source/libraries/form_validation.rst:510: WARNING: Block quote ends without a blank line; unexpected unindent.
/home/ibotpeaches/Projects/CodeIgniter/user_guide_src/source/libraries/form_validation.rst:511: WARNING: Definition list ends without a blank line; unexpected unindent.
```

Fixes that. Smallest change ever!
