### PR TITLE
Added support for Symbian OS platforms to recognize Nokia devices

### DIFF
--- a/application/config/user_agents.php
+++ b/application/config/user_agents.php
@@ -76,7 +76,8 @@ $platforms = array(
 	'bsdi'				=> 'BSDi',
 	'openbsd'			=> 'OpenBSD',
 	'gnu'				=> 'GNU/Linux',
-	'unix'				=> 'Unknown Unix OS'
+	'unix'				=> 'Unknown Unix OS',
+	'symbian' 			=> 'Symbian OS'
 );
 
 


### PR DESCRIPTION
User_agent class cannot recognize Nokia devices using Symbian OS returning the value Unknown Platform by adding these line it can be possible.

One of Agents string  tested:
Mozilla/5.0 (SymbianOS/9.4; U; Series60/5.0 Nokia5235-1d/12.8.092; Profile/MIDP-2.1 Configuration/CLDC-1.1 ) AppleWebKit/413 (KHTML, like Gecko) Safari/413
