### PR TITLE
Update config.php

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -368,7 +368,7 @@ $config['encryption_key'] = '';
 */
 $config['sess_driver']			= 'cookie';
 $config['sess_valid_drivers']	= array();
-$config['sess_cookie_name']		= 'ci_session';
+$config['sess_cookie_name']		= 'cisession';
 $config['sess_expiration']		= 7200;
 $config['sess_expire_on_close']	= FALSE;
 $config['sess_encrypt_cookie']	= FALSE;


### PR DESCRIPTION
I propose changing the cookie name for the default session - IE has numerous documented issues with cookie names containing underscores:

http://erichickstech.com/codeigniter-cookies-and-ie9-oh-my-underscores-in-cookie-name-fails-in-ie9/
http://stackoverflow.com/questions/9912168/codeigniter-2-x-sessions-and-internet-explorer

I have ran across a few installs of CodeIgniter where no one had changed the default cookie and we had multiple issues stemming from this issue.
