### PR TITLE
Simplify code in get_config()

### DIFF
--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -226,9 +226,9 @@ if ( ! function_exists('get_config'))
 	 */
 	function &get_config(Array $replace = array())
 	{
-		static $_config;
+		static $config;
 
-		if (empty($_config))
+		if (empty($config))
 		{
 			$file_path = APPPATH.'config/config.php';
 			$found = FALSE;
@@ -257,18 +257,15 @@ if ( ! function_exists('get_config'))
 				echo 'Your config file does not appear to be formatted correctly.';
 				exit(3); // EXIT_CONFIG
 			}
-
-			// references cannot be directly assigned to static variables, so we use an array
-			$_config[0] =& $config;
 		}
 
 		// Are any values being dynamically added or replaced?
 		foreach ($replace as $key => $val)
 		{
-			$_config[0][$key] = $val;
+			$config[$key] = $val;
 		}
 
-		return $_config[0];
+		return $config;
 	}
 }
 


### PR DESCRIPTION
Exact same behavior. The reference was just redundant.
