### PR TITLE
Update inflector_helper.php

### DIFF
--- a/system/helpers/inflector_helper.php
+++ b/system/helpers/inflector_helper.php
@@ -84,6 +84,7 @@ if ( ! function_exists('singular'))
 			'/(s)tatuses$/'		=> '\1\2tatus',
 			'/(c)hildren$/'		=> '\1\2hild',
 			'/(n)ews$/'		=> '\1\2ews',
+			'/(acc|succ)ess$'	=> '\1\2ess',
 			'/([^us])s$/'		=> '\1'
 		);
 


### PR DESCRIPTION
Inflector incorrectly removes last 's' in access despite being singular giving the false value of 'acces'. This fix worked, may need refining?
