### PR TITLE
Always Print CSRF token with form_open() unless `get` method

### DIFF
--- a/system/core/Security.php
+++ b/system/core/Security.php
@@ -157,31 +157,33 @@ class CI_Security {
 	 */
 	public function __construct()
 	{
-		// Is CSRF protection enabled?
-		if (config_item('csrf_protection') === TRUE)
+		// CSRF config
+		foreach (array('csrf_expire', 'csrf_token_name', 'csrf_cookie_name') as $key)
 		{
-			// CSRF config
-			foreach (array('csrf_expire', 'csrf_token_name', 'csrf_cookie_name') as $key)
+			if (FALSE !== ($val = config_item($key)))
 			{
-				if (FALSE !== ($val = config_item($key)))
-				{
-					$this->{'_'.$key} = $val;
-				}
+				$this->{'_'.$key} = $val;
 			}
-
-			// Append application specific cookie prefix
-			if (config_item('cookie_prefix'))
-			{
-				$this->_csrf_cookie_name = config_item('cookie_prefix').$this->_csrf_cookie_name;
-			}
-
-			// Set the CSRF hash
-			$this->_csrf_set_hash();
 		}
+
+		// Append application specific cookie prefix
+		if (config_item('cookie_prefix'))
+		{
+			$this->_csrf_cookie_name = config_item('cookie_prefix').$this->_csrf_cookie_name;
+		}
+
+		// Set the CSRF hash
+		$this->_csrf_set_hash();
 
 		$this->charset = strtoupper(config_item('charset'));
 
 		log_message('debug', 'Security Class Initialized');
+
+		// Is CSRF protection enabled? Verify it
+		if (config_item('csrf_protection') === TRUE)
+		{
+			$this->csrf_verify();
+		}
 	}
 
 	// --------------------------------------------------------------------

--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -79,8 +79,8 @@ if ( ! function_exists('form_open'))
 
 		$form = '<form action="'.$action.'"'.$attributes.">\n";
 
-		// Add CSRF field if enabled, but leave it out for GET requests and requests to external websites
-		if ($CI->config->item('csrf_protection') === TRUE && strpos($action, $CI->config->base_url()) !== FALSE && ! stripos($form, 'method="get"'))
+		// Add CSRF field, but leave it out for GET requests and requests to external websites
+		if (strpos($action, $CI->config->base_url()) !== FALSE && ! stripos($form, 'method="get"'))
 		{
 			$hidden[$CI->security->get_csrf_token_name()] = $CI->security->get_csrf_hash();
 		}

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -106,6 +106,7 @@ Release Date: Not Released
 
       - :func:`form_dropdown()` will now also take an array for unity with other form helpers.
       - :func:`form_prep()`'s second argument now only accepts a boolean value, which determines whether the value is escaped for a <textarea> or a regular <input> element.
+      - :func:`form_open()` will now always add the csrf token if the form's method attribute is not `get`.
 
    -  :doc:`Security Helper <helpers/security_helper>` changes include:
 
@@ -503,6 +504,7 @@ Release Date: Not Released
       -  Added ``$config['csrf_regeneration']``, which makes token regeneration optional.
       -  Added ``$config['csrf_exclude_uris']``, which allows you list URIs which will not have the CSRF validation methods run.
       -  Modified method ``sanitize_filename()`` to read a public ``$filename_bad_chars`` property for getting the invalid characters list.
+      -  Modified the ``__construct()``, as csrf token will now always be set on class load.
 
    -  :doc:`Language Library <libraries/language>` changes include:
 


### PR DESCRIPTION
I prefer to do csrf verification inside my controller / method with `$this->security->csrf_verify()`. Reason, while setting the non-csrf uris in `csrf_exclude_uris` works, placing in the controller/method gives me better idea on what the controller / method doing, plus I can set more precisely where I want to check for CSRF incase I dont want all $_POST requests to check with CSRF.

So mainly I'm doing csrf verification when required instead of global csrf checking.

This PR is Backward Compatible, so if `csrf_protection` is set to TRUE, it will work like expected.
