### PR TITLE
Socket connection for the mysqli driver

### DIFF
--- a/application/config/database.php
+++ b/application/config/database.php
@@ -105,6 +105,7 @@ $db['default'] = array(
 	'username' => '',
 	'password' => '',
 	'database' => '',
+	'socket'   => NULL,
 	'dbdriver' => 'mysqli',
 	'dbprefix' => '',
 	'pconnect' => TRUE,

--- a/system/database/drivers/mysqli/mysqli_driver.php
+++ b/system/database/drivers/mysqli/mysqli_driver.php
@@ -118,7 +118,7 @@ class CI_DB_mysqli_driver extends CI_DB {
 			$mysqli->options(MYSQLI_INIT_COMMAND, 'SET SESSION sql_mode="STRICT_ALL_TABLES"');
 		}
 
-		return $mysqli->real_connect($hostname, $this->username, $this->password, $this->database, $port, NULL, $client_flags)
+		return $mysqli->real_connect($hostname, $this->username, $this->password, $this->database, $port, $this->socket, $client_flags)
 			? $mysqli : FALSE;
 	}
 


### PR DESCRIPTION
If you try to do a socket connection with mysqli you get an error,
because the parameter for that is set in the core to null.

To get it work, i have added a new parameter to the databse config and
did a small change in mysqli_driver.php to allow a socket connection.
