### PR TITLE
Remove default parameter of is_php()

### DIFF
--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -51,14 +51,14 @@ if ( ! function_exists('is_php'))
 	 * @param	string
 	 * @return	bool	TRUE if the current version is $version or higher
 	 */
-	function is_php($version = '5.3.0')
+	function is_php($version)
 	{
 		static $_is_php;
 		$version = (string) $version;
 
 		if ( ! isset($_is_php[$version]))
 		{
-			$_is_php[$version] = (version_compare(PHP_VERSION, $version) >= 0);
+			$_is_php[$version] = version_compare(PHP_VERSION, $version, '>=');
 		}
 
 		return $_is_php[$version];

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -480,6 +480,7 @@ Release Date: Not Released
       -  Added function :func:`function_usable()` to work around a bug in `Suhosin <http://www.hardened-php.net/suhosin/>`.
       -  Removed the third (`$php_error`) argument from function :func:`log_message()`.
       -  Changed internal function ``load_class()`` to accept a constructor parameter instead of (previously unused) class name prefix.
+      -  Removed default parameter value of :func:`is_php()`.
 
    -  :doc:`Output Library <libraries/output>` changes include:
 

--- a/user_guide_src/source/general/common_functions.rst
+++ b/user_guide_src/source/general/common_functions.rst
@@ -13,13 +13,13 @@ loading any libraries or helpers.
 
   <div class="custom-index container"></div>
 
-.. function:: is_php([$version = '5.3.0'])
+.. function:: is_php($version)
 
 	:param	string	$version: Version number
 	:returns:	TRUE if the running PHP version is at least the one specified or FALSE if not
 	:rtype:	bool
 
-	Determines of the PHP version being used is greater than the
+	Determines if the PHP version being used is greater than the
 	supplied version number.
 
 	Example::


### PR DESCRIPTION
It was simply pointless.

I know it's the bigger PHP 5 update, but why 5.3 in particular? Why not the minimum supported version, 5.2.4? For the record, previous value was 5.0. We could put 5.3.3, it has interesting fixes. Hey, let's put 5.4 as it's the lowest active branch. Ummm no, let's rather put the edgy 5.5.

And imagine this in code:

```
// here we compare against some magical version which could change at any time.
// and no, we won't tell which one it is, go find it yourself. ha ha.
is_php();
```
