### PR TITLE
Add auto-detection capabilities to the Lang class

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -87,15 +87,39 @@ $config['url_suffix'] = '';
 
 /*
 |--------------------------------------------------------------------------
-| Default Language
+| Supported Languages
 |--------------------------------------------------------------------------
 |
-| This determines which set of language files should be used. Make sure
-| there is an available translation if you intend to use something other
-| than english.
+| This determines which languages are supported. The first one in the list
+| will be used by default.
+| Note that the automatic detection mechanism need those to be IETF
+| Language Tags (RFC 5646) (e.g. 'en-US'), but you can provide an alternate
+| language directory name if they don't match (see below).
 |
+| Make sure CodeIgniter's system translations are available if you intend
+| to use something other than english.
+|
+| Recognized syntaxes:
+| $config['language']	= 'english'; // Compat-only, prefer IETF tags
+| $config['language']	= array(
+|   'en-us' => 'english',
+|   'fr-fr',
+| );
 */
-$config['language']	= 'english';
+$config['language'] = 'english';
+
+/*
+|--------------------------------------------------------------------------
+| Language Storage
+|--------------------------------------------------------------------------
+|
+| This determines the field name that CodeIgniter will use to find the
+| user's selected language. The default order is $_POST, $_GET, $_SESSION,
+| and ultimately the client's HTTP Accept-Language header.
+| The selected language code will be stored back in the session under that
+| key.
+*/
+$config['language_key'] = 'lang';
 
 /*
 |--------------------------------------------------------------------------

--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -1221,12 +1221,12 @@ class CI_Loader {
 			}
 		}
 
-		// Autoload helpers and languages
-		foreach (array('helper', 'language') as $type)
+		// Autoload helpers
+		if (count($autoload['helper']) > 0)
 		{
-			if (isset($autoload[$type]) && count($autoload[$type]) > 0)
+			foreach ($autoload['helper'] as $item)
 			{
-				$this->$type($autoload[$type]);
+				$this->helper($item);
 			}
 		}
 
@@ -1253,6 +1253,15 @@ class CI_Loader {
 			foreach ($autoload['libraries'] as $item)
 			{
 				$this->library($item);
+			}
+		}
+
+		// Autoload language files
+		if (count($autoload['language']) > 0)
+		{
+			foreach ($autoload['language'] as $item)
+			{
+				$this->language($item);
 			}
 		}
 


### PR DESCRIPTION
This adds :
- a list of supported languages, trying to be backward-compatible with the existing configuration variable.
- a way to get the currently selected language & supported language list from the API.
- the capability to auto-detect the language based on the client's settings (whitelisted through the supported list).

Signed-off-by: Etienne Samson samson.etienne@gmail.com
