### PR TITLE
var_export in DB.php outputting string

### DIFF
--- a/system/database/DB.php
+++ b/system/database/DB.php
@@ -130,7 +130,7 @@ function &DB($params = '', $query_builder_override = NULL)
 			{
 				if (is_string($val) && in_array(strtoupper($val), array('TRUE', 'FALSE', 'NULL')))
 				{
-					$val = var_export($val);
+					$val = var_export($val, TRUE);
 				}
 
 				$params[$key] = $val;


### PR DESCRIPTION
When a DSN string is supplied and it contains parameters such as "db_debug=TRUE", var_export will currently output the parsable string representation of the variable. By setting the second parameter to TRUE, the output is killed.