### PR TITLE
Check if session key exists before unseting.

### DIFF
--- a/system/libraries/Session/Session.php
+++ b/system/libraries/Session/Session.php
@@ -720,13 +720,18 @@ class CI_Session {
 		{
 			foreach ($key as $k)
 			{
-				unset($_SESSION[$k]);
+				if(isset($_SESSION[$k]))
+				{
+					unset($_SESSION[$k]);
+				}
 			}
 
 			return;
 		}
-
-		unset($_SESSION[$key]);
+		if(isset($_SESSION[$key]))
+		{
+			unset($_SESSION[$key]);
+		}
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
Method unset_userdata is public so it will be good if we check existence of any key before unsetting it.