### PR TITLE
Pagination class: Retrieving LIMIT variables

### DIFF
--- a/system/libraries/Pagination.php
+++ b/system/libraries/Pagination.php
@@ -670,6 +670,26 @@ class CI_Pagination {
 		return '';
 	}
 
+	/**
+	 * Get LIMIT offset for ActiveRecord use
+	 *
+	 * @access	public
+	 * @return	int
+	 */
+	public function get_limit_offset() {
+		return ($this->cur_page-1) * $this->per_page;
+	}
+
+	/**
+	 * Get LIMIT row count for ActiveRecord use
+	 *
+	 * @access	public
+	 * @return	int
+	 */
+	public function get_limit_count() {
+		return $this->per_page;
+	}
+
 }
 
 /* End of file Pagination.php */


### PR DESCRIPTION
I needed an easy way to calculate LIMIT offset and row count as need by ActiveRecord.

Here are two new functions (get_limit_offset and get_limit_count) integrated into the pagination library which return this informations.
