### PR TITLE
fix calling of callable hooks

### DIFF
--- a/system/core/Hooks.php
+++ b/system/core/Hooks.php
@@ -127,7 +127,7 @@ class CI_Hooks {
 			return FALSE;
 		}
 
-		if (is_array($this->hooks[$which]) && isset($this->hooks[$which][0]) && is_array($this->hooks[$which][0]))
+		if (is_array($this->hooks[$which]))
 		{
 			foreach ($this->hooks[$which] as $val)
 			{


### PR DESCRIPTION
If callable hook is defined, we have such error:
"Fatal error: Cannot use object of type Closure as array in ...system\core\Hooks.php on line 130"
because, if callable hook is function, [0] has no sense.

I propose in "call_hook" function just check, either hook is array, or not an array, and then pass data to "_run_hook", which do all other necesssary checks and run hook.
