### PR TITLE
Added `_trans_failure` property to fix PHP Warning.

### DIFF
--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -261,6 +261,15 @@ abstract class CI_DB_driver {
 	protected $_trans_status	= TRUE;
 
 	/**
+	 * Transaction failure flag
+	 *
+	 * Used with transactions to determine if a transaction has failed.
+	 *
+	 * @var	bool
+	 */
+	protected $_trans_failure	= FALSE;
+
+	/**
 	 * Cache On flag
 	 *
 	 * @var	bool


### PR DESCRIPTION
When using transaction with trans_complete(), was generating a PHP error Undefined Property. This fixes that warning. I use mysqli driver, if it matters.
