### PR TITLE
Allow not-escaping the value in set_value()

### DIFF
--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -676,17 +676,18 @@ if ( ! function_exists('set_value'))
 	 *
 	 * @param	string	$field		Field name
 	 * @param	string	$default	Default value
+	 * @param	bool	$escaped	Escaped value
 	 * @return	string
 	 */
-	function set_value($field, $default = '')
+	function set_value($field, $default = '',$escaped = TRUE)
 	{
 		$CI =& get_instance();
 
 		$value = (isset($CI->form_validation) && is_object($CI->form_validation) && $CI->form_validation->has_rule($field))
 			? $CI->form_validation->set_value($field, $default)
 			: $CI->input->post($field, FALSE);
-
-		return html_escape($value === NULL ? $default : $value);
+		$value = ($value === NULL) ? $default : $value;
+		return $escaped ? html_escape($value) : $value;
 	}
 }
 

--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -676,7 +676,7 @@ if ( ! function_exists('set_value'))
 	 *
 	 * @param	string	$field		Field name
 	 * @param	string	$default	Default value
-	 * @param	bool	$html_escape	HTML escaped value
+	 * @param	bool	$html_escape	Whether to escape HTML special characters or not
 	 * @return	string
 	 */
 	function set_value($field, $default = '', $html_escape = TRUE)

--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -676,18 +676,19 @@ if ( ! function_exists('set_value'))
 	 *
 	 * @param	string	$field		Field name
 	 * @param	string	$default	Default value
-	 * @param	bool	$escaped	Escaped value
+	 * @param	bool	$html_escape	HTML escaped value
 	 * @return	string
 	 */
-	function set_value($field, $default = '',$escaped = TRUE)
+	function set_value($field, $default = '', $html_escape = TRUE)
 	{
 		$CI =& get_instance();
 
 		$value = (isset($CI->form_validation) && is_object($CI->form_validation) && $CI->form_validation->has_rule($field))
 			? $CI->form_validation->set_value($field, $default)
 			: $CI->input->post($field, FALSE);
-		$value = ($value === NULL) ? $default : $value;
-		return $escaped ? html_escape($value) : $value;
+			
+		isset($value) OR $value = $default;
+		return ($html_escape) ? html_escape($value) : $value;
 	}
 }
 

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -105,6 +105,7 @@ Release Date: Not Released
 
       - :php:func:`form_dropdown()` will now also take an array for unity with other form helpers.
       - :php:func:`form_prep()` is now DEPRECATED and only acts as an alias for :doc:`common function <general/common_functions>` :php:func:`html_escape()`.
+      - :php:func:`set_value()` will now also accept a third argument, allowing to turn off HTML escaping of the value.
 
    -  :doc:`Security Helper <helpers/security_helper>` changes include:
 

--- a/user_guide_src/source/helpers/form_helper.rst
+++ b/user_guide_src/source/helpers/form_helper.rst
@@ -581,7 +581,9 @@ The following functions are available:
 	Permits you to set the value of an input form or textarea. You must
 	supply the field name via the first parameter of the function. The
 	second (optional) parameter allows you to set a default value for the
-	form.
+	form. The third (optional) parameter allows you to turn off HTML escaping
+	of the value, in case you need to use this function in combination with
+	i.e. :php:func:`form_input()` and avoid double-escaping.
 
 	Example::
 
@@ -589,11 +591,7 @@ The following functions are available:
 
 	The above form will show "0" when loaded for the first time.
 
-	.. note:: Only use this function with raw HTML fields, as it
-		internally calls :php:func:`html_escape()` and combining its
-		usage with other form helper functions will result in
-		double HTML encoding!
-
+	
 .. php:function:: set_select($field[, $value = ''[, $default = FALSE]])
 
 	:param	string	$field: Field name


### PR DESCRIPTION
Wouldn't it be a good idea to allow for not escaped html in set_value()?