### PR TITLE
Flag the smiley helper and shopping cart as deprecated.

### DIFF
--- a/system/helpers/smiley_helper.php
+++ b/system/helpers/smiley_helper.php
@@ -44,7 +44,8 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  * @subpackage	Helpers
  * @category	Helpers
  * @author		EllisLab Dev Team
- * @link		http://codeigniter.com/user_guide/helpers/smiley_helper.html
+ * @link		http://codeigniter.com/user_guide/helpers/smilclass does not fit CI
+ * @deprecated	3.0.0	This class does not fit CI.
  */
 
 // ------------------------------------------------------------------------

--- a/system/libraries/Cart.php
+++ b/system/libraries/Cart.php
@@ -45,6 +45,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  * @category	Shopping Cart
  * @author		EllisLab Dev Team
  * @link		http://codeigniter.com/user_guide/libraries/cart.html
+ * @deprecated	3.0.0	This class does not fit CI
  */
 class CI_Cart {
 

--- a/user_guide_src/source/helpers/smiley_helper.rst
+++ b/user_guide_src/source/helpers/smiley_helper.rst
@@ -2,6 +2,10 @@
 Smiley Helper
 #############
 
+.. important:: This library is DEPRECATED and should not be used. 
+        It is now no longer supported.
+	Currently only kept for backwards compatibility.
+
 The Smiley Helper file contains functions that let you manage smileys
 (emoticons).
 

--- a/user_guide_src/source/libraries/cart.rst
+++ b/user_guide_src/source/libraries/cart.rst
@@ -2,6 +2,10 @@
 Shopping Cart Class
 ###################
 
+.. important:: This library is DEPRECATED and should not be used. 
+        It is now no longer supported.
+	Currently only kept for backwards compatibility.
+
 The Cart Class permits items to be added to a session that stays active
 while a user is browsing your site. These items can be retrieved and
 displayed in a standard "shopping cart" format, allowing the user to

--- a/user_guide_src/source/libraries/javascript.rst
+++ b/user_guide_src/source/libraries/javascript.rst
@@ -2,7 +2,7 @@
 Javascript Class
 ################
 
-.. note:: This library is DEPRECATED and should not be used. It has always
+.. important:: This library is DEPRECATED and should not be used. It has always
 	been with an 'experimental' status and is now no longer supported.
 	Currently only kept for backwards compatibility.
 


### PR DESCRIPTION
They should be removed the next minor release.
Lowered the "javascript" deprecation message to "important" instead of "warning", for consistency with the rest of CI.
Signed-off-by:James L Parry jim_parry@bcit.ca
