### PR TITLE
Add different Environmental variable for errors and config loading

### DIFF
--- a/index.php
+++ b/index.php
@@ -54,6 +54,7 @@
  * NOTE: If you change these, also change the error_reporting() code below
  */
 	define('ENVIRONMENT', isset($_SERVER['CI_ENV']) ? $_SERVER['CI_ENV'] : 'development');
+	define('DEBUG', isset($_SERVER['CI_DEBUG']) ? $_SERVER['CI_DEBUG'] : ENVIRONMENT);
 
 /*
  *---------------------------------------------------------------
@@ -63,7 +64,7 @@
  * Different environments will require different levels of error reporting.
  * By default development will show errors but testing and live will hide them.
  */
-switch (ENVIRONMENT)
+switch (DEBUG)
 {
 	case 'development':
 		error_reporting(-1);


### PR DESCRIPTION
Since we have updated the config loading to cascade being able to have the config file loading not tied directly to the way the errors are displayed comes in handy. You could set your local environment to "sandbox" and debug to "development" for example and then on the development server "development" for both.

This also safely falls back to it's present workflow.