### PR TITLE
Fix incorrect FCPATH when a folder is named SELF

### DIFF
--- a/index.php
+++ b/index.php
@@ -225,7 +225,7 @@ switch (ENVIRONMENT)
 	define('BASEPATH', str_replace('\\', '/', $system_path));
 
 	// Path to the front controller (this file)
-	define('FCPATH', str_replace(SELF, '', __FILE__));
+	define('FCPATH', dirname(__FILE__) . '/');
 
 	// Name of the "system folder"
 	define('SYSDIR', trim(strrchr(trim(BASEPATH, '/'), '/'), '/'));


### PR DESCRIPTION
If code igniter is located inside a folder named like SELF (eg. index.php), the FCPATH constant will have an incorrect value.