### PR TITLE
fix cannot use backup driver

### DIFF
--- a/system/libraries/Cache/Cache.php
+++ b/system/libraries/Cache/Cache.php
@@ -203,6 +203,7 @@ class CI_Cache extends CI_Driver_Library {
 		if ( ! $this->is_supported($child))
 		{
 			$this->_adapter = $this->_backup_driver;
+			$obj = parent::__get($this->_adapter);
 		}
 
 		return $obj;


### PR DESCRIPTION
$ci = &get_instance();
$ci->load->driver('cache', array('adapter' => 'memcached', 'backup' => 'file'));

$ci->cache->get('cache_key');  // if the Memcached(Memcache) Extension does not exist, it will not work.
// Fatal error:  Call to a member function get() on a non-object in .../system/libraries/Cache/drivers/Cache_memcached.php on line 50