### PR TITLE
#92 `directory_map()` alternative for `get_dir_file_info()`

### DIFF
--- a/system/helpers/directory_helper.php
+++ b/system/helpers/directory_helper.php
@@ -62,12 +62,33 @@ if ( ! function_exists('directory_map'))
 	 * @param	int	$directory_depth	Depth of directories to traverse
 	 *						(0 = fully recursive, 1 = current dir, etc)
 	 * @param	bool	$hidden			Whether to show hidden files
+	 * @param	mixed	$get_file_info		Whether to get file info, or an array (or 
+	 *						string) to specify the returned file info 
+	 *						(see {@link get_file_info()} for options)
 	 * @return	array
 	 */
-	function directory_map($source_dir, $directory_depth = 0, $hidden = FALSE)
+	function directory_map($source_dir, $directory_depth = 0, $hidden = FALSE, $get_file_info = FALSE)
 	{
 		if ($fp = @opendir($source_dir))
 		{
+			if ($get_file_info !== FALSE)
+			{
+				// If $get_file_info is not one of the permitted types, set it
+				// to the default value to indicate that the default functionality
+				// should be used. This reduces the need to perform more (or more
+				// complex) type checks inside the loop.
+
+				if ($get_file_info !== TRUE && ! is_array($get_file_info) && ! is_string($get_file_info))
+				{
+					$get_file_info = FALSE;
+				}
+				else
+				{
+					// Ensure the availability of get_file_info().
+					get_instance()->load->helper('file');
+				}
+			}
+
 			$filedata	= array();
 			$new_depth	= $directory_depth - 1;
 			$source_dir	= rtrim($source_dir, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
@@ -88,7 +109,18 @@ if ( ! function_exists('directory_map'))
 				}
 				else
 				{
+					if ($get_file_info === FALSE)
+					{
 					$filedata[] = $file;
+					}
+					elseif ($get_file_info === TRUE)
+					{
+						$filedata[$file] = get_file_info($file);
+					}
+					else
+					{
+						$filedata[$file] = get_file_info($file, $get_file_info);
+					}
 				}
 			}
 

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -140,7 +140,11 @@ Release Date: Not Released
       - Changed the default tag for use in :func:`highlight_phrase()` to ``<mark>`` (formerly ``<strong>``).
       - Changed :func:`character_limiter()`, :func:`word_wrap()` and :func:`ellipsize()` to utilize `mbstring <http://php.net/mbstring>`_ or `iconv <http://php.net/iconv>`_, if available.
 
-   -  :doc:`Directory Helper <helpers/directory_helper>` :func:`directory_map()` will now append ``DIRECTORY_SEPARATOR`` to directory names in the returned array.
+   -  :doc:`Directory Helper <helpers/directory_helper>` changes include:
+   
+      - func:`directory_map()` will now append ``DIRECTORY_SEPARATOR`` to directory names in the returned array.
+      - func:`directory_map()` will now accept a 4th parameter to indicate whether each file in the map should be passed to func:`get_file_info()`. This parameter may also be an array or string to be passed as the second argument to func:`get_file_info()`, indicating what information should be returned.
+
    -  :doc:`Array Helper <helpers/array_helper>` :func:`element()` and :func:`elements()` now return NULL instead of FALSE when the required elements don't exist.
    -  :doc:`Language Helper <helpers/language_helper>` :func:`lang()` now accepts an optional list of additional HTML attributes.
    -  Deprecated the :doc:`Email Helper <helpers/email_helper>` as its ``valid_email()``, ``send_email()`` functions are now only aliases for PHP native functions ``filter_var()`` and ``mail()`` respectively.

--- a/user_guide_src/source/helpers/directory_helper.rst
+++ b/user_guide_src/source/helpers/directory_helper.rst
@@ -27,11 +27,12 @@ Available Functions
 The following functions are available:
 
 
-.. function:: directory_map($source_dir[, $directory_depth = 0[, $hidden = FALSE]])
+.. function:: directory_map($source_dir[, $directory_depth = 0[, $hidden = FALSE[, $get_file_info = FALSE]]])
 
 	:param	string	$source_dir: Path to the source directory
 	:param	int	$directory_depth: Depth of directories to traverse (0 = fully recursive, 1 = current dir, etc)
 	:param	bool	$hidden: Whether to include hidden directories
+	:param	mixed	$get_file_info: Whether to get file info, or an array (or string) to specify the returned file info (see :doc:`file helper <file_helper>`'s :func:`get_file_info()` function for options)
 	:returns:	An array of files
 	:rtype:	array
 
@@ -81,3 +82,10 @@ The following functions are available:
 					[8] => pagination.html
 					[9] => uri.html
 				)
+		)
+
+	If the optional 4th parameter *$get_file_info* is TRUE, an array, or a 
+	string, each file name becomes an array index containing the appropriate 
+	output from the :doc:`file helper <file_helper>`'s :func:`get_file_info()` 
+	function. If this parameter is not TRUE or FALSE, it should be an array or
+	string matching the expected input for that function's second parameter.

--- a/user_guide_src/source/helpers/file_helper.rst
+++ b/user_guide_src/source/helpers/file_helper.rst
@@ -139,6 +139,12 @@ The following functions are available:
 	if forced by sending the second parameter to FALSE, as this can be an intensive
 	operation.
 
+	Note that the array keys returned by this function are the names of the files. This can be problematic
+	when ``$top_level_only`` is FALSE and files in multiple levels of the directory hierarchy use the same
+	file name. For these situations, it may be preferable to use the directory helper's ``directory_map()`` 
+	function with the optional 4th parameter set to TRUE (or a value accepted by ``get_file_info()``'s 
+	``$returned_values`` parameter).
+
 	Example::
 
 		$models_info = get_dir_file_info(APPPATH.'models/');


### PR DESCRIPTION
- Added optional parameter to `directory_map()` to call
`get_file_info()` on each file and add the result to the function's
output.
- Documented limitation of `get_dir_file_info()` when multiple files in
the directory hierarchy share the same name, and recommended use of
`directory_map()` as a possible solution.

This is not necessarily a fix for #92, but a work-around to maintain
backwards compatibility (in both functions) and make it relatively easy
to gain access to this information under these conditions.