### PR TITLE
Added the generate_hashed_string()

### DIFF
--- a/system/core/Security.php
+++ b/system/core/Security.php
@@ -548,6 +548,49 @@ class CI_Security {
 	// --------------------------------------------------------------------
 
 	/**
+	 * Generate hash with random length
+	 *
+	 * A replacement for html_entity_decode()
+	 *
+	 * To help people leave bad practice like storing md5-hashed strings
+	 * as passwords etc, we should provide a simple function for generating
+	 * a slightly better hashed string with random storage length to make it 
+	 * slightly harder to bruteforce.
+	 *
+	 * @param	string	$primary_string		Input
+	 * @param	string	$support_string		Input
+	 * @return	string
+	 */
+
+	public function generate_hashed_string( $primary_string = "", $support_string = "" )
+	{
+		$returnation_string = "";
+		$algorithms = array('sha512', 'haval256,5', 'snefru256', 'tiger192,4');
+		if ( strlen( $primary_string ) < 15 )
+		{
+			$substrlen = substr( str_replace( 0, '', strlen( $primary_string ) * ( strlen( $primary_string ) * 2 ) ), 0, 2 );
+		} else {
+			$substrlen = substr( str_replace( 0, '', strlen( $primary_string ) * 2), 0, 2 );
+		}
+		if ( strlen( $substrlen ) < 2 )
+		{
+			$substrlen = $substrlen . 0;
+		}
+		for ( $i=0;$i<strlen($primary_string);$i++ )
+		{
+			$based = base64_encode($primary_string[$i]);
+			for ( $s=0;$s<strlen($based);$s++ )
+			{
+				$returnation_string .= substr( hash( $algorithms[$s], $based[$s] . $support_string ), $substrlen, $substrlen );
+			}
+		}
+		return substr( $returnation_string, $substrlen, $substrlen );
+	}
+
+
+	// --------------------------------------------------------------------
+
+	/**
 	 * HTML Entities Decode
 	 *
 	 * A replacement for html_entity_decode()

--- a/system/helpers/security_helper.php
+++ b/system/helpers/security_helper.php
@@ -95,6 +95,23 @@ if ( ! function_exists('do_hash'))
 
 // ------------------------------------------------------------------------
 
+if ( ! function_exists('generate_hashed_string'))
+{
+	/**
+	 * Generates a hash, based on four different hash algos, with random length
+	 *
+	 * @param	string	required
+	 * @param	string	a salt string for the hashed string
+	 * @return	string
+	 */
+	function generate_hashed_string( $primary_string = "", $support_string = "salt" )
+	{
+		return get_instance()->security->generate_hashed_string($primary_string, $support_string);
+	}
+}
+
+// ------------------------------------------------------------------------
+
 if ( ! function_exists('strip_image_tags'))
 {
 	/**


### PR DESCRIPTION
Added the generate_hashed_string() function to generate a multi-hashed string with random length. To help people leave bad practice like storing md5-hashed strings as passwords etc, we should provide a simple function for generating a slightly better hashed string with random storage length to make it  slightly harder to bruteforce.
