### PR TITLE
Change order of hooks loading

### DIFF
--- a/system/core/Hooks.php
+++ b/system/core/Hooks.php
@@ -99,14 +99,14 @@ class CI_Hooks {
 		}
 
 		// Grab the "hooks" definition file.
-		if (file_exists(APPPATH.'config/'.ENVIRONMENT.'/hooks.php'))
-		{
-			include(APPPATH.'config/'.ENVIRONMENT.'/hooks.php');
-		}
-
 		if (file_exists(APPPATH.'config/hooks.php'))
 		{
 			include(APPPATH.'config/hooks.php');
+		}
+
+		if (file_exists(APPPATH.'config/'.ENVIRONMENT.'/hooks.php'))
+		{
+			include(APPPATH.'config/'.ENVIRONMENT.'/hooks.php');
 		}
 
 		// If there are no hooks, we're done.


### PR DESCRIPTION
Let override hooks via environment-specific config.

Also for consistency with config `autoload.php`, `routes.php`, etc.