### PR TITLE
Array keys validation before set and unset them.

### DIFF
--- a/system/libraries/Session/Session.php
+++ b/system/libraries/Session/Session.php
@@ -700,8 +700,11 @@ class CI_Session {
 
 			return;
 		}
-
-		$_SESSION[$data] = $value;
+		
+		if(is_string($data) OR is_int($data))
+		{
+			$_SESSION[$data] = $value;
+		}
 	}
 
 	// ------------------------------------------------------------------------
@@ -720,13 +723,19 @@ class CI_Session {
 		{
 			foreach ($key as $k)
 			{
-				unset($_SESSION[$k]);
+				if(is_string($k) OR is_int($k))
+				{
+					unset($_SESSION[$k]);
+				}
 			}
 
 			return;
 		}
 
-		unset($_SESSION[$key]);
+		if(is_string($key) OR is_int($key))
+		{
+			unset($_SESSION[$key]);
+		}
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
As set_userdata and unset_userdata are public methods which directly work with SESSION array they should have validation of sent keys.
By default Arrays have keys (int or string) and values - anything. This means that values don't have any validation while keys must be checked else there can be errors if clients send invalid format NULL/Object...

This is related to a previous PR from me which was poor.
Validation of keys is needed in those 2 places on setting and unseting session array items.

How ever this may cause need of either logging error or returning false. Specially at the case with setting data. I am not quite sure why there is no return at the moment.