### PR TITLE
Fix - Preventing an infinite recursion

### DIFF
--- a/system/libraries/Ftp.php
+++ b/system/libraries/Ftp.php
@@ -479,7 +479,11 @@ class CI_FTP {
 				// so we'll recursively call delete_dir()
 				if ( ! @ftp_delete($this->conn_id, $list[$i]))
 				{
-					$this->delete_dir($list[$i]);
+					// don't recurse into current of parent directory
+					if ( ! preg_match('/\/\.\.|\/\.$/', $list[$i]))
+					{
+						$this->delete_dir($list[$i]);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
When the recursive method list the files to make sure that the folder is empty (list_files), the delete_dir list again the self dir and the parent, and recursion is generated.

Logging

``` php
public function delete_dir($filepath)
{
  Logger::log('Deleting $item: ' . $filepath);
  ...
  $list = $this->list_files($filepath);
  if ( ! empty($list)) {
    for ($i = 0, $c = count($list); $i < $c; $i++) {
      Logger::log('Deleting $item: ' . $list[$i]);
      ...
    ...
  ...
```

Output:

```
[2014-04-08 11:07:37] logger.INFO: Deleting $item: /folder/.. [] []
[2014-04-08 11:07:37] logger.INFO: Deleting $item: /folder/.. [] []
[2014-04-08 11:07:37] logger.INFO: Deleting $item: /folder [] []
[2014-04-08 11:07:37] logger.INFO: Deleting $item: /folder [] []
[2014-04-08 11:07:37] logger.INFO: Deleting $item: /folder/.. [] []
[2014-04-08 11:07:37] logger.INFO: Deleting $item: /folder/.. [] []
[2014-04-08 11:07:37] logger.INFO: Deleting $item: /folder [] []
[2014-04-08 11:07:37] logger.INFO: Deleting $item: /folder [] []
[2014-04-08 11:07:37] logger.INFO: Deleting $item: /folder/.. [] []
[2014-04-08 11:07:37] logger.INFO: Deleting $item: /folder/.. [] []
[2014-04-08 11:07:37] logger.INFO: Deleting $item: /folder [] []
[2014-04-08 11:07:37] logger.INFO: Deleting $item: /folder [] []
[2014-04-08 11:07:37] logger.INFO: Deleting $item: /folder/.. [] []
[2014-04-08 11:07:37] logger.INFO: Deleting $item: /folder/.. [] []
[2014-04-08 11:07:37] logger.INFO: Deleting $item: /folder [] []
```

Already patched in https://github.com/fuel/core/pull/1673
