### PR TITLE
Revert to default sphinx theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ user_guide_src/cilexer/build/*
 user_guide_src/cilexer/dist/*
 user_guide_src/cilexer/pycilexer.egg-info/*
 /vendor/
+/nbproject/

--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -1,7 +1,0 @@
-include.path=${php.global.include.path}
-php.version=PHP_54
-source.encoding=UTF-8
-src.dir=.
-tags.asp=false
-tags.short=false
-web.root=.

--- a/nbproject/project.xml
+++ b/nbproject/project.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://www.netbeans.org/ns/project/1">
-    <type>org.netbeans.modules.php.project</type>
-    <configuration>
-        <data xmlns="http://www.netbeans.org/ns/php-project/1">
-            <name>CodeIgniter</name>
-        </data>
-    </configuration>
-</project>


### PR DESCRIPTION
Remove dependency on EllisLab corporate theme - that is not appropriate for us.
Reverted to default Sphinx theme, with a couple of options, which have the side-effect of adding back document tree navigation (next/previous) and collapsible menu (albeit a sidebar not a top one).

Closes #2605 and closes #2354, for now.
This is not a proper styling - that is a separate issue!
Signed-off-by:James L Parry jim_parry@bcit.ca
