### PR TITLE
Fixes pagination with relative URL

### DIFF
--- a/system/libraries/Pagination.php
+++ b/system/libraries/Pagination.php
@@ -644,7 +644,7 @@ class CI_Pagination {
 
 		// Kill double slashes. Note: Sometimes we can end up with a double slash
 		// in the penultimate link so we'll kill all double slashes.
-		$output = preg_replace('#([^:])//+#', '\\1/', $output);
+		$output = preg_replace('#([^:"])//+#', '\\1/', $output);
 
 		// Add the wrapper HTML if exists
 		return $this->full_tag_open.$output.$this->full_tag_close;


### PR DESCRIPTION
When base_url is a URL based on protocol, like "//www.google.com" the double slash regex kills the first "//".