### PR TITLE
A fix about loading language files - ensuring suffix '_lang' presence properly.

### DIFF
--- a/system/core/Lang.php
+++ b/system/core/Lang.php
@@ -80,7 +80,7 @@ class CI_Lang {
 
 		if ($add_suffix === TRUE)
 		{
-			$langfile = str_replace('_lang', '', $langfile).'_lang';
+			$langfile = preg_replace('/_lang$/', '', $langfile).'_lang';
 		}
 
 		$langfile .= '.php';


### PR DESCRIPTION
I have language files with the funny name 'spoken_languages_lang.php'. Due to using str_preplace() function, when the suffix '_lang' is to be ensured, loading files with names that contain the substring '_lang' in arbitrary place (and not at the end) fails.
