### PR TITLE
Fix HELO localhost.localdomain violates RFC standards

### DIFF
--- a/system/libraries/Email.php
+++ b/system/libraries/Email.php
@@ -2171,12 +2171,16 @@ class CI_Email {
 
 	/**
 	 * Get Hostname
-	 *
+	 * 
+	 * There are only two legal types of hostname either a fully qualified domain
+	 * name (eg: "mail.example.com") or an "IP literal" (eg: "[1.2.3.4]").
+	 *     
+	 * @link	http://cbl.abuseat.org/namingproblems.html
 	 * @return	string
 	 */
 	protected function _get_hostname()
 	{
-		return isset($_SERVER['SERVER_NAME']) ? $_SERVER['SERVER_NAME'] : 'localhost.localdomain';
+		return isset($_SERVER['SERVER_NAME']) ? $_SERVER['SERVER_NAME'] : '[' . $_SERVER['SERVER_ADDR'] . ']';
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
Hi there,

You'll find that if CodeIgniter cannot find the SERVER_NAME it will fallback to "localhost.localdomain" on line 2179 of "system/libraries/Email.php":

* https://github.com/bcit-ci/CodeIgniter/blob/21898a45f323bb74ef6e5ee8cf21c3397467665b/system/libraries/Email.php#L2179

This use of "localhost.localdomain" violates the standards outlined in the RFC.

Instead when a valid hostname is not available it must use an IP literal,
eg: "HELO [1.2.3.4]" instead of "HELO localhost.localdomain".

Failure to comply with the RFC will result in rejection from many mail servers
 and will see your IP added to blacklists which will prevent your mail from
 reaching the intended recipient.

From CBL:

There are two basic types of detections that land an IP in this page. RFC2821 section 4.1.1.1 says that there are only two legal types of HELO/EHLO a mail server can issue - either a fully qualified domain name (eg: "mail.example.com") or an "IP literal" (eg: "[1.2.3.4]").

From RFC2821:

4.1.1.1 Extended HELLO (EHLO) or HELLO (HELO)
These commands are used to identify the SMTP client to the SMTP server. The
argument field contains the fully-qualified domain name of the SMTP client
if one is available. In situations in which the SMTP client system does not
have a meaningful domain name (e.g., when its address is dynamically
allocated and no reverse mapping record is available), the client SHOULD
send an address literal (see section 4.1.3), optionally followed by
information that will help to identify the client system. The SMTP server
identifies itself to the SMTP client in the connection greeting reply and
in the response to this command.

From RFC5321:

"The domain name given in the EHLO command MUST be either a primary
      host name (a domain name that resolves to an address RR) or, if
      the host has no name, an address literal, as described in
      Section 4.1.3 and discussed further in the EHLO discussion of
      Section 4.1.4."

From SpamAssassin:

Every outgoing mail server SHOULD announce its FQDN (fully qualified Domain Name) in the first line of the SMTP session (note, only EHLO is REQUIRED to be a valid FQDN), however, many anti-spam systems at large ISP's and email providers are rejecting email sessions and email from hosts that appear to 'forge' their HELO line.
Many 'default' installations may 'forge' a helo line of 'localhost.localdomain', or 'localhost'. 

See also:
* http://cbl.abuseat.org/namingproblems.html
* http://cbl.abuseat.org/hostname.html
* http://cbl.abuseat.org/helocheck.html
* https://tools.ietf.org/html/rfc2821#section-4.1.1.1
* https://tools.ietf.org/html/rfc5321
* http://wiki.apache.org/spamassassin/Rules/FORGED_RCVD_HELO
* https://code.google.com/p/k9mail/issues/detail?id=45

Thanks.