### PR TITLE
Session writeup error?

### DIFF
--- a/user_guide_src/source/libraries/sessions.rst
+++ b/user_guide_src/source/libraries/sessions.rst
@@ -569,7 +569,7 @@ For PostgreSQL::
 		"ip_address" varchar(45) NOT NULL,
 		"timestamp" bigint DEFAULT 0 NOT NULL,
 		"data" text DEFAULT '' NOT NULL,
-		PRIMARY KEY ("session_id")
+		PRIMARY KEY ("id")
 	);
 
 	CREATE INDEX "ci_sessions_timestamp" ON "ci_sessions" ("timestamp");


### PR DESCRIPTION
This mistake was pointed out to me ... it looks like the session table create command suggests "session_id" as the primary key, when it should actually say "id".

Signed-off-by:Master Yoda <jim_parry@bcit.ca>