### PR TITLE
Fix wrongly guessed base_url on some webservers

### DIFF
--- a/system/core/Config.php
+++ b/system/core/Config.php
@@ -80,7 +80,7 @@ class CI_Config {
 			{
 				$script_name = "";
 				// if SCRIPT_NAME contains index.php, use it as a reference for base_url guess
-				if (strpos($_SERVER['SCRIPT_NAME']) !== false) {
+				if (strpos($_SERVER['SCRIPT_NAME'], "index.php") !== false) {
 					$script_name = substr($_SERVER['SCRIPT_NAME'], 0, strpos($_SERVER['SCRIPT_NAME'], "index.php"));
 				} else {
 					// if not, use the old method


### PR DESCRIPTION
Some of the webservers report more than they should in
_$_SERVER['SCRIPT_NAME']_, and this messes up the CodeIgniter base_url
guessing. Example, upon visiting http://url.com/Controller/Method, the
reported SCRIPT_NAME is /index.php/Controller/Method, and CI guesses the
base_url as: http://url.com/index.php/Controller, which is wrong. This commit
addresses this issue, and looks for an "index.php" in SCRIPT_NAME, if
found, everything before index.php is part of the base_url, if not
found, the old method is used.
