### PR TITLE
Tweak in Lang class

### DIFF
--- a/system/core/Lang.php
+++ b/system/core/Lang.php
@@ -162,20 +162,14 @@ class CI_Lang {
 	 *
 	 * Fetches a single line of text from the language array
 	 *
-	 * @param	 string	$line				Language line key
-	 * @param  mixed 	$args 			Variables to be parsed within string
-	 * @param	 bool		$log_errors	Whether to log an error message if the line is not found
-	 * @return string							Translation
+	 * @param	string	$line		Language line key
+	 * @param array $args Variables to be parsed within string
+	 * @param	bool	$log_errors	Whether to log an error message if the line is not found
+	 * @return	string	Translation
 	 */
-	public function line($line = '', $args = '', $log_errors = TRUE)
+	public function line($line, array $args = NULL, $log_errors = TRUE)
 	{
-		$value = ($line === '' OR ! isset($this->language[$line])) ? FALSE : $this->language[$line];
-
-		// Backward compatibility prior to adding $args parameter
-		if (is_bool($args))
-		{
-			$log_errors = $args;
-		}
+		$value = isset($this->language[$line]) ? $this->language[$line] : FALSE;
 
 		// Because killer robots like unicorns!
 		if ($value === FALSE && $log_errors === TRUE)
@@ -183,17 +177,9 @@ class CI_Lang {
 			log_message('error', 'Could not find the language line "'.$line.'"');
 		}
 
-		if ( ! is_bool($args) && ! empty($args))
-		{
-			if ( ! is_array($args))
-			{
-				$args = array($args);
-			}
-
-			return vsprintf($value, $args);
-		}
-
-		return $value;
+		return empty($args)
+						? $value
+						: vsprintf($value, $args);
 	}
 }
 

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -521,6 +521,7 @@ Release Date: Not Released
       -  Changed method ``load()`` to filter the language name with ``ctype_alpha()``.
       -  Added an optional second parameter to method ``line()`` to disable error logging for line keys that were not found.
       -  Language files are now loaded in a cascading style with the one in **system/** always loaded and overriden afterwards, if another one is found.
+      -  Added is new second parameter in method ``line()`` for variables which will be parsed within line string.
 
    -  :doc:`Hooks Library <general/hooks>` changes include:
 


### PR DESCRIPTION
Changed function line() a bit, so we can pass parameters to be parsed by translation. For example:

$this->lang->line('name', 'John');

Where:

$lang['name'] = 'How is %s?';

Result:

'How is John?'
