### PR TITLE
count_all_results() with $this->reset_select() 

### DIFF
--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -1355,7 +1355,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 * @param	string
 	 * @return	int
 	 */
-	public function count_all_results($table = '')
+	public function count_all_results($table = '', $reset = true)
 	{
 		if ($table !== '')
 		{
@@ -1366,7 +1366,10 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 		$result = ($this->qb_distinct === TRUE)
 			? $this->query($this->_count_string.$this->protect_identifiers('numrows')."\nFROM (\n".$this->_compile_select()."\n) CI_count_all_results")
 			: $this->query($this->_compile_select($this->_count_string.$this->protect_identifiers('numrows')));
-		$this->_reset_select();
+        if($reset)
+        {
+		    $this->_reset_select();
+        }
 
 		if ($result->num_rows() === 0)
 		{

--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -1353,9 +1353,10 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 * returned by an Query Builder query.
 	 *
 	 * @param	string
+	 * @param	bool	TRUE: resets QB values; FALSE: leave QB vaules alone
 	 * @return	int
 	 */
-	public function count_all_results($table = '', $reset = true)
+	public function count_all_results($table = '', $reset = TRUE)
 	{
 		if ($table !== '')
 		{
@@ -1367,10 +1368,10 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 			? $this->query($this->_count_string.$this->protect_identifiers('numrows')."\nFROM (\n".$this->_compile_select()."\n) CI_count_all_results")
 			: $this->query($this->_compile_select($this->_count_string.$this->protect_identifiers('numrows')));
 
-                if($reset)
-                {
-		        $this->_reset_select();
-                }
+		if($reset === TRUE)
+		{
+		    $this->_reset_select();
+		}
 
 		if ($result->num_rows() === 0)
 		{

--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -1366,10 +1366,11 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 		$result = ($this->qb_distinct === TRUE)
 			? $this->query($this->_count_string.$this->protect_identifiers('numrows')."\nFROM (\n".$this->_compile_select()."\n) CI_count_all_results")
 			: $this->query($this->_compile_select($this->_count_string.$this->protect_identifiers('numrows')));
-        if($reset)
-        {
-		    $this->_reset_select();
-        }
+
+                if($reset)
+                {
+		        $this->_reset_select();
+                }
 
 		if ($result->num_rows() === 0)
 		{

--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -1353,7 +1353,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 * returned by an Query Builder query.
 	 *
 	 * @param	string
-	 * @param	bool	TRUE: resets QB values; FALSE: leave QB vaules alone
+	 * @param	bool	the reset clause
 	 * @return	int
 	 */
 	public function count_all_results($table = '', $reset = TRUE)
@@ -1368,9 +1368,9 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 			? $this->query($this->_count_string.$this->protect_identifiers('numrows')."\nFROM (\n".$this->_compile_select()."\n) CI_count_all_results")
 			: $this->query($this->_compile_select($this->_count_string.$this->protect_identifiers('numrows')));
 
-		if($reset === TRUE)
+		if ($reset === TRUE)
 		{
-		    $this->_reset_select();
+			$this->_reset_select();
 		}
 
 		if ($result->num_rows() === 0)

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -176,6 +176,7 @@ Release Date: Not Released
    -  Added Interbase/Firebird database support via the *ibase* driver.
    -  Added ODBC support for ``create_database()``, ``drop_database()`` and ``drop_table()`` in :doc:`Database Forge <database/forge>`.
    -  Added support to binding arrays as ``IN()`` sets in ``query()``.
+   -  Added an optional second parameter to ``count_all_results()``.
 
    -  :doc:`Query Builder <database/query_builder>` changes include:
 
@@ -192,6 +193,7 @@ Release Date: Not Released
       - Methods ``insert_batch()`` and ``update_batch()`` now return an integer representing the number of rows affected by them.
       - Methods ``where()``, ``or_where()``, ``having()`` and ``or_having()`` now convert trailing  ``=`` and ``<>``,  ``!=`` SQL operators to ``IS NULL`` and ``IS NOT NULL`` respectively when the supplied comparison value is ``NULL``.
       - Added method chaining support to ``reset_query()``, ``start_cache()``, ``stop_cache()`` and ``flush_cache()``.
+      - Added an optional second parameter to ``count_all_results`` that allows leaving QB values alone.
 
    -  :doc:`Database Results <database/results>` changes include:
 

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -176,7 +176,6 @@ Release Date: Not Released
    -  Added Interbase/Firebird database support via the *ibase* driver.
    -  Added ODBC support for ``create_database()``, ``drop_database()`` and ``drop_table()`` in :doc:`Database Forge <database/forge>`.
    -  Added support to binding arrays as ``IN()`` sets in ``query()``.
-   -  Added an optional second parameter to ``count_all_results()``.
 
    -  :doc:`Query Builder <database/query_builder>` changes include:
 
@@ -193,7 +192,7 @@ Release Date: Not Released
       - Methods ``insert_batch()`` and ``update_batch()`` now return an integer representing the number of rows affected by them.
       - Methods ``where()``, ``or_where()``, ``having()`` and ``or_having()`` now convert trailing  ``=`` and ``<>``,  ``!=`` SQL operators to ``IS NULL`` and ``IS NOT NULL`` respectively when the supplied comparison value is ``NULL``.
       - Added method chaining support to ``reset_query()``, ``start_cache()``, ``stop_cache()`` and ``flush_cache()``.
-      - Added an optional second parameter to ``count_all_results`` that allows leaving QB values alone.
+      - Added an optional second to ``count_all_results()`` to disable resetting of QB values.
 
    -  :doc:`Database Results <database/results>` changes include:
 

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -527,6 +527,12 @@ where(), or_where(), like(), or_like(), etc. Example::
 	$this->db->from('my_table');
 	echo $this->db->count_all_results(); // Produces an integer, like 17
 
+The second paramater is to disable resetting of QB values. Example::
+
+	echo $this->db->count_all_results('my_table');  // Produces an integer, like 25
+	$this->db->like('title', 'match');
+	echo $this->db->count_all_results(); // Produces an integer, like 17
+
 **$this->db->count_all()**
 
 Permits you to determine the number of rows in a particular table.


### PR DESCRIPTION
On line 1358 of file 'system/database/DB_query_builder.php'，function count_all_results() will call reset_select(), and this will reset the condition of select query.
However, in some case, we need to get the results as well as count. For example, in pagination, we need to count all the results, but only results of 0-20 using limit.
If we code as

    $count = $this->db->count_all_results();//get total numbers
    $this->db->limit(0, 20);//get first 20
    $data = $this->db->get()->result();//this will not work

So, I suggest to add a parameter with boolean value to judge whether to call reset_select().