### PR TITLE
Fix Common::get_config() error in PHP 5.6 - fix #3302

### DIFF
--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -251,7 +251,8 @@ if ( ! function_exists('get_config'))
 			}
 		}
 
-		return $_config[0] =& $config;
+		$_config[0] =& $config;
+		return $_config[0];
 	}
 }
 


### PR DESCRIPTION
fix #3302
