### PR TITLE
fix uploaded filename with dot(.) in orig filename

### DIFF
--- a/system/libraries/Upload.php
+++ b/system/libraries/Upload.php
@@ -1171,7 +1171,7 @@ class CI_Upload {
 		{
 			if ( ! in_array(strtolower($part), $this->allowed_types) OR ! isset($this->_mimes[strtolower($part)]))
 			{
-				$filename .= '.'.$part.'_';
+				$filename .= '_'.$part;
 			}
 			else
 			{


### PR DESCRIPTION
for example:
I upload an image, 
the _original filename_ is "254.JPG.jpg.140F3_0S.235.jpg"
the _uploaded filename_ is "254.JPG.jpg.140F3_0S_.235_.jpg"
the filename _most of us_ really want is "254_JPG_jpg_140F3_0S_235.jpg" or "254.JPG.jpg_140F3_0S_235.jpg"

so, my suggestion is change the code to

   $filename .= '_' . $part;
