### PR TITLE
Query builder fix for where('field NOT IN (a,b)')

### DIFF
--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -664,7 +664,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 			else
 			{
 				$operator = $this->_get_operator($k);
-				if (stripos($operator, 'NULL') === FALSE && strncasecmp(ltrim($operator), 'IN', 2) !== 0)
+				if (stripos($operator, 'NULL') === FALSE && strncasecmp(ltrim($operator), 'IN', 2) !== 0 && strncasecmp(ltrim($operator), 'NOT IN', 6) !== 0)
 				{
 					$op = strrpos($k, $operator);
 					if (strlen($k) === ($op + strlen($operator)))


### PR DESCRIPTION
same as issue #3242 just for NOT IN operator
