### PR TITLE
Altered CSRF whitelist matching to allow for simple, robust exclusions

### DIFF
--- a/system/core/Security.php
+++ b/system/core/Security.php
@@ -203,11 +203,13 @@ class CI_Security {
 		if ($exclude_uris = config_item('csrf_exclude_uris'))
 		{
 			$uri = load_class('URI', 'core');
-			foreach ($exclude_uris as $excluded) {
-				if (stripos($uri->uri_string(), $excluded) === 0) {
-					return $this;
-				}
-			}
+            foreach ($exclude_uris as $excluded) {
+                $excluded = str_replace(array(':any', ':num'), array('[^/]+', '[0-9]+'), $excluded);
+                if (preg_match('#^'.$excluded.'$#', $uri->uri_string()))
+                {
+                    return $this;
+                }
+            }
 		}
 
 		// Do the tokens exist in both the _POST and _COOKIE arrays?

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -507,7 +507,7 @@ Release Date: Not Released
 
       -  Added method ``strip_image_tags()``.
       -  Added ``$config['csrf_regeneration']``, which makes token regeneration optional.
-      -  Added ``$config['csrf_exclude_uris']``, which allows you to list URIs which will not have the CSRF validation methods run. Allows trailing GET params or segments.
+      -  Added ``$config['csrf_exclude_uris']``, which allows you to list URIs which will not have the CSRF validation methods run. Optionally allows regular expressions and wildcards.
       -  Modified method ``sanitize_filename()`` to read a public ``$filename_bad_chars`` property for getting the invalid characters list.
       -  Return status code of 403 instead of a 500 if CSRF protection is enabled but a token is missing from a request.
 

--- a/user_guide_src/source/libraries/security.rst
+++ b/user_guide_src/source/libraries/security.rst
@@ -97,9 +97,7 @@ by editing the 'csrf_exclude_uris' config parameter::
 
 	$config['csrf_exclude_uris'] = array('api/person/add');
 
-For better security, request URIs only match a whitelisted URI from position 0
-following the base URI. However, any valid uri character(s) (such as another segment
-or GET data) past a whitelisted URI will not prevent a match.
+Whitelisted URIs can include regular expressions as well as the ':any' and ':num' wildcards. 
 
 ***************
 Class Reference


### PR DESCRIPTION
Uses stripos to match a request URI to a whitelisted uri from position 0 following the base url. Allows for GET parameters and additional segments to follow a whitelisted URI, without requiring regex.
