### PR TITLE
optimization cipher noise

### DIFF
--- a/system/libraries/Encrypt.php
+++ b/system/libraries/Encrypt.php
@@ -328,14 +328,9 @@ class CI_Encrypt {
 		$key = $this->hash($key);
 		$str = '';
 
-		for ($i = 0, $j = 0, $ld = strlen($data), $lk = strlen($key); $i < $ld; ++$i, ++$j)
+		for ($i = 0, $j = 0, $ld = strlen($data), $lk = strlen($key); $i < $ld; ++$i)
 		{
-			if ($j >= $lk)
-			{
-				$j = 0;
-			}
-
-			$str .= chr((ord($data[$i]) + ord($key[$j])) % 256);
+			$str .= chr((ord($data[$i]) + ord($key[$j%$lk])) % 256);
 		}
 
 		return $str;
@@ -360,12 +355,7 @@ class CI_Encrypt {
 
 		for ($i = 0, $j = 0, $ld = strlen($data), $lk = strlen($key); $i < $ld; ++$i, ++$j)
 		{
-			if ($j >= $lk)
-			{
-				$j = 0;
-			}
-
-			$temp = ord($data[$i]) - ord($key[$j]);
+			$temp = ord($data[$i]) - ord($key[$j%$lk]);
 
 			if ($temp < 0)
 			{


### PR DESCRIPTION
I found an optimization for the function _remove_cipher_noise and _add_cipher_noise. We don't need to create an another variable $j and check if it's greater than the lenght of $data.

Just use the modulo.
