### PR TITLE
Fix a wrong var name in class CI_DB_pdo_4d_forge

### DIFF
--- a/system/database/drivers/pdo/subdrivers/pdo_4d_forge.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_4d_forge.php
@@ -164,7 +164,7 @@ class CI_DB_pdo_4d_forge extends CI_DB_pdo_forge {
 				$attributes['TYPE'] = 'INT';
 				return;
 			case 'BIGINT':
-				$attribites['TYPE'] = 'INT64';
+				$attributes['TYPE'] = 'INT64';
 				return;
 			default: return;
 		}


### PR DESCRIPTION
Hello,
Fix a wrong var name in class CI_DB_pdo_4d_forge::_attr_type