### PR TITLE
Create zip_helper.php

### DIFF
--- a/system/helpers/zip_helper.php
+++ b/system/helpers/zip_helper.php
@@ -1,0 +1,215 @@
+<?php
+if (!defined('BASEPATH'))
+{
+    exit('No direct script access allowed');
+}
+
+/**
+ * Zip file creation class.
+ * Makes zip files.
+ *
+ * @access  public
+ * @package PhpMyAdmin
+ * @see     Official ZIP file format: http://www.pkware.com/support/zip-app-note
+ */
+
+class ZipFile
+{
+    /**
+     * Whether to echo zip as it's built or return as string from -> file
+     *
+     * @var  boolean $doWrite
+     */
+    var $doWrite = FALSE;
+
+    /**
+     * Array to store compressed data
+     *
+     * @var  array $datasec
+     */
+    var $datasec = array();
+
+    /**
+     * Central directory
+     *
+     * @var  array $ctrl_dir
+     */
+    var $ctrl_dir = array();
+
+    /**
+     * End of central directory record
+     *
+     * @var  string $eof_ctrl_dir
+     */
+    var $eof_ctrl_dir = "\x50\x4b\x05\x06\x00\x00\x00\x00";
+
+    /**
+     * Last offset position
+     *
+     * @var  integer $old_offset
+     */
+    var $old_offset = 0;
+
+
+    /**
+     * Sets member variable this -> doWrite to true
+     * - Should be called immediately after class instantiantion
+     * - If set to true, then ZIP archive are echo'ed to STDOUT as each
+     *   file is added via this -> addfile(), and central directories are
+     *   echoed to STDOUT on final call to this -> file().  Also,
+     *   this -> file() returns an empty string so it is safe to issue a
+     *   "echo $zipfile;" command
+     *
+     * @access public
+     *
+     * @return void
+     */
+    function setDoWrite()
+    {
+        $this->doWrite = TRUE;
+    } // end of the 'setDoWrite()' method
+
+    /**
+     * Converts an Unix timestamp to a four byte DOS date and time format (date
+     * in high two bytes, time in low two bytes allowing magnitude comparison).
+     *
+     * @param integer $unixtime the current Unix timestamp
+     *
+     * @return integer the current date in a four byte DOS format
+     *
+     * @access private
+     */
+    function unix2DosTime($unixtime = 0)
+    {
+        $timearray = ($unixtime == 0) ? getdate() : getdate($unixtime);
+
+        if ($timearray['year'] < 1980)
+        {
+            $timearray['year']    = 1980;
+            $timearray['mon']     = 1;
+            $timearray['mday']    = 1;
+            $timearray['hours']   = 0;
+            $timearray['minutes'] = 0;
+            $timearray['seconds'] = 0;
+        } // end if
+
+        return (($timearray['year'] - 1980) << 25)
+        | ($timearray['mon'] << 21)
+        | ($timearray['mday'] << 16)
+        | ($timearray['hours'] << 11)
+        | ($timearray['minutes'] << 5)
+        | ($timearray['seconds'] >> 1);
+    } // end of the 'unix2DosTime()' method
+
+
+    /**
+     * Adds "file" to archive
+     *
+     * @param string $data file contents
+     * @param string $name name of the file in the archive (may contains the path)
+     * @param integer $time the current timestamp
+     *
+     * @access public
+     *
+     * @return void
+     */
+    function addFile($data, $name, $time = 0)
+    {
+        $name = str_replace('\\', '/', $name);
+
+        $hexdtime = pack('V', $this->unix2DosTime($time));
+
+        $fr = "\x50\x4b\x03\x04";
+        $fr .= "\x14\x00"; // ver needed to extract
+        $fr .= "\x00\x00"; // gen purpose bit flag
+        $fr .= "\x08\x00"; // compression method
+        $fr .= $hexdtime; // last mod time and date
+
+        // "local file header" segment
+        $unc_len = strlen($data);
+        $crc     = crc32($data);
+        $zdata   = gzcompress($data);
+        $zdata   = substr(substr($zdata, 0, strlen($zdata) - 4), 2); // fix crc bug
+        $c_len   = strlen($zdata);
+        $fr .= pack('V', $crc); // crc32
+        $fr .= pack('V', $c_len); // compressed filesize
+        $fr .= pack('V', $unc_len); // uncompressed filesize
+        $fr .= pack('v', strlen($name)); // length of filename
+        $fr .= pack('v', 0); // extra field length
+        $fr .= $name;
+
+        // "file data" segment
+        $fr .= $zdata;
+
+        // echo this entry on the fly, ...
+        if ($this->doWrite)
+        {
+            echo $fr;
+        }
+        else
+        { // ... OR add this entry to array
+            $this->datasec[] = $fr;
+        }
+
+        // now add to central directory record
+        $cdrec = "\x50\x4b\x01\x02";
+        $cdrec .= "\x00\x00"; // version made by
+        $cdrec .= "\x14\x00"; // version needed to extract
+        $cdrec .= "\x00\x00"; // gen purpose bit flag
+        $cdrec .= "\x08\x00"; // compression method
+        $cdrec .= $hexdtime; // last mod time & date
+        $cdrec .= pack('V', $crc); // crc32
+        $cdrec .= pack('V', $c_len); // compressed filesize
+        $cdrec .= pack('V', $unc_len); // uncompressed filesize
+        $cdrec .= pack('v', strlen($name)); // length of filename
+        $cdrec .= pack('v', 0); // extra field length
+        $cdrec .= pack('v', 0); // file comment length
+        $cdrec .= pack('v', 0); // disk number start
+        $cdrec .= pack('v', 0); // internal file attributes
+        $cdrec .= pack('V', 32); // external file attributes
+        // - 'archive' bit set
+
+        $cdrec .= pack('V', $this->old_offset); // relative offset of local header
+        $this->old_offset += strlen($fr);
+
+        $cdrec .= $name;
+
+        // optional extra field, file comment goes here
+        // save to central directory
+        $this->ctrl_dir[] = $cdrec;
+    }
+
+
+    /**
+     * Echo central dir if ->doWrite==true, else build string to return
+     *
+     * @return string  if ->doWrite {empty string} else the ZIP file contents
+     *
+     * @access public
+     */
+    function file()
+    {
+        $ctrldir = implode('', $this->ctrl_dir);
+        $header  = $ctrldir .
+            $this->eof_ctrl_dir .
+            pack('v', sizeof($this->ctrl_dir)) . //total #of entries "on this disk"
+            pack('v', sizeof($this->ctrl_dir)) . //total #of entries overall
+            pack('V', strlen($ctrldir)) . //size of central dir
+            pack('V', $this->old_offset) . //offset to start of central dir
+            "\x00\x00"; //.zip file comment length
+
+        if ($this->doWrite)
+        {
+            // Send central directory & end ctrl dir to STDOUT
+            echo $header;
+            return ""; // Return empty string
+        }
+        else
+        {
+            // Return entire ZIP archive as string
+            $data = implode('', $this->datasec);
+            return $data . $header;
+        }
+    }
+
+} // end of the 'ZipFile' class


### PR DESCRIPTION
Functionality that is not in PHP or CI: create zip-file in memory. Took it directly from this project: https://github.com/phpmyadmin/phpmyadmin/blob/master/libraries/zip.lib.php 

Used it in our software successfully.

Found it here: http://stackoverflow.com/questions/1189019/manipulate-an-archive-in-memory-with-php-without-creating-a-temporary-file-on-d

Use:

```
//create the zip
$zip = new zipfile();

//add files to the zip, passing file contents, not actual files
$zip->addFile($file_content, $file_name);

...

//prepare the proper content type
header("Content-type: application/octet-stream");
header("Content-Disposition: attachment; filename=my_archive.zip");
header("Content-Description: Files of an applicant");

//get the zip content and send it back to the browser
exit( $zip->file() );
```
