### PR TITLE
Fixed redis cache save logic

### DIFF
--- a/system/libraries/Cache/drivers/Cache_redis.php
+++ b/system/libraries/Cache/drivers/Cache_redis.php
@@ -111,7 +111,7 @@ class CI_Cache_redis extends CI_Driver
 	{
 		if (is_array($data) OR is_object($data))
 		{
-			if ( ! $this->_redis->sAdd('_ci_redis_serialized', $id))
+			if ( ! $this->_redis->sIsMember('_ci_redis_serialized', $id) && ! $this->_redis->sAdd('_ci_redis_serialized', $id))
 			{
 				return FALSE;
 			}


### PR DESCRIPTION
It was trying to use sAdd as a check if the key was created, but that will return false if it is already present in the set.