### PR TITLE
add field as preference to upload class

### DIFF
--- a/system/libraries/Upload.php
+++ b/system/libraries/Upload.php
@@ -38,6 +38,13 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 class CI_Upload {
 
 	/**
+	 * File input field
+	 *
+	 * @var	string
+	 */
+	public $field			= '';
+
+	/**
 	 * Maximum file size
 	 *
 	 * @var	int
@@ -345,6 +352,8 @@ class CI_Upload {
 	 */
 	public function do_upload($field = 'userfile')
 	{
+		$field = ($this->field) ? $this->field : $field;
+		
 		// Is $_FILES[$field] set? If not, no reason to continue.
 		if ( ! isset($_FILES[$field]))
 		{


### PR DESCRIPTION
I always look for the input field name in preferences to change according to my upload form. $field variable in do_upload method should be in preferences. I have added $field as class property and for backward compatibilty I have added the line below to the do_upload function.
        $field = ($this->field) ? $this->field : $field;
