### PR TITLE
Stronger deprecation warnings

### DIFF
--- a/user_guide_src/source/libraries/encrypt.rst
+++ b/user_guide_src/source/libraries/encrypt.rst
@@ -5,7 +5,7 @@ Encrypt Class
 The Encrypt Class provides two-way data encryption. It encrypted using
 the Mcrypt PHP extension, which is required for the Encrypt Class to run.
 
-.. important:: This library has been DEPRECATED and is only kept for
+.. warning:: This library has been DEPRECATED and is only kept for
 	backwards compatibility. Please use the new :doc:`Encryption Library
 	<encryption>`.
 

--- a/user_guide_src/source/libraries/javascript.rst
+++ b/user_guide_src/source/libraries/javascript.rst
@@ -2,7 +2,7 @@
 Javascript Class
 ################
 
-.. note:: This library is DEPRECATED and should not be used. It has always
+.. warning:: This library is DEPRECATED and should not be used. It has always
 	been with an 'experimental' status and is now no longer supported.
 	Currently only kept for backwards compatibility.
 


### PR DESCRIPTION
Changed the deprecation warnings for the Encrypt and Javascript classes, from "note" to "warning" admonitions. They show up a bit more noticeably.

Verified sphinx build.
Signed-off-by:James L Parry jim_parry@bcit.ca
