### PR TITLE
Fix language overriding

### DIFF
--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -1656,7 +1656,11 @@ abstract class CI_DB_driver {
 	public function display_error($error = '', $swap = '', $native = FALSE)
 	{
 		$LANG =& load_class('Lang', 'core');
-		$LANG->load('db');
+
+		if ( ! isset($LANG->is_loaded['db_lang.php']))
+		{
+			$LANG->load('db');
+		}
 
 		$heading = $LANG->line('db_error_heading');
 

--- a/system/helpers/date_helper.php
+++ b/system/helpers/date_helper.php
@@ -178,7 +178,11 @@ if ( ! function_exists('timespan'))
 	function timespan($seconds = 1, $time = '', $units = 7)
 	{
 		$CI =& get_instance();
-		$CI->lang->load('date');
+
+		if ( ! isset($CI->lang->is_loaded['date_lang.php']))
+		{
+			$CI->lang->load('date');
+		}
 
 		is_numeric($seconds) OR $seconds = 1;
 		is_numeric($time) OR $time = time();

--- a/system/helpers/number_helper.php
+++ b/system/helpers/number_helper.php
@@ -61,7 +61,11 @@ if ( ! function_exists('byte_format'))
 	function byte_format($num, $precision = 1)
 	{
 		$CI =& get_instance();
-		$CI->lang->load('number');
+
+		if ( ! isset($CI->lang->is_loaded['number_lang.php']))
+		{
+			$CI->lang->load('number');
+		}
 
 		if ($num >= 1000000000000)
 		{

--- a/system/libraries/Email.php
+++ b/system/libraries/Email.php
@@ -2245,7 +2245,11 @@ class CI_Email {
 	protected function _set_error_message($msg, $val = '')
 	{
 		$CI =& get_instance();
-		$CI->lang->load('email');
+
+		if ( ! isset($CI->lang->is_loaded['email_lang.php']))
+		{
+			$CI->lang->load('email');
+		}
 
 		if (sscanf($msg, 'lang:%s', $line) !== 1 OR FALSE === ($line = $CI->lang->line($line)))
 		{

--- a/system/libraries/Ftp.php
+++ b/system/libraries/Ftp.php
@@ -660,7 +660,11 @@ class CI_FTP {
 	protected function _error($line)
 	{
 		$CI =& get_instance();
-		$CI->lang->load('ftp');
+
+		if ( ! isset($CI->lang->is_loaded['ftp_lang.php']))
+		{
+			$CI->lang->load('ftp');
+		}
 		show_error($CI->lang->line($line));
 	}
 

--- a/system/libraries/Image_lib.php
+++ b/system/libraries/Image_lib.php
@@ -1783,7 +1783,11 @@ class CI_Image_lib {
 	public function set_error($msg)
 	{
 		$CI =& get_instance();
-		$CI->lang->load('imglib');
+
+		if ( ! isset($CI->lang->is_loaded['imglib_lang.php']))
+		{
+			$CI->lang->load('imglib');
+		}
 
 		if (is_array($msg))
 		{

--- a/system/libraries/Migration.php
+++ b/system/libraries/Migration.php
@@ -141,7 +141,10 @@ class CI_Migration {
 		$this->_migration_path = rtrim($this->_migration_path, '/').'/';
 
 		// Load migration language
-		$this->lang->load('migration');
+		if ( ! isset($this->lang->is_loaded['migration_lang.php']))
+		{
+			$this->lang->load('migration');
+		}
 
 		// They'll probably be using dbforge
 		$this->load->dbforge();

--- a/system/libraries/Pagination.php
+++ b/system/libraries/Pagination.php
@@ -330,7 +330,11 @@ class CI_Pagination {
 	public function __construct($params = array())
 	{
 		$this->CI =& get_instance();
-		$this->CI->load->language('pagination');
+
+		if ( ! isset($this->CI->lang->is_loaded['pagination_lang.php']))
+		{
+			$this->CI->lang->load('pagination');
+		}
 		foreach (array('first_link', 'next_link', 'prev_link', 'last_link') as $key)
 		{
 			if (($val = $this->CI->lang->line('pagination_'.$key)) !== FALSE)

--- a/system/libraries/Profiler.php
+++ b/system/libraries/Profiler.php
@@ -98,7 +98,11 @@ class CI_Profiler {
 	public function __construct($config = array())
 	{
 		$this->CI =& get_instance();
-		$this->CI->load->language('profiler');
+
+		if ( ! isset($this->CI->lang->is_loaded['profiler_lang.php']))
+		{
+			$this->CI->lang->load('profiler');
+		}
 
 		if (isset($config['query_toggle_count']))
 		{

--- a/system/libraries/Upload.php
+++ b/system/libraries/Upload.php
@@ -1123,7 +1123,10 @@ class CI_Upload {
 	 */
 	public function set_error($msg)
 	{
-		$this->_CI->lang->load('upload');
+		if ( ! isset($this->_CI->lang->is_loaded['upload_lang.php']))
+		{
+			$this->_CI->lang->load('upload');
+		}
 
 		is_array($msg) OR $msg = array($msg);
 


### PR DESCRIPTION
I think this is supposed to be done for 8d5b24a8c55dc1ae7721e10de094c4aba2ca7eae. I don't think this is a good way to do it, though. I think lang library should be changed to support this natively. Not sure of the best way. Open to suggestions.