### PR TITLE
system/core/Common.php, function html_escape

### DIFF
--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -741,7 +741,6 @@ if ( ! function_exists('html_escape'))
 	 */
 	function html_escape($var, $double_encode = TRUE)
 	{
-		// If empty, skip escaping
 		if (empty($var))
 		{
 			return $var;

--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -743,6 +743,12 @@ if ( ! function_exists('html_escape'))
 	{
 		if (is_array($var))
 		{
+			// If empty array, skip escaping
+			if ( empty($var) )
+			{
+				return $var;
+			}
+			
 			return array_map('html_escape', $var, array_fill(0, count($var), $double_encode));
 		}
 

--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -741,14 +741,14 @@ if ( ! function_exists('html_escape'))
 	 */
 	function html_escape($var, $double_encode = TRUE)
 	{
+		// If empty, skip escaping
+		if (empty($var))
+		{
+			return $var;
+		}
+		
 		if (is_array($var))
 		{
-			// If empty array, skip escaping
-			if ( empty($var) )
-			{
-				return $var;
-			}
-			
 			return array_map('html_escape', $var, array_fill(0, count($var), $double_encode));
 		}
 


### PR DESCRIPTION
Fix: array_fill() throws an error if count($var) is 0
Signed-off-by: Joshua Logsdon <logsdon.joshua@gmail.com>