### PR TITLE
Add the name of the directory in the array key.

### DIFF
--- a/system/helpers/file_helper.php
+++ b/system/helpers/file_helper.php
@@ -245,8 +245,9 @@ if ( ! function_exists('get_dir_file_info'))
 				}
 				elseif ($file[0] !== '.')
 				{
-					$_filedata[$file] = get_file_info($source_dir.$file);
-					$_filedata[$file]['relative_path'] = $relative_path;
+					$_filekey = basename($source_dir) . "/" . $file;
+					$_filedata[$_filekey] = get_file_info($source_dir.$file);
+					$_filedata[$_filekey]['relative_path'] = $relative_path;
 				}
 			}
 


### PR DESCRIPTION
When I have two files are the same in the sub directory the file is in the root directory will not be listed. probably due to an array of key using the file name, so it will override the existing file in the subdirectory.

Example:

```
/dir_a/
|- file_a.jpg
|- /sub_dir_a/
   |- file_a.jpg
```

Will generate :

```
[file_a.jpg] => Array
        (
            [name] => file_a.jpg
            [server_path] => /dir_a/sub_dir_a/file_a.jpg
            [size] => 103675
            [date] => 1425054886
            [relative_path] => /dir_a/sub_dir_a
        )
```

After adding the name of the directory in the array key:

```
[dir_a/file_a.jpg] => Array
        (
            [name] => file_a.jpg
            [server_path] => /dir_a/file_a.jpg
            [size] => 103675
            [date] => 1425054886
            [relative_path] => /dir_a
        )
[sub_dir_a/file_a.jpg] => Array
        (
            [name] => file_a.jpg
            [server_path] => /dir_a/sub_dir_a/file_a.jpg
            [size] => 103675
            [date] => 1425054886
            [relative_path] => /dir_a/sub_dir_a
        )
```
