### PR TITLE
remove $data['title'] declaration from controller

### DIFF
--- a/user_guide_src/source/tutorial/news_section.rst
+++ b/user_guide_src/source/tutorial/news_section.rst
@@ -175,8 +175,6 @@ news controller and update ``view()`` with the following:
 			show_404();
 		}
 
-		$data['title'] = $data['news_item']['title'];
-
 		$this->load->view('templates/header', $data);
 		$this->load->view('news/view', $data);
 		$this->load->view('templates/footer');


### PR DESCRIPTION
$data['title'] declared in the controller is not used in the view
