### PR TITLE
input.rst : clarifies cookie_prefix is not added

### DIFF
--- a/user_guide_src/source/libraries/input.rst
+++ b/user_guide_src/source/libraries/input.rst
@@ -81,6 +81,8 @@ The main methods are:
 -  ``$this->input->cookie()``
 -  ``$this->input->server()``
 
+Note that, unlike the get_cookie() function, ``$this->input->cookie()`` does not prepend the cookie prefix you might have set in config.php.
+
 Using the php://input stream
 ============================
 


### PR DESCRIPTION
The CI manual states that the get_cookie() function "is an alias to $this->input->cookie()." I believe this is an erroneous as $this->input->cookie() does not prepend the cookie prefix a user might have set in its config.php file, while get_cookie() does.
This is the source of many headaches... ;)
This change strives to clarify the difference in the way these two functions work for the benefit of all users.