### PR TITLE
Language loading 

### DIFF
--- a/system/core/Lang.php
+++ b/system/core/Lang.php
@@ -123,6 +123,14 @@ class CI_Lang {
 		{
 			include($basepath);
 		}
+		
+		// Override language settings with any found in application/language
+		$basepath = APPPATH.'language/'.$idiom.'/'.$langfile;
+		if (file_exists($basepath) === TRUE)
+		{
+			include($basepath);
+			$found = TRUE;
+		}
 
 		// Do we have an alternative path to look in?
 		if ($alt_path !== '')


### PR DESCRIPTION
Include application/language in the loading of a language file, for consistency with the other application components (config, libraries, etc).

At the moment, language files are loaded from system/language, and then over-ridden in a lang->load call or else in one of the package paths. This change would load them from system/language, over-ride them from application/language, and then finally from a path specified in the lang->load call or else in one of the package paths.

Signed-off-by:Master Yoda <jim_parry@bcit.ca>