### PR TITLE
Fixing #3733 issue with new library autoloader foreach.

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -1305,11 +1305,32 @@ class CI_Loader {
 				$this->database();
 				$autoload['libraries'] = array_diff($autoload['libraries'], array('database'));
 			}
-
-			// Load all other libraries
-			foreach ($autoload['libraries'] as $item)
-			{
-				$this->library($item);
+			
+			/**
+			 * Load all other libraries with fixing issue #3733
+			 *
+			 * @url: https://github.com/bcit-ci/CodeIgniter/issues/3733
+			 * @author: Adam Liszkai <contact@liszkaiadam.hu>
+			 * @date: 2015.04.04 16:00
+			 *
+			 * previous snippet:
+			 *
+			 * foreach ($autoload['libraries'] as $item)
+			 * {
+		     *		$this->library($item);
+			 * }
+			 *
+			 */
+			foreach ($autoload['libraries'] as $item => $name)
+			{			    
+			    if(is_int($item))
+			    {
+				    $this->library($name);
+				}
+				else
+				{
+				    $this->library($item, NULL, $name);
+				}
 			}
 		}
 


### PR DESCRIPTION
Rewrite the autoloader library load with the custom name feature what is missing from autoloader (but is in the comments to available to use it)

```php
/*
| -------------------------------------------------------------------
|  Auto-load Libraries
| -------------------------------------------------------------------
| These are the classes located in the system/libraries folder
| or in your application/libraries folder.
|
| Prototype:
|
|	$autoload['libraries'] = array('database', 'email', 'session');
|
| You can also supply an alternative library name to be assigned
| in the controller:
|
|	$autoload['libraries'] = array('user_agent' => 'ua');
*/
```