### PR TITLE
Fixed a typo in uri.rst documentation

### DIFF
--- a/user_guide_src/source/libraries/uri.rst
+++ b/user_guide_src/source/libraries/uri.rst
@@ -110,7 +110,7 @@ Class Reference
 		:returns:	Associative URI segments array
 		:rtype:	array
 
-		This method lets you turn URI segments into and associative array of
+		This method lets you turn URI segments into an associative array of
 		key/value pairs. Consider this URI::
 
 			index.php/user/search/name/joe/location/UK/gender/male


### PR DESCRIPTION
Changed "and" to "an". Editing the file online on github.com shows the last line of the file as changed, even though I didn't change it at all. It keeps doing that so I don't know how to avoid it. What I really changed is only line 113.