### PR TITLE
Cache_redis: Adding serialization support.

### DIFF
--- a/system/libraries/Cache/drivers/Cache_redis.php
+++ b/system/libraries/Cache/drivers/Cache_redis.php
@@ -102,7 +102,7 @@ class CI_Cache_redis extends CI_Driver
 		{
 			$data = serialize($data);
 
-			if (! in_array($id, $this->_serialized, TRUE))
+			if ( ! in_array($id, $this->_serialized, TRUE))
 			{
 				$this->_serialized[] = $id;
 			}


### PR DESCRIPTION
This is an alternative implementation of value serialization for Redis cache driver. It is the third idea that appeared at the discussion about https://github.com/EllisLab/CodeIgniter/pull/3181

Now the driver has an internal cache for storing keys of serialized values, in order these serialized values to be distinguished.

I tested it with the same test of mine, it looks OK.
