### PR TITLE
Support for microseconds in CI_Log

### DIFF
--- a/system/core/Log.php
+++ b/system/core/Log.php
@@ -198,7 +198,12 @@ class CI_Log {
 			return FALSE;
 		}
 
-		$message .= $level.' - '.date($this->_date_fmt).' --> '.$msg."\n";
+		// Instantiate DateTime with microseconds accuracy to allow proper use of "u" character in date format
+		$t = microtime(true);
+		$micro = sprintf("%06d",($t - floor($t)) * 1000000);
+		$date = new DateTime(date('Y-m-d H:i:s.'.$micro, $t));
+
+		$message .= $level.' - '.$date->format($this->_date_fmt).' --> '.$msg."\n";
 
 		flock($fp, LOCK_EX);
 

--- a/system/core/Log.php
+++ b/system/core/Log.php
@@ -198,12 +198,20 @@ class CI_Log {
 			return FALSE;
 		}
 
-		// Instantiate DateTime with microseconds accuracy to allow proper use of "u" character in date format
-		$t = microtime(true);
-		$micro = sprintf("%06d",($t - floor($t)) * 1000000);
-		$date = new DateTime(date('Y-m-d H:i:s.'.$micro, $t));
+		// Instantiating DateTime with microseconds appended to initial date is needed for proper support of this format
+		if (strpos($this->_date_fmt, 'u') !== FALSE)
+		{
+			$microtime_full = microtime(TRUE);
+			$microtime_short = sprintf("%06d", ($microtime_full - floor($microtime_full)) * 1000000);
+			$date = new DateTime(date('Y-m-d H:i:s.'.$microtime_short, $microtime_full));
+			$date = $date->format($this->_date_fmt);
+		}
+		else
+		{
+			$date = date($this->_date_fmt);
+		}
 
-		$message .= $level.' - '.$date->format($this->_date_fmt).' --> '.$msg."\n";
+		$message .= $level.' - '.$date.' --> '.$msg."\n";
 
 		flock($fp, LOCK_EX);
 

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -553,6 +553,7 @@ Release Date: Not Released
 
       -  Added a ``$config['log_file_permissions']`` setting.
       -  Changed the library constructor to try to create the **log_path** directory if it doesn't exist.
+      -  Added support for microseconds ("u" date format character) in ``$config['log_date_format']``
 
    -  Added `compatibility layers <general/compatibility_functions>` for:
 

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -553,7 +553,7 @@ Release Date: Not Released
 
       -  Added a ``$config['log_file_permissions']`` setting.
       -  Changed the library constructor to try to create the **log_path** directory if it doesn't exist.
-      -  Added support for microseconds ("u" date format character) in ``$config['log_date_format']``
+      -  Added support for microseconds ("u" date format character) in ``$config['log_date_format']``.
 
    -  Added `compatibility layers <general/compatibility_functions>` for:
 


### PR DESCRIPTION
Allows to utilize "u" date format character for log entries. Support for this was added in PHP 5.2.2.