### PR TITLE
CI_DB_query_builder::like() strtolower for $side variable

### DIFF
--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -832,7 +832,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 */
 	public function like($field, $match = '', $side = 'both', $escape = NULL)
 	{
-		return $this->_like($field, $match, 'AND ', $side, '', $escape);
+		return $this->_like($field, $match, 'AND ', strtolower($side), '', $escape);
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
$this->db->like('name',$value,'AFTER') returns LIKE '%$value%'. Safer to lowercase for coding speed and developer habits.