### PR TITLE
Change name didn't work if reset initialization it's true

### DIFF
--- a/system/libraries/Upload.php
+++ b/system/libraries/Upload.php
@@ -327,7 +327,9 @@ class CI_Upload {
 					$this->$key = $defaults[$key];
 				}
 			}
-
+			// if a file_name was provided in the config, use it instead of the user input
+			// supplied file name for all uploads until initialized again
+			$this->_file_name_override = $this->file_name;
 			return $this;
 		}
 


### PR DESCRIPTION
If user initializes the upload library with the reset flag as true, the uploaded file wasn't changed, so I have added the same lines from #350 into the return where the reset flag it's setted to TRUE.
