### PR TITLE
Removed @ symbols from the connection calls.

### DIFF
--- a/system/database/drivers/mysql/mysql_driver.php
+++ b/system/database/drivers/mysql/mysql_driver.php
@@ -120,8 +120,8 @@ class CI_DB_mysql_driver extends CI_DB {
 		}
 
 		$this->conn_id = ($persistent === TRUE)
-			? @mysql_pconnect($this->hostname, $this->username, $this->password, $client_flags)
-			: @mysql_connect($this->hostname, $this->username, $this->password, TRUE, $client_flags);
+			? mysql_pconnect($this->hostname, $this->username, $this->password, $client_flags)
+			: mysql_connect($this->hostname, $this->username, $this->password, TRUE, $client_flags);
 
 		// ----------------------------------------------------------------
 


### PR DESCRIPTION
This can cause massive confusion when trying to diagnose issues as it did for me. Try not having php-mysql installed and you'll see why it's a problem.

Other connection issues could occur that are fatal etc.

Please see http://www.phptherightway.com/#errors for reasons on why the @ symbol is a bad idea.
