### PR TITLE
User Guide Tuning

### DIFF
--- a/user_guide_src/source/libraries/input.rst
+++ b/user_guide_src/source/libraries/input.rst
@@ -17,6 +17,10 @@ The Input Class serves two purposes:
 
   <div class="custom-index container"></div>
 
+***************
+Input Filtering
+***************
+
 Security Filtering
 ==================
 
@@ -48,6 +52,10 @@ this::
 
 Please refer to the :doc:`Security class <security>` documentation for
 information on using XSS Filtering in your application.
+
+*******************
+Accessing form data
+*******************
 
 Using POST, GET, COOKIE, or SERVER Data
 =======================================

--- a/user_guide_src/source/libraries/loader.rst
+++ b/user_guide_src/source/libraries/loader.rst
@@ -18,8 +18,9 @@ can be libraries (classes) :doc:`View files <../general/views>`,
 
   <div class="custom-index container"></div>
 
+**********************
 Application "Packages"
-======================
+**********************
 
 An application package allows for the easy distribution of complete sets
 of resources in a single directory, complete with its own libraries,

--- a/user_guide_src/source/libraries/security.rst
+++ b/user_guide_src/source/libraries/security.rst
@@ -12,8 +12,9 @@ application, processing input data for security.
 
   <div class="custom-index container"></div>
 
+*************
 XSS Filtering
-=============
+*************
 
 CodeIgniter comes with a Cross Site Scripting Hack prevention filter
 which can either run automatically to filter all POST and COOKIE data
@@ -57,8 +58,9 @@ browser may attempt to execute.
 		// file failed the XSS test
 	}
 
+*********************************
 Cross-site request forgery (CSRF)
-=================================
+*********************************
 
 You can enable CSRF protection by altering your **application/config/config.php**
 file in the following way::

--- a/user_guide_src/source/libraries/unit_testing.rst
+++ b/user_guide_src/source/libraries/unit_testing.rst
@@ -18,6 +18,10 @@ code to determine if it is producing the correct data type and result.
 
   <div class="custom-index container"></div>
 
+******************************
+Using the Unit Testing Library
+******************************
+
 Initializing the Class
 ======================
 


### PR DESCRIPTION
Adjust the heading levels in the writeups for the input, loader, security and unit testing libraries, to match the other library writeups.
Specifically, the class reference section in each of these was appearing as a sub-level in the toctree, when it should be at the same level.
Signed-off-by:James L Parry jim_parry@bcit.ca
