### PR TITLE
Lowercase $side variable for $this->db->like() in Query Builder

### DIFF
--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -925,6 +925,9 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 				? $this->_group_get_type('') : $this->_group_get_type($type);
 
 			$v = $this->escape_like_str($v);
+			
+			// lowercase $side for user habits to write in UPPERCASE
+			$side = strtlower($side);
 
 			if ($side === 'none')
 			{


### PR DESCRIPTION
```$this->db->like('name',$value,'AFTER')``` returns ```LIKE '%$value%'```. Safer to lowercase for coding speed and developer habits.