### PR TITLE
If we have is_unique() why not also have exists()?

### DIFF
--- a/system/language/english/form_validation_lang.php
+++ b/system/language/english/form_validation_lang.php
@@ -57,6 +57,7 @@ $lang['form_validation_regex_match']		= 'The {field} field is not in the correct
 $lang['form_validation_matches']		= 'The {field} field does not match the {param} field.';
 $lang['form_validation_differs']		= 'The {field} field must differ from the {param} field.';
 $lang['form_validation_is_unique'] 		= 'The {field} field must contain a unique value.';
+$lang['form_validation_exists'] 		= 'The {field} field doesn\'t exist in database table.';
 $lang['form_validation_is_natural']		= 'The {field} field must only contain digits.';
 $lang['form_validation_is_natural_no_zero']	= 'The {field} field must only contain digits and must be greater than zero.';
 $lang['form_validation_decimal']		= 'The {field} field must contain a decimal number.';

--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -1134,7 +1134,27 @@ class CI_Form_validation {
 			? ($this->CI->db->limit(1)->get_where($table, array($field => $str))->num_rows() === 0)
 			: FALSE;
 	}
+	
+	// --------------------------------------------------------------------
 
+	/**
+	 * Exists
+	 *
+	 * Check if the input value already exist
+	 * in the specified database field.
+	 *
+	 * @param	string	$str
+	 * @param	string	$field
+	 * @return	bool
+	 */
+	public function exists($str, $field)
+	{
+		sscanf($field, '%[^.].%[^.]', $table, $field);
+		return isset($this->CI->db)
+			? ($this->CI->db->limit(1)->get_where($table, array($field => $str))->num_rows() === 1)
+			: FALSE;
+	}
+	
 	// --------------------------------------------------------------------
 
 	/**

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -355,6 +355,7 @@ Release Date: Not Released
       -  Added rule **differs** to check if the value of a field differs from the value of another field.
       -  Added rule **valid_url**.
       -  Added rule **in_list** to check if the value of a field is within a given list.
+      -  Added rule **exists** to check if the value of a field exists in a database table field.
       -  Added support for named parameters in error messages.
       -  :doc:`Language <libraries/language>` line keys must now be prefixed with **form_validation_**.
       -  Added rule **alpha_numeric_spaces**.

--- a/user_guide_src/source/libraries/form_validation.rst
+++ b/user_guide_src/source/libraries/form_validation.rst
@@ -950,6 +950,9 @@ Rule                      Parameter  Description                                
 **is_unique**             Yes        Returns FALSE if the form element is not unique to the table and field name in the            is_unique[table.field]
                                      parameter. Note: This rule requires :doc:`Query Builder <../database/query_builder>` to be
                                      enabled in order to work.
+**exists**		  Yes	     Returns FALSE if the form element value doesn't already exist in the table and field	   exists[table.field]
+				     mentioned in the parameter. Note: This rule requires :doc:`Query Builder
+				     <../database/query_builder>` to be enabled in order to work.
 **min_length**            Yes        Returns FALSE if the form element is shorter than the parameter value.                        min_length[3]
 **max_length**            Yes        Returns FALSE if the form element is longer than the parameter value.                         max_length[12]
 **exact_length**          Yes        Returns FALSE if the form element is not exactly the parameter value.                         exact_length[8]


### PR DESCRIPTION
This rule will verify if a value already exists in a specified database table field.