### PR TITLE
xss_clean is not protecting GET requests that &item=/startwithslash

### DIFF
--- a/system/core/Security.php
+++ b/system/core/Security.php
@@ -862,7 +862,7 @@ class CI_Security {
 		 */
 
 		// 901119URL5918AMP18930PROTECT8198
-		$str = preg_replace('|\&([a-z\_0-9\-]+)\=([a-z\_0-9\-]+)|i', $this->xss_hash().'\\1=\\2', $str);
+		$str = preg_replace('|\&([a-z\_0-9\-]+)\=([a-z\_0-9\-/]+)|i', $this->xss_hash().'\\1=\\2', $str);
 
 		/*
 		 * Validate standard character entities


### PR DESCRIPTION
/webacd.do?isurlact=true&entactname=/webacd.do
becomes
/webacd.do?isurlact=true&entactname;=/webacd.do

This commit adds / to the regex to it will escape those GET requests

related to issue #3030
