### PR TITLE
Allow optional auto-loading of composer packages.

### DIFF
--- a/index.php
+++ b/index.php
@@ -264,6 +264,8 @@ switch (ENVIRONMENT)
 
 	define('VIEWPATH', $view_folder);
 
+	@include_once 'vendor/autoload.php';
+
 /*
  * --------------------------------------------------------------------
  * LOAD THE BOOTSTRAP FILE


### PR DESCRIPTION
prefixed with @ so that CI doesn't complaint when the `vendor`/autoload.php` doesn't exist.
