### PR TITLE
Loader.php

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -1169,7 +1169,7 @@ class CI_Loader {
 		}
 
 		// Save the class name and object name
-		$this->_ci_classes[$object_name] = $class;
+		$this->_ci_classes[$object_name] = $object_name;
 
 		// Instantiate the class
 		$CI->$object_name = isset($config)


### PR DESCRIPTION
La linea:   $this->_ci_classes[$object_name] = $class;  proporciona error al momento de buscar librerias ya que por defecto la variable $class llega a este punto con la primera letra en mayuscula y el sistema no encuentra una propiedad o clase en el CI:$Class  con la primera letra en mayuscula. la forma correcta es  $this->_ci_classes[$object_name] = $object_name;
