### PR TITLE
Add the function of strip_link_tags

### DIFF
--- a/system/helpers/security_helper.php
+++ b/system/helpers/security_helper.php
@@ -136,5 +136,23 @@ if ( ! function_exists('encode_php_tags'))
 	}
 }
 
+// ------------------------------------------------------------------------
+
+/**
+ * Strip Link Tags
+ *
+ * @access	public
+ * @param	string
+ * @return	string
+ */
+if ( ! function_exists('strip_link_tags'))
+{
+	function strip_link_tags($str)
+	{
+	$str=preg_replace("/<a[^>]*href=[^>]*>|<\/[^a]*a[^>]*>/i","\\2",$str);
+	return $str;
+	}
+}
+
 /* End of file security_helper.php */
 /* Location: ./system/helpers/security_helper.php */


### PR DESCRIPTION
it is very useful to remove the link(url) from a article.
