### PR TITLE
Edit dbforge drop_table line 230

### DIFF
--- a/user_guide_src/source/database/forge.rst
+++ b/user_guide_src/source/database/forge.rst
@@ -227,7 +227,7 @@ Execute a DROP TABLE statement and optionally add an IF EXISTS clause.
 	$this->dbforge->drop_table('table_name');
 
 	// Produces: DROP TABLE IF EXISTS table_name
-	$this->dbforge->drop_table('table_name');
+	$this->dbforge->drop_table('table_name',TRUE);
 
 
 Renaming a table


### PR DESCRIPTION
At current the documentation does not distinguish between DROP TABLE IF EXISTS table_name and DROP TABLE table_name. As seen by the DB_forge.php class in system/database; the function accepts a Boolean as the second parameter as to whether or not to apply the IF EXISTS mysql condition.