### PR TITLE
Fix #3642

### DIFF
--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -247,12 +247,14 @@ if ( ! function_exists('get_config'))
 			{
 				$found = TRUE;
 				require($file_path);
+				$config['__is_loaded'][] = $file_path;
 			}
 
 			// Is the config file in the environment folder?
 			if (file_exists($file_path = APPPATH.'config/'.ENVIRONMENT.'/config.php'))
 			{
 				require($file_path);
+				$config['__is_loaded'][] = $file_path;
 			}
 			elseif ( ! $found)
 			{

--- a/system/core/Config.php
+++ b/system/core/Config.php
@@ -102,7 +102,14 @@ class CI_Config {
 
 			$this->set_item('base_url', $base_url);
 		}
-
+		
+		// Add loaded confing path to list 
+		if (isset($this->config['__is_loaded'])) 
+		{
+        		$this->is_loaded = $this->config['__is_loaded'];
+        		unset($this->config['__is_loaded']);
+        	}
+        	
 		log_message('info', 'Config Class Initialized');
 	}
 
@@ -128,7 +135,7 @@ class CI_Config {
 				$file_path = $path.'config/'.$location.'.php';
 				if (in_array($file_path, $this->is_loaded, TRUE))
 				{
-					return TRUE;
+					continue;
 				}
 
 				if ( ! file_exists($file_path))

--- a/system/core/Config.php
+++ b/system/core/Config.php
@@ -103,7 +103,7 @@ class CI_Config {
 			$this->set_item('base_url', $base_url);
 		}
 		
-		// Add loaded confing path to list 
+		// Add loaded config path to list 
 		if (isset($this->config['__is_loaded'])) 
 		{
         		$this->is_loaded = $this->config['__is_loaded'];


### PR DESCRIPTION
Fix 1. when load the main config file, it will not add into CI_Config::is_loaded. once load other package/config.php, the application/config/config.php will include again and merge into current config. if application/config/config.php base_url is empty, here will jump over automatically set the base_url if none was provided in config class constructor and override the base_url to empty.
Fix 2. when use the same name, it will stop end quit the function when the file use a same file, change return true to continue to make sure check all config paths.