### PR TITLE
Fix db(pgsql) conn_id false cause pg_escape_string() param error during ...

### DIFF
--- a/system/database/drivers/postgre/postgre_driver.php
+++ b/system/database/drivers/postgre/postgre_driver.php
@@ -319,6 +319,7 @@ class CI_DB_postgre_driver extends CI_DB {
 	 */
 	protected function _escape_str($str)
 	{
+		$this->conn_id OR $this->initialize();
 		return pg_escape_string($this->conn_id, $str);
 	}
 


### PR DESCRIPTION
Fix db(pgsql) conn_id false cause pg_escape_string() param error during autoinit set FALSE

log: pg_escape_string() expects parameter 1 to be resource, boolean given
