### PR TITLE
Update reserved controller names

### DIFF
--- a/user_guide_src/source/general/reserved_names.rst
+++ b/user_guide_src/source/general/reserved_names.rst
@@ -16,9 +16,7 @@ the ones used by that class, otherwise your local methods will
 override them. The following is a list of reserved names. Do not name
 your controller any of these:
 
--  Controller
--  CI_Base
--  _ci_initialize
+-  CI_Controller
 -  Default
 -  index
 


### PR DESCRIPTION
Very legacy stuff :)

I had a hard time digging to understand why the "Default" [was added](https://github.com/bcit-ci/CodeIgniter/commit/c47eb1e3009cb4d0760748c9c1fe029fb988dd55), before I try and understand it is simply the PHP keyword...

So basically, the rule is: « Don't name your controller "Index" or any [PHP keyword](http://php.net/manual/en/reserved.keywords.php). » (the "CI_Controller" is quite obvious)