### PR TITLE
repair autoload.php when environment exists

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -1232,10 +1232,13 @@ class CI_Loader {
 	 */
 	protected function _ci_autoloader()
 	{
-		include(APPPATH.'config/autoload.php');
 		if (file_exists(APPPATH.'config/'.ENVIRONMENT.'/autoload.php'))
 		{
 			include(APPPATH.'config/'.ENVIRONMENT.'/autoload.php');
+		}
+		else
+		{
+			include(APPPATH.'config/autoload.php');
 		}
 
 		if ( ! isset($autoload))


### PR DESCRIPTION
autoload.php didn't load properly if an enviroment directory exists (develpment directory).