### PR TITLE
cookie_helper.rst: clarifies cookie_prefix is added

### DIFF
--- a/user_guide_src/source/helpers/cookie_helper.rst
+++ b/user_guide_src/source/helpers/cookie_helper.rst
@@ -22,8 +22,7 @@ This helper is loaded using the following code::
 Available Functions
 ===================
 
-The following functions are available:
-
+The following functions are available::
 
 .. function:: set_cookie($name[, $value = ''[, $expire = ''[, $domain = ''[, $path = '/'[, $prefix = ''[, $secure = FALSE[, $httponly = FALSE]]]]]]]])
 
@@ -51,8 +50,7 @@ The following functions are available:
 	:rtype:	mixed
 
 	This helper function gives you view file friendly syntax to get browser
-	cookies. Refer to the :doc:`Input Library <../libraries/input>` for a
-	description of its use, as this function is an alias for ``CI_Input::cookie()``.
+	cookies. It is similar to the :doc:`Input Library <../libraries/input>` ``CI_Input::cookie()`` function, except that ``get_cookie()`` will automatically prepend the cookie prefix you might have set in config.php.
 
 
 .. function:: delete_cookie($name[, $domain = ''[, $path = '/'[, $prefix = '']]]])
@@ -75,4 +73,4 @@ The following functions are available:
 	parameters.
 	::
 
-		delete_cookie($name, $domain, $path, $prefix)
+		delete_cookie($name, $domain, $path, $prefix);


### PR DESCRIPTION
The CI manual states that the get_cookie() function "is an alias to $this->input->cookie()." I believe this is an erroneous as $this->input->cookie() does not prepend the cookie prefix a user might have set in its config.php file, while get_cookie() does.
This is the source of many headaches... ;)
This change strives to clarify the difference in the way these two functions work for the benefit of all users.