### PR TITLE
Add Array Capability for Cache_redis.php

### DIFF
--- a/system/libraries/Cache/drivers/Cache_redis.php
+++ b/system/libraries/Cache/drivers/Cache_redis.php
@@ -16,12 +16,12 @@
  * through the world wide web, please send an email to
  * licensing@ellislab.com so we can send you a copy immediately.
  *
- * @package		CodeIgniter
- * @author		EllisLab Dev Team
- * @copyright	Copyright (c) 2008 - 2014, EllisLab, Inc. (http://ellislab.com/)
- * @license		http://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- * @link		http://codeigniter.com
- * @since		Version 3.0
+ * @package     CodeIgniter
+ * @author      EllisLab Dev Team
+ * @copyright   Copyright (c) 2008 - 2014, EllisLab, Inc. (http://ellislab.com/)
+ * @license     http://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * @link        http://codeigniter.com
+ * @since       Version 3.0
  * @filesource
  */
 defined('BASEPATH') OR exit('No direct script access allowed');
@@ -29,267 +29,296 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 /**
  * CodeIgniter Redis Caching Class
  *
- * @package	   CodeIgniter
+ * @package    CodeIgniter
  * @subpackage Libraries
  * @category   Core
- * @author	   Anton Lindqvist <anton@qvister.se>
+ * @author     Anton Lindqvist <anton@qvister.se>
  * @link
  */
 class CI_Cache_redis extends CI_Driver
 {
-	/** const postfix for serialized data recognition */
-	const SERIALIZE_POSTFIX = '__serialized__';
-	
-	/**
-	 * Default config
-	 *
-	 * @static
-	 * @var	array
-	 */
-	protected static $_default_config = array(
-		'socket_type' => 'tcp',
-		'host' => '127.0.0.1',
-		'password' => NULL,
-		'port' => 6379,
-		'timeout' => 0
-	);
+    /**
+     * A key-suffix for distinguishing serialized values.
+     */
+    const KEY_SUFFIX_FOR_SERIALIZATION = '_ci_driver_serialized';
 
-	/**
-	 * Redis connection
-	 *
-	 * @var	Redis
-	 */
-	protected $_redis;
+    /**
+     * Default config
+     *
+     * @static
+     * @var array
+     */
+    protected static $_default_config = array(
+        'socket_type' => 'tcp',
+        'host' => '127.0.0.1',
+        'password' => NULL,
+        'port' => 6379,
+        'timeout' => 0
+    );
 
-	// ------------------------------------------------------------------------
+    /**
+     * Redis connection
+     *
+     * @var Redis
+     */
+    protected $_redis;
 
-	/**
-	 * Get cache
-	 *
-	 * @param	string	Cache ID
-	 * @return	mixed
-	 */
-	public function get($key)
-	{
-		$data = $this->_redis->get($key);
-		if($data === FALSE) {
-			$data = $this->_redis->get($key.self::SERIALIZE_POSTFIX);
-			$data = ($data === FALSE)? FALSE : unserialize($data);
-		}
-		return $data;
-	}
+    // ------------------------------------------------------------------------
 
-	// ------------------------------------------------------------------------
+    /**
+     * Get cache
+     *
+     * @param   string  Cache ID
+     * @return  mixed
+     */
+    public function get($key)
+    {
+        $value = $this->_redis->get($key);
 
-	/**
-	 * Save cache
-	 *
-	 * @param	string	$id	Cache ID
-	 * @param	mixed	$data	Data to save
-	 * @param	int	$ttl	Time to live in seconds
-	 * @param	bool	$raw	Whether to store the raw value (unused)
-	 * @return	bool	TRUE on success, FALSE on failure
-	 */
-	public function save($id, $data, $ttl = 60, $raw = FALSE)
-	{
-		if(is_array($data) || is_object($data)) {
-			$this->_redis->delete($id);
-			$data = serialize($data);
-			$id .= self::SERIALIZE_POSTFIX;
-		} else {
-			$this->_redis->delete($id.self::SERIALIZE_POSTFIX);
-		}
-		return ($ttl)
-			? $this->_redis->setex($id, $ttl, $data)
-			: $this->_redis->set($id, $data);
-	}
+        if ($value === FALSE)
+        {
+            $value = $this->_redis->get($key.self::KEY_SUFFIX_FOR_SERIALIZATION);
+            $value = $value === FALSE ? FALSE : unserialize($value);
+        }
 
-	// ------------------------------------------------------------------------
+        return $value;
+    }
 
-	/**
-	 * Delete from cache
-	 *
-	 * @param	string	Cache key
-	 * @return	bool
-	 */
-	public function delete($key)
-	{
-		return ($this->_redis->delete($key) === 1);
-	}
+    // ------------------------------------------------------------------------
 
-	// ------------------------------------------------------------------------
+    /**
+     * Save cache
+     *
+     * @param   string  $id Cache ID
+     * @param   mixed   $data   Data to save
+     * @param   int $ttl    Time to live in seconds
+     * @param   bool    $raw    Whether to store the raw value (unused)
+     * @return  bool    TRUE on success, FALSE on failure
+     */
+    public function save($id, $data, $ttl = 60, $raw = FALSE)
+    {
+        if (is_array($data) || is_object($data))
+        {
+            $this->_redis->delete($id);
 
-	/**
-	 * Increment a raw value
-	 *
-	 * @param	string	$id	Cache ID
-	 * @param	int	$offset	Step/value to add
-	 * @return	mixed	New value on success or FALSE on failure
-	 */
-	public function increment($id, $offset = 1)
-	{
-		return $this->_redis->incr($id, $offset);
-	}
+            $data = serialize($data);
+            $id .= self::KEY_SUFFIX_FOR_SERIALIZATION;
+        }
 
-	// ------------------------------------------------------------------------
+        return ($ttl)
+            ? $this->_redis->setex($id, $ttl, $data)
+            : $this->_redis->set($id, $data);
+    }
 
-	/**
-	 * Decrement a raw value
-	 *
-	 * @param	string	$id	Cache ID
-	 * @param	int	$offset	Step/value to reduce by
-	 * @return	mixed	New value on success or FALSE on failure
-	 */
-	public function decrement($id, $offset = 1)
-	{
-		return $this->_redis->decr($id, $offset);
-	}
+    // ------------------------------------------------------------------------
 
-	// ------------------------------------------------------------------------
+    /**
+     * Delete from cache
+     *
+     * @param   string  Cache key
+     * @return  bool
+     */
+    public function delete($key)
+    {
+        if ($this->_redis->delete($key) === 1)
+        {
+            return TRUE;
+        }
 
-	/**
-	 * Clean cache
-	 *
-	 * @return	bool
-	 * @see		Redis::flushDB()
-	 */
-	public function clean()
-	{
-		return $this->_redis->flushDB();
-	}
+        return ($this->_redis->delete($key.self::KEY_SUFFIX_FOR_SERIALIZATION) === 1);
+    }
 
-	// ------------------------------------------------------------------------
+    // ------------------------------------------------------------------------
 
-	/**
-	 * Get cache driver info
-	 *
-	 * @param	string	Not supported in Redis.
-	 *			Only included in order to offer a
-	 *			consistent cache API.
-	 * @return	array
-	 * @see		Redis::info()
-	 */
-	public function cache_info($type = NULL)
-	{
-		return $this->_redis->info();
-	}
+    /**
+     * Increment a raw value
+     *
+     * @param   string  $id Cache ID
+     * @param   int $offset Step/value to add
+     * @return  mixed   New value on success or FALSE on failure
+     */
+    public function increment($id, $offset = 1)
+    {
+        if ($this->_redis->exists($id.self::KEY_SUFFIX_FOR_SERIALIZATION))
+        {
+            return FALSE;
+        }
 
-	// ------------------------------------------------------------------------
+        return $this->_redis->incr($id, $offset);
+    }
 
-	/**
-	 * Get cache metadata
-	 *
-	 * @param	string	Cache key
-	 * @return	array
-	 */
-	public function get_metadata($key)
-	{
-		$value = $this->get($key);
+    // ------------------------------------------------------------------------
 
-		if ($value)
-		{
-			return array(
-				'expire' => time() + $this->_redis->ttl($key),
-				'data' => $value
-			);
-		}
+    /**
+     * Decrement a raw value
+     *
+     * @param   string  $id Cache ID
+     * @param   int $offset Step/value to reduce by
+     * @return  mixed   New value on success or FALSE on failure
+     */
+    public function decrement($id, $offset = 1)
+    {
+        if ($this->_redis->exists($id.self::KEY_SUFFIX_FOR_SERIALIZATION))
+        {
+            return FALSE;
+        }
 
-		return FALSE;
-	}
+        return $this->_redis->decr($id, $offset);
+    }
 
-	// ------------------------------------------------------------------------
+    // ------------------------------------------------------------------------
 
-	/**
-	 * Check if Redis driver is supported
-	 *
-	 * @return	bool
-	 */
-	public function is_supported()
-	{
-		if (extension_loaded('redis'))
-		{
-			return $this->_setup_redis();
-		}
-		else
-		{
-			log_message('debug', 'The Redis extension must be loaded to use Redis cache.');
-			return FALSE;
-		}
-	}
+    /**
+     * Clean cache
+     *
+     * @return  bool
+     * @see     Redis::flushDB()
+     */
+    public function clean()
+    {
+        return $this->_redis->flushDB();
+    }
 
-	// ------------------------------------------------------------------------
+    // ------------------------------------------------------------------------
 
-	/**
-	 * Setup Redis config and connection
-	 *
-	 * Loads Redis config file if present. Will halt execution
-	 * if a Redis connection can't be established.
-	 *
-	 * @return	bool
-	 * @see		Redis::connect()
-	 */
-	protected function _setup_redis()
-	{
-		$config = array();
-		$CI =& get_instance();
+    /**
+     * Get cache driver info
+     *
+     * @param   string  Not supported in Redis.
+     *          Only included in order to offer a
+     *          consistent cache API.
+     * @return  array
+     * @see     Redis::info()
+     */
+    public function cache_info($type = NULL)
+    {
+        return $this->_redis->info();
+    }
 
-		if ($CI->config->load('redis', TRUE, TRUE))
-		{
-			$config += $CI->config->item('redis');
-		}
+    // ------------------------------------------------------------------------
 
-		$config = array_merge(self::$_default_config, $config);
+    /**
+     * Get cache metadata
+     *
+     * @param   string  Cache key
+     * @return  array
+     */
+    public function get_metadata($key)
+    {
+        $value = $this->_redis->get($key);
 
-		$this->_redis = new Redis();
+        if ($value === FALSE)
+        {
+            $key .= self::KEY_SUFFIX_FOR_SERIALIZATION;
+            $value = $this->_redis->get($key);
 
-		try
-		{
-			if ($config['socket_type'] === 'unix')
-			{
-				$success = $this->_redis->connect($config['socket']);
-			}
-			else // tcp socket
-			{
-				$success = $this->_redis->connect($config['host'], $config['port'], $config['timeout']);
-			}
+            if ($value === FALSE)
+            {
+                return FALSE;
+            }
 
-			if ( ! $success)
-			{
-				log_message('debug', 'Cache: Redis connection refused. Check the config.');
-				return FALSE;
-			}
-		}
-		catch (RedisException $e)
-		{
-			log_message('debug', 'Cache: Redis connection refused ('.$e->getMessage().')');
-			return FALSE;
-		}
+            $value = unserialize($value);
+        }
 
-		if (isset($config['password']))
-		{
-			$this->_redis->auth($config['password']);
-		}
+        return array(
+            'expire' => time() + $this->_redis->ttl($key),
+            'data' => $value
+        );
 
-		return TRUE;
-	}
+    }
 
-	// ------------------------------------------------------------------------
+    // ------------------------------------------------------------------------
 
-	/**
+    /**
+     * Check if Redis driver is supported
+     *
+     * @return  bool
+     */
+    public function is_supported()
+    {
+        if (extension_loaded('redis'))
+        {
+            return $this->_setup_redis();
+        }
+        else
+        {
+            log_message('debug', 'The Redis extension must be loaded to use Redis cache.');
+            return FALSE;
+        }
+    }
 
-	 * Class destructor
-	 *
-	 * Closes the connection to Redis if present.
-	 *
-	 * @return	void
-	 */
-	public function __destruct()
-	{
-		if ($this->_redis)
-		{
-			$this->_redis->close();
-		}
-	}
+    // ------------------------------------------------------------------------
+
+    /**
+     * Setup Redis config and connection
+     *
+     * Loads Redis config file if present. Will halt execution
+     * if a Redis connection can't be established.
+     *
+     * @return  bool
+     * @see     Redis::connect()
+     */
+    protected function _setup_redis()
+    {
+        $config = array();
+        $CI =& get_instance();
+
+        if ($CI->config->load('redis', TRUE, TRUE))
+        {
+            $config += $CI->config->item('redis');
+        }
+
+        $config = array_merge(self::$_default_config, $config);
+
+        $this->_redis = new Redis();
+
+        try
+        {
+            if ($config['socket_type'] === 'unix')
+            {
+                $success = $this->_redis->connect($config['socket']);
+            }
+            else // tcp socket
+            {
+                $success = $this->_redis->connect($config['host'], $config['port'], $config['timeout']);
+            }
+
+            if ( ! $success)
+            {
+                log_message('debug', 'Cache: Redis connection refused. Check the config.');
+                return FALSE;
+            }
+        }
+        catch (RedisException $e)
+        {
+            log_message('debug', 'Cache: Redis connection refused ('.$e->getMessage().')');
+            return FALSE;
+        }
+
+        if (isset($config['password']))
+        {
+            $this->_redis->auth($config['password']);
+        }
+
+        return TRUE;
+    }
+
+    // ------------------------------------------------------------------------
+
+    /**
+     * Class destructor
+     *
+     * Closes the connection to Redis if present.
+     *
+     * @return  void
+     */
+    public function __destruct()
+    {
+        if ($this->_redis)
+        {
+            $this->_redis->close();
+        }
+    }
 
 }
 


### PR DESCRIPTION
Hello, 
Today I tried to use this Cache_redis.php for my application to deal with some query result set which is array-based data. Due to the native features of Redis that does not support 'array' data type. So I add the two 'serialize' and 'unserialize' function to 'save' and 'get' separately to add multidimensional array capability. Wish it can help some people like me who wants to deal with the same array set cache.

Regards,
Chonhan
