### PR TITLE
first_url is documented

### DIFF
--- a/user_guide_src/source/libraries/pagination.rst
+++ b/user_guide_src/source/libraries/pagination.rst
@@ -138,6 +138,11 @@ $config['suffix'] = '';
 A custom suffix added to the path. The sufix value will be right after
 the offset segment.
 
+$config['first_url'] = '';
+=======================
+
+A custom first_url added to the path. First link in pagination normally refer to base url of pagination, we can customize it using this setting. 
+
 ***********************
 Adding Enclosing Markup
 ***********************


### PR DESCRIPTION
$config['first_url'] is documented. First link in pagination losing the url parameters. 
The problem is discussed in [stackoverflow](http://stackoverflow.com/q/5384644/430112), but it's not documented!
