### PR TITLE
Use session cookie name in gc check

### DIFF
--- a/system/libraries/Session/drivers/Session_files_driver.php
+++ b/system/libraries/Session/drivers/Session_files_driver.php
@@ -107,7 +107,7 @@ class CI_Session_files_driver extends CI_Session_driver implements SessionHandle
 	 * Sanitizes the save_path directory.
 	 *
 	 * @param	string	$save_path	Path to session files' directory
-	 * @param	string	$name		Session cookie name, unused
+	 * @param	string	$name		Session cookie name
 	 * @return	bool
 	 */
 	public function open($save_path, $name)
@@ -332,10 +332,16 @@ class CI_Session_files_driver extends CI_Session_driver implements SessionHandle
 
 		$ts = time() - $maxlifetime;
 
+		$pattern = sprintf(
+			'/^%s[0-9a-f]{%d}$/',
+			preg_quote($this->_config['cookie_name'], '/'),
+			($this->_config['match_ip'] === TRUE ? 72 : 40)
+		);
+
 		foreach ($files as $file)
 		{
 			// If the filename doesn't match this pattern, it's either not a session file or is not ours
-			if ( ! preg_match('/(?:[0-9a-f]{32})?[0-9a-f]{40}$/i', $file)
+			if ( ! preg_match($pattern, $file)
 				OR ! is_file($this->_config['save_path'].DIRECTORY_SEPARATOR.$file)
 				OR ($mtime = filemtime($this->_config['save_path'].DIRECTORY_SEPARATOR.$file)) === FALSE
 				OR $mtime > $ts)


### PR DESCRIPTION
I noticed this check in the session gc code isn't particularly reliable. First, it ignores the cookie name which is the obvious thing to use to check if the file is a CI session file. Secondly it assumes the session id is a 40 character hex string which is not a valid assumption.