### PR TITLE
Added Missing Permitted Uri chars

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -154,7 +154,7 @@ $config['composer_autoload'] = FALSE;
 | DO NOT CHANGE THIS UNLESS YOU FULLY UNDERSTAND THE REPERCUSSIONS!!
 |
 */
-$config['permitted_uri_chars'] = 'a-z 0-9~%.:_\-';
+$config['permitted_uri_chars'] = 'a-z 0-9~%\.\:_\-&=$';
 
 
 /*


### PR DESCRIPTION
I added more permitted_uri_chars because some times developers need the & and =.