### PR TITLE
Matched root_path's slashes with the name being replaced in the Zip::read_dir() library

### DIFF
--- a/system/libraries/Zip.php
+++ b/system/libraries/Zip.php
@@ -352,7 +352,7 @@ class CI_Zip {
 		// Set the original directory root for child dir's to use as relative
 		if ($root_path === NULL)
 		{
-			$root_path = dirname($path).DIRECTORY_SEPARATOR;
+			$root_path = str_replace(array('\\', '/'), DIRECTORY_SEPARATOR, dirname($path)).DIRECTORY_SEPARATOR;
 		}
 
 		while (FALSE !== ($file = readdir($fp)))


### PR DESCRIPTION
This pull request solves an issue with the $root_path's slashes not matching up with the $name it is replacing when $preserve_filepath is set to FALSE.