### PR TITLE
do not create un-needed files.

### DIFF
--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -91,7 +91,8 @@ if ( ! function_exists('is_really_writable'))
 		/* For Windows servers and safe_mode "on" installations we'll actually
 		 * write a file then read it. Bah...
 		 */
-		if( ! is_dir($file) && ! is_file($file) ) {
+		if ( ! is_dir($file) && ! is_file($file) )
+		{
 			return FALSE;
 		}
 		elseif (is_dir($file))


### PR DESCRIPTION
If $file doesn't end with a slash it's considered as a file, 
is_really_writable is creating a new file & leave it there when what you really want is checking if directory is writable.
