### PR TITLE
Added composer.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ user_guide_src/cilexer/dist/*
 user_guide_src/cilexer/pycilexer.egg-info/*
 /vendor/
 /nbproject/
+composer.lock


### PR DESCRIPTION
Hi,

Is this file supposed to be in .gitignore? It seems it should be in there, but I'm not sure.

If you do want to merge this in, please let me know if I should change anything before you can accept it.

Thanks for sharing your software.

Signed-off-by: Dan Bernardic <dan.bernardic@gmail.com>