### PR TITLE
Update pdo_forge.php line 163

### DIFF
--- a/system/database/drivers/pdo/pdo_forge.php
+++ b/system/database/drivers/pdo/pdo_forge.php
@@ -160,7 +160,7 @@ class CI_DB_pdo_forge extends CI_DB_forge {
 					$key = array($this->db->_protect_identifiers($key));
 				}
 
-				$sql .= ",\n\tFOREIGN KEY (" . implode(', ', $key) . ")";
+				$sql .= ",\n\tKEY (" . implode(', ', $key) . ")";
 			}
 		}
 


### PR DESCRIPTION
When i use
"$this->dbforge->add_key('abc')"
it will produce
"FOREIGN KEY (abc)"
i think it should be
"KEY (abc)"
