### PR TITLE
Fixed typo

### DIFF
--- a/system/libraries/Encryption.php
+++ b/system/libraries/Encryption.php
@@ -121,7 +121,7 @@ class CI_Encryption {
 	);
 
 	/**
-	 * List of supported HMAC algorightms
+	 * List of supported HMAC algorithms
 	 *
 	 * name => digest size pairs
 	 *


### PR DESCRIPTION
Fixed a typo in the HMAC array list, the "algorithms" word of the comment was mistyped.