### PR TITLE
Fix preg_replace issue in remove_evil_attributes

### DIFF
--- a/system/core/Security.php
+++ b/system/core/Security.php
@@ -774,44 +774,32 @@ class CI_Security {
 	{
 		$evil_attributes = array('on\w*', 'style', 'xmlns', 'formaction', 'form', 'xlink:href');
 
-		if ($is_image === TRUE)
-		{
-			/*
-			 * Adobe Photoshop puts XML metadata into JFIF images,
-			 * including namespacing, so we have to allow this for images.
-			 */
-			unset($evil_attributes[array_search('xmlns', $evil_attributes)]);
-		}
+	        if ($is_image === TRUE)
+	        {
+	            /*
+	             * Adobe Photoshop puts XML metadata into JFIF images,
+	             * including namespacing, so we have to allow this for images.
+	             */
+	            unset($evil_attributes[array_search('xmlns', $evil_attributes)]);
+	        }
 
-		do {
-			$count = 0;
-			$attribs = array();
-
-			// find occurrences of illegal attribute strings with quotes (042 and 047 are octal quotes)
-			preg_match_all('/(?<!\w)('.implode('|', $evil_attributes).')\s*=\s*(\042|\047)([^\\2]*?)(\\2)/is', $str, $matches, PREG_SET_ORDER);
-
-			foreach ($matches as $attr)
-			{
-				$attribs[] = preg_quote($attr[0], '/');
-			}
-
-			// find occurrences of illegal attribute strings without quotes
-			preg_match_all('/(?<!\w)('.implode('|', $evil_attributes).')\s*=\s*([^\s>]*)/is', $str, $matches, PREG_SET_ORDER);
-
-			foreach ($matches as $attr)
-			{
-				$attribs[] = preg_quote($attr[0], '/');
-			}
-
-			// replace illegal attribute strings that are inside an html tag
-			if (count($attribs) > 0)
-			{
-				$str = preg_replace('/(<?)(\/?[^><]+?)([^A-Za-z<>\-])(.*?)('.implode('|', $attribs).')(.*?)([\s><]?)([><]*)/i', '$1$2 $4$6$7$8', $str, -1, $count);
-			}
-		}
-		while ($count);
-
-		return $str;
+	        do {
+	            $GLOBALS['_remove_evil_attributes_count'] = 0;
+	
+	            //php 5.2 compatible
+	            $replace_func = create_function ('$match', '$GLOBALS["_remove_evil_attributes_count"]++; return "";');
+	
+	            // find occurrences of illegal attribute strings with quotes (042 and 047 are octal quotes)
+	            $str = preg_replace_callback('/('.implode('|', $evil_attributes).')\s*=\s*(\042|\047)([^\\2]*?)(\\2)/is', $replace_func, $str);
+	
+	            $str = preg_replace_callback('/('.implode('|', $evil_attributes).')\s*=\s*([^\s>]*)/is', $replace_func, $str);
+	
+	
+	        } while ($GLOBALS['_remove_evil_attributes_count']);
+	
+	        unset($GLOBALS['_remove_evil_attributes_count']);
+	
+	        return $str;
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
If there are too many evil attributes passed in a POST array variable, the original preg_replace('') expression will fail because the resulting pattern becomes far too long.  This patch uses preg_replace_callback instead and hopefully should be PHP 5.2 compatible (if needed.)