### PR TITLE
Change name didn't work if reset initialization it's true

### DIFF
--- a/system/libraries/Upload.php
+++ b/system/libraries/Upload.php
@@ -327,23 +327,26 @@ class CI_Upload {
 					$this->$key = $defaults[$key];
 				}
 			}
-
-			return $this;
+		
 		}
-
-		foreach ($config as $key => &$value)
+		else
 		{
-			if ($key[0] !== '_' && $reflection->hasProperty($key))
+			
+			foreach ($config as $key => &$value)
 			{
-				if ($reflection->hasMethod('set_'.$key))
+				if ($key[0] !== '_' && $reflection->hasProperty($key))
 				{
-					$this->{'set_'.$key}($value);
-				}
-				else
-				{
-					$this->$key = $value;
+					if ($reflection->hasMethod('set_'.$key))
+					{
+						$this->{'set_'.$key}($value);
+					}
+					else
+					{
+						$this->$key = $value;
+					}
 				}
 			}
+			
 		}
 
 		// if a file_name was provided in the config, use it instead of the user input


### PR DESCRIPTION
If user initializes the upload library with the reset flag as true, the
uploaded file doesn't change it's name, it's neccesary to initialize or
change the $_file_name_override every time.
