### PR TITLE
Extending form validation methods

### DIFF
--- a/system/language/english/form_validation_lang.php
+++ b/system/language/english/form_validation_lang.php
@@ -65,4 +65,4 @@ $lang['form_validation_less_than_equal_to']	= 'The {field} field must contain a 
 $lang['form_validation_greater_than']		= 'The {field} field must contain a number greater than {param}.';
 $lang['form_validation_greater_than_equal_to']	= 'The {field} field must contain a number greater than or equal to {param}.';
 $lang['form_validation_error_message_not_set']	= 'Unable to access an error message corresponding to your field name {field}.';
-$lang['form_validation_in']		= 'The {field} field must be one of: {param}.';
+$lang['form_validation_in_list']		= 'The {field} field must be one of: {param}.';

--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -1455,7 +1455,7 @@ class CI_Form_validation {
 	 * @param	array
 	 * @return	bool
 	 */
-	public function in($value, $list)
+	public function in_list($value, $list)
 	{
 		return in_array($value, explode(',', $list), TRUE);
 	}

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -350,10 +350,10 @@ Release Date: Not Released
       -  Removed method ``is_numeric()`` as it exists as a native PHP function and ``_execute()`` will find and use that (the **is_numeric** rule itself is deprecated since 1.6.1).
       -  Native PHP functions used as rules can now accept an additional parameter, other than the data itself.
       -  Updated method ``set_rules()`` to accept an array of rules as well as a string.
-      -  Added support for ``in`` method that test if a given value is within a given list.
       -  Fields that have empty rules set no longer run through validation (and therefore are not considered erroneous).
       -  Added rule **differs** to check if the value of a field differs from the value of another field.
       -  Added rule **valid_url**.
+      -  Added rule **in_list** to check if the value of a field is within a given list.
       -  Added support for named parameters in error messages.
       -  :doc:`Language <libraries/language>` line keys must now be prefixed with **form_validation_**.
       -  Added rule **alpha_numeric_spaces**.

--- a/user_guide_src/source/libraries/form_validation.rst
+++ b/user_guide_src/source/libraries/form_validation.rst
@@ -961,7 +961,7 @@ Rule                      Parameter  Description                                
                                      not numeric.
 **less_than_equal_to**    Yes        Returns FALSE if the form element is greater than the parameter value,                        less_than_equal_to[8]
                                      or not numeric.
-**in**                    Yes        Returns FALSE if the form element is not within a predetermined list.                         in[red,blue,green]
+**in_list**               Yes        Returns FALSE if the form element is not within a predetermined list.                         in_list[red,blue,green]
 **alpha**                 No         Returns FALSE if the form element contains anything other than alphabetical characters.
 **alpha_numeric**         No         Returns FALSE if the form element contains anything other than alpha-numeric characters.
 **alpha_numeric_spaces**  No         Returns FALSE if the form element contains anything other than alpha-numeric characters


### PR DESCRIPTION
Added support for the following functions:

Between - numeric value should be within a given range
In / Not In - string should be in/not in a list of allowed values
Date - string should be a valid date
Before Date / After Date - date should fall between a given date range