### PR TITLE
Library Typography Cleaning

### DIFF
--- a/system/libraries/Typography.php
+++ b/system/libraries/Typography.php
@@ -172,7 +172,6 @@ class CI_Typography {
 		// Build our finalized string.  We cycle through the array, skipping tags, and processing the contained text
 		$str = '';
 		$process = TRUE;
-		$paragraph = FALSE;
 
 		for ($i = 0, $c = count($chunks) - 1; $i <= $c; $i++)
 		{


### PR DESCRIPTION
Hello,
This `$paragraph = FALSE` local variable is declared but never used.