### PR TITLE
Added support for raw_input_stream and json_input_stream

### DIFF
--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -103,22 +103,16 @@ class CI_Input {
 	 */
 	protected $headers = array();
 
-	/**
-	 * Raw input stream data as received from php://input
-	 *
-	 * @see	CI_Input::raw_input_stream()
-	 * @var	array
-	 */
 	protected $_raw_input_stream = NULL;
 
 	/**
-	 * Input stream data
-	 *
-	 * Parsed from raw_input_stream at runtime
-	 *
-	 * @see	CI_Input::input_stream()
-	 * @var	array
-	 */
+	* Input stream data
+	*
+	* Parsed from php://input at runtime
+	*
+	* @see	CI_Input::input_stream()
+	* @var	array
+	*/
 	protected $_input_stream = NULL;
 
 	/**
@@ -307,54 +301,35 @@ class CI_Input {
 	// ------------------------------------------------------------------------
 
 	/**
-	 * Fetch raw data from php://input stream
-	 *
-	 * Useful when data is not an array.
-	 */
-	public function raw_input_stream()
-	{
-		// Prior to PHP 5.6, the input stream can only be read once,
-		// so we'll need to check if we have already done that first.
-		if (is_null($this->_raw_input_stream))
-		{
-			$this->_raw_input_stream = file_get_contents('php://input');
-		}
-
-		return $this->_raw_input_stream;
-	}
-	
-	// ------------------------------------------------------------------------
-
-	/**
-	 * Fetch an item from the input stream
-	 *
-	 * Useful when you need to access PUT, DELETE or PATCH request data.
-	 *
-	 * @param	string	$index		Index for item to be fetched
-	 * @param	bool	$xss_clean	Whether to apply XSS filtering
-	 * @return	mixed
-	 */
+	* Fetch an item from the php://input stream
+	*
+	* Useful when you need to access PUT, DELETE or PATCH request data.
+	*
+	* @param	string $index Index for item to be fetched
+	* @param	bool $xss_clean Whether to apply XSS filtering
+	* @return	mixed
+	*/
 	public function input_stream($index = NULL, $xss_clean = NULL)
 	{
-		parse_str($this->raw_input_stream(), $this->_input_stream);
+	// Prior to PHP 5.6, the input stream can only be read once,
+	// so we'll need to check if we have already done that first.
+		if ( ! is_array($this->_input_stream))
+		{
+			parse_str($this->raw_input_stream, $this->_input_stream);
+			is_array($this->_input_stream) OR $this->_input_stream = array();
+		}
 		return $this->_fetch_from_array($this->_input_stream, $index, $xss_clean);
 	}
-	
+
 	// ------------------------------------------------------------------------
 
-	/**
-	 * Fetch an item from the input stream
-	 *
-	 * Useful when you need to access input that's been send as json'
-	 *
-	 * @param	string	$index		Index for item to be fetched
-	 * @param	bool	$xss_clean	Whether to apply XSS filtering
-	 * @return	mixed
-	 */
-	public function json_input_stream($index = NULL, $xss_clean = NULL)
+	public function __get($name)
 	{
-		$json_input_stream = json_decode($this->raw_input_stream(), true);
-		return $this->_fetch_from_array($json_input_stream, $index, $xss_clean);
+		if ($name === 'raw_input_stream')
+		{
+			isset($this->_raw_input_stream) OR $this->_raw_input_stream = file_get_contents('php://input');
+			return $this->_raw_input_stream;
+		}
 	}
 
 	// ------------------------------------------------------------------------

--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -104,9 +104,9 @@ class CI_Input {
 	protected $headers = array();
 
 	/**
-	 * Raw input stream data
+	 * Raw input stream data as received from php://input
 	 *
-	 * @see	CI_Input::input_stream()
+	 * @see	CI_Input::raw_input_stream()
 	 * @var	array
 	 */
 	protected $_raw_input_stream = NULL;
@@ -114,12 +114,12 @@ class CI_Input {
 	/**
 	 * Input stream data
 	 *
-	 * Parsed from php://input at runtime
+	 * Parsed from raw_input_stream at runtime
 	 *
 	 * @see	CI_Input::input_stream()
 	 * @var	array
 	 */
-	protected $_input_stream = NULL; // Kept for backward compatible.
+	protected $_input_stream = NULL;
 
 	/**
 	 * Class constructor
@@ -309,7 +309,7 @@ class CI_Input {
 	/**
 	 * Fetch raw data from php://input stream
 	 *
-	 * Useful when data is not an array and might contain = and & symbols.
+	 * Useful when data is not an array.
 	 */
 	public function raw_input_stream()
 	{
@@ -326,7 +326,7 @@ class CI_Input {
 	// ------------------------------------------------------------------------
 
 	/**
-	 * Fetch an item from the php://input stream
+	 * Fetch an item from the input stream
 	 *
 	 * Useful when you need to access PUT, DELETE or PATCH request data.
 	 *
@@ -343,9 +343,9 @@ class CI_Input {
 	// ------------------------------------------------------------------------
 
 	/**
-	 * Fetch an item from the php://input stream
+	 * Fetch an item from the input stream
 	 *
-	 * Useful when you need to access input that's been send as raw json data'
+	 * Useful when you need to access input that's been send as json'
 	 *
 	 * @param	string	$index		Index for item to be fetched
 	 * @param	bool	$xss_clean	Whether to apply XSS filtering

--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -103,16 +103,16 @@ class CI_Input {
 	 */
 	protected $headers = array();
 
-	protected $_raw_input_stream = NULL;
+	protected $_raw_input_stream;
 
 	/**
-	* Input stream data
-	*
-	* Parsed from php://input at runtime
-	*
-	* @see	CI_Input::input_stream()
-	* @var	array
-	*/
+	 * Input stream data
+	 *
+	 * Parsed from php://input at runtime
+	 *
+	 * @see	CI_Input::input_stream()
+	 * @var	array
+	 */
 	protected $_input_stream = NULL;
 
 	/**
@@ -301,23 +301,25 @@ class CI_Input {
 	// ------------------------------------------------------------------------
 
 	/**
-	* Fetch an item from the php://input stream
-	*
-	* Useful when you need to access PUT, DELETE or PATCH request data.
-	*
-	* @param	string $index Index for item to be fetched
-	* @param	bool $xss_clean Whether to apply XSS filtering
-	* @return	mixed
-	*/
+	 * Fetch an item from the php://input stream
+	 *
+	 * Useful when you need to access PUT, DELETE or PATCH request data.
+	 *
+	 * @param	string $index Index for item to be fetched
+	 * @param	bool $xss_clean Whether to apply XSS filtering
+	 * @return	mixed
+	 */
 	public function input_stream($index = NULL, $xss_clean = NULL)
 	{
-	// Prior to PHP 5.6, the input stream can only be read once,
-	// so we'll need to check if we have already done that first.
+		// Prior to PHP 5.6, the input stream can only be read once,
+		// so we'll need to check if we have already done that first.
 		if ( ! is_array($this->_input_stream))
 		{
+			// $this->raw_input_stream will trigger __get().
 			parse_str($this->raw_input_stream, $this->_input_stream);
 			is_array($this->_input_stream) OR $this->_input_stream = array();
 		}
+		
 		return $this->_fetch_from_array($this->_input_stream, $index, $xss_clean);
 	}
 

--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -305,8 +305,8 @@ class CI_Input {
 	 *
 	 * Useful when you need to access PUT, DELETE or PATCH request data.
 	 *
-	 * @param	string $index Index for item to be fetched
-	 * @param	bool $xss_clean Whether to apply XSS filtering
+	 * @param	string	$index		Index for item to be fetched
+	 * @param	bool	$xss_clean	Whether to apply XSS filtering
 	 * @return	mixed
 	 */
 	public function input_stream($index = NULL, $xss_clean = NULL)
@@ -319,7 +319,7 @@ class CI_Input {
 			parse_str($this->raw_input_stream, $this->_input_stream);
 			is_array($this->_input_stream) OR $this->_input_stream = array();
 		}
-		
+
 		return $this->_fetch_from_array($this->_input_stream, $index, $xss_clean);
 	}
 

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -492,6 +492,8 @@ Release Date: Not Released
       -  Added an option for ``_clean_input_keys()`` to return FALSE instead of terminating the whole script.
       -  Deprecated the ``is_cli_request()`` method, it is now an alias for the new :php:func:`is_cli()` common function.
       -  Added an ``$xss_clean`` parameter to method ``user_agent()`` and removed the ``$user_agent`` property.
+      -  Added gettable property ``raw_input_stream`` to access the **php://input** data.
+      -  Changed method ``input_stream()`` to obtain the data from ``raw_input_stream`` property.
 
    -  :doc:`Common functions <general/common_functions>` changes include:
 

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -492,8 +492,7 @@ Release Date: Not Released
       -  Added an option for ``_clean_input_keys()`` to return FALSE instead of terminating the whole script.
       -  Deprecated the ``is_cli_request()`` method, it is now an alias for the new :php:func:`is_cli()` common function.
       -  Added an ``$xss_clean`` parameter to method ``user_agent()`` and removed the ``$user_agent`` property.
-      -  Added gettable property ``raw_input_stream`` to access the **php://input** data.
-      -  Changed method ``input_stream()`` to obtain the data from ``raw_input_stream`` property.
+      -  Added property ``$raw_input_stream`` to access **php://input** data.
 
    -  :doc:`Common functions <general/common_functions>` changes include:
 

--- a/user_guide_src/source/libraries/input.rst
+++ b/user_guide_src/source/libraries/input.rst
@@ -93,12 +93,12 @@ one shot at all of the POST data.
 
 CodeIgniter will take care of that for you, and you can read the data
 from the **php://input** stream at any time, just by using the
-``raw_input_stream`` property::
+``$raw_input_stream`` property::
 
 	$this->input->raw_input_stream;
 
-Additionally if the input stream is formated in a query string fashion
-you can access it's values, just by calling the
+Additionally if the input stream is form-encoded like $_POST you can 
+access its values by calling the
 ``input_stream()`` method::
 
 	$this->input->input_stream('key');
@@ -119,6 +119,12 @@ Class Reference
 ***************
 
 .. php:class:: CI_Input
+
+	.. attribute:: $raw_input_stream
+		
+		Read only property that will return php://input data as is.
+		
+		The property can be read multiple times.
 
 	.. php:method:: post([$index = NULL[, $xss_clean = NULL]])
 

--- a/user_guide_src/source/libraries/input.rst
+++ b/user_guide_src/source/libraries/input.rst
@@ -91,8 +91,14 @@ the ``$_POST`` array, because it will always exist and you can try
 and access multiple variables without caring that you might only have
 one shot at all of the POST data.
 
-CodeIgniter will take care of that for you, and you can access data
-from the **php://input** stream at any time, just by calling the
+CodeIgniter will take care of that for you, and you can read the data
+from the **php://input** stream at any time, just by using the
+``raw_input_stream`` property::
+
+	$this->input->raw_input_stream;
+
+Additionally if the input stream is formated in a query string fashion
+you can access it's values, just by calling the
 ``input_stream()`` method::
 
 	$this->input->input_stream('key');


### PR DESCRIPTION
There might be cases were a client sends a request with data not in the key1=value1&key2=value2&... fashion for those cases I've added the raw_input_stream.
The input_stream function has been modified to get the data from raw_input_stream.
json_input_stream has been added for cases where the body of the request is in a json format.

Some notes:
$_input_stream has been preserved cause some people might be using it on a extension of the class, even though since 3.0 it's a pre-release version maybe it could be deleted.
On the other hand and even though it's not implemented maybe it would be better (for performance) to just parse both the input / json once, and leave it on a variable, to avoid parsing on the next call.