### PR TITLE
Fix mysqli_real_escape_string

### DIFF
--- a/system/database/drivers/mysqli/mysqli_driver.php
+++ b/system/database/drivers/mysqli/mysqli_driver.php
@@ -312,8 +312,10 @@ class CI_DB_mysqli_driver extends CI_DB {
 			return $str;
 		}
 
-
-		$str = mysqli_real_escape_string($this->conn_id, $str);
+        if(is_object($this->conn_id) && !empty($str))
+        {
+            $str = mysqli_real_escape_string($this->conn_id, $str);
+        }
 
 		// escape LIKE condition wildcards
 		if ($like === TRUE)


### PR DESCRIPTION
When string is empty or connection is not available do not run function mysqli_real_escape_string