### PR TITLE
Removed double quotation for Content-Type

### DIFF
--- a/system/helpers/download_helper.php
+++ b/system/helpers/download_helper.php
@@ -102,6 +102,5 @@ if ( ! function_exists('force_download'))
 	}
 }
 
-
 /* End of file download_helper.php */
 /* Location: ./system/helpers/download_helper.php */


### PR DESCRIPTION
There is no need to use double quotation when sending the MIME type through the `Content-Type` header. Chrome will accept either way but Firefox will fail under certain circumstances.
