### PR TITLE
Separate mobile cache feature

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -296,6 +296,18 @@ $config['cache_query_string'] = FALSE;
 
 /*
 |--------------------------------------------------------------------------
+| Separate Mobile Cache
+|--------------------------------------------------------------------------
+|
+| Set this to TRUE if you want to use different cache files for mobile 
+| visitors.  Please be aware that this will result in twice as many cache 
+| files.
+|
+*/
+$config['separate_mobile_cache'] = FALSE;
+
+/*
+|--------------------------------------------------------------------------
 | Encryption Key
 |--------------------------------------------------------------------------
 |

--- a/system/core/CodeIgniter.php
+++ b/system/core/CodeIgniter.php
@@ -501,6 +501,16 @@ if ( ! is_php('5.4'))
 
 /*
  * ------------------------------------------------------
+ *  If separate mobile cache is enabled, then the 
+ *  CI_User_agent class has already been instantiated.
+ *  Automatically load it into the controller.
+ * ------------------------------------------------------
+ */
+	$CI->user_agent = $OUT->user_agent;
+
+
+/*
+ * ------------------------------------------------------
  *  Is there a "post_controller_constructor" hook?
  * ------------------------------------------------------
  */

--- a/system/core/Output.php
+++ b/system/core/Output.php
@@ -737,8 +737,7 @@ class CI_Output {
 	/**
 	 * Delete cache
 	 *
-	 * @param	string	$uri	    URI string
-	 * @param       bool    $is_mobile  Whether to delete the mobile cache
+	 * @param	string	$uri  URI string
 	 * @return	bool
 	 */
 	public function delete_cache($uri = '')

--- a/system/core/Output.php
+++ b/system/core/Output.php
@@ -671,15 +671,15 @@ class CI_Output {
 			$uri .= '?'.$_SERVER['QUERY_STRING'];
 		}
         
-        if ($CFG->item('separate_mobile_cache'))
-        {
-            require_once(BASEPATH.'libraries/User_agent.php');
-            $this->user_agent = new CI_User_agent();
-            if ($this->user_agent->is_mobile)
-            {
-                $uri .= self::MOBILE_HASHTAG;
-            }
-        }
+		if ($CFG->item('separate_mobile_cache'))
+		{
+			require_once(BASEPATH.'libraries/User_agent.php');
+			$this->user_agent = new CI_User_agent();
+			if ($this->user_agent->is_mobile)
+			{
+				$uri .= self::MOBILE_HASHTAG;
+			}
+		}
 
 		$filepath = $cache_path.md5($uri);
 
@@ -737,10 +737,11 @@ class CI_Output {
 	/**
 	 * Delete cache
 	 *
-	 * @param	string	$uri	URI string
+	 * @param	string	$uri	    URI string
+	 * @param       bool    $is_mobile  Whether to delete the mobile cache
 	 * @return	bool
 	 */
-	public function delete_cache($uri = '', $is_mobile = false)
+	public function delete_cache($uri = '')
 	{
 		$CI =& get_instance();
 		$cache_path = $CI->config->item('cache_path');
@@ -763,26 +764,32 @@ class CI_Output {
 			{
 				$uri .= '?'.$_SERVER['QUERY_STRING'];
 			}
-            
-            if ($CI->config->item('separate_mobile_cache') && $this->user_agent->is_mobile)
-            {
-                $uri .= self::MOBILE_HASHTAG;
-            }
 		}
-        else if ($is_mobile)
-        {
-            $uri .= self::MOBILE_HASHTAG;
-        }
-        
+        	
+        	// If separate mobile cache is enabled, remember the cache path for mobile as well
+        	$mobile_cachepath = $cache_path;
 		$cache_path .= md5($CI->config->item('base_url').$CI->config->item('index_page').$uri);
-
+		
+		$success = TRUE;
 		if ( ! @unlink($cache_path))
 		{
-			log_message('error', 'Unable to delete cache file for '.$uri);
-			return FALSE;
+			log_message('error', 'Unable to delete standard cache file for '.$uri);
+			$success = FALSE;
 		}
-
-		return TRUE;
+		
+		if ($CI->config->item('separate_mobile_cache'))
+		{
+			$mobile_uri = $uri . self::MOBILE_HASHTAG;
+			$mobile_cachepath .= md5($CI->config->item('base_url').$CI->config->item('index_page').$mobile_uri);
+			
+			if ( ! @unlink($mobile_cachepath))
+			{
+				log_message('error', 'Unable to delete mobile cache file for '.$uri);
+				$success = FALSE;
+			}
+		}
+		
+		return $success;
 	}
 
 	// --------------------------------------------------------------------

--- a/system/core/Output.php
+++ b/system/core/Output.php
@@ -781,7 +781,7 @@ class CI_Output {
 			$mobile_uri = $uri . self::MOBILE_HASHTAG;
 			$mobile_cachepath .= md5($CI->config->item('base_url').$CI->config->item('index_page').$mobile_uri);
 			
-			if (file_exists($mobile_cache_path) && ! @unlink($mobile_cachepath))
+			if (file_exists($mobile_cachepath) && ! @unlink($mobile_cachepath))
 			{
 				log_message('error', 'Unable to delete mobile cache file for '.$uri);
 				$success = FALSE;

--- a/system/core/Output.php
+++ b/system/core/Output.php
@@ -122,20 +122,20 @@ class CI_Output {
 	 */
 	public $parse_exec_vars = TRUE;
     
-    /**
-     * User agent information class
-     * 
-     * Used to determine whether the request is from a mobile device, if separate mobile
-     * caching is enabled
-     * 
-     * @var CI_User_agent
-     */
-    private $user_agent;
-    
-    /**
-     * The hashtag appended to a URI to indicate it is mobile (for separate mobile caching, if enabled)
-     */
-    const MOBILE_HASHTAG = "#mobile";
+	/**
+	 * User agent information class
+	 * 
+	 * Used to determine whether the request is from a mobile device, if separate mobile
+	 * caching is enabled
+	 * 
+	 * @var CI_User_agent
+	 */
+	 public $user_agent;
+    	
+	 /**
+	 * The hashtag appended to a URI to indicate it is mobile (for separate mobile caching, if enabled)
+	 */
+	 const MOBILE_HASHTAG = "#mobile";
     
 	/**
 	 * Class constructor

--- a/system/core/Output.php
+++ b/system/core/Output.php
@@ -121,7 +121,22 @@ class CI_Output {
 	 * @var	bool
 	 */
 	public $parse_exec_vars = TRUE;
-
+    
+    /**
+     * User agent information class
+     * 
+     * Used to determine whether the request is from a mobile device, if separate mobile
+     * caching is enabled
+     * 
+     * @var CI_User_agent
+     */
+    private $user_agent;
+    
+    /**
+     * The hashtag appended to a URI to indicate it is mobile (for separate mobile caching, if enabled)
+     */
+    const MOBILE_HASHTAG = "#mobile";
+    
 	/**
 	 * Class constructor
 	 *
@@ -560,6 +575,11 @@ class CI_Output {
 		{
 			$uri .= '?'.$_SERVER['QUERY_STRING'];
 		}
+        
+        if ($CI->config->item('separate_mobile_cache') && $this->user_agent->is_mobile)
+        {
+            $uri .= self::MOBILE_HASHTAG;
+        }
 
 		$cache_path .= md5($uri);
 
@@ -650,6 +670,16 @@ class CI_Output {
 		{
 			$uri .= '?'.$_SERVER['QUERY_STRING'];
 		}
+        
+        if ($CFG->item('separate_mobile_cache'))
+        {
+            require_once(BASEPATH.'libraries/User_agent.php');
+            $this->user_agent = new CI_User_agent();
+            if ($this->user_agent->is_mobile)
+            {
+                $uri .= self::MOBILE_HASHTAG;
+            }
+        }
 
 		$filepath = $cache_path.md5($uri);
 
@@ -710,7 +740,7 @@ class CI_Output {
 	 * @param	string	$uri	URI string
 	 * @return	bool
 	 */
-	public function delete_cache($uri = '')
+	public function delete_cache($uri = '', $is_mobile = false)
 	{
 		$CI =& get_instance();
 		$cache_path = $CI->config->item('cache_path');
@@ -733,8 +763,17 @@ class CI_Output {
 			{
 				$uri .= '?'.$_SERVER['QUERY_STRING'];
 			}
+            
+            if ($CI->config->item('separate_mobile_cache') && $this->user_agent->is_mobile)
+            {
+                $uri .= self::MOBILE_HASHTAG;
+            }
 		}
-
+        else if ($is_mobile)
+        {
+            $uri .= self::MOBILE_HASHTAG;
+        }
+        
 		$cache_path .= md5($CI->config->item('base_url').$CI->config->item('index_page').$uri);
 
 		if ( ! @unlink($cache_path))

--- a/system/core/Output.php
+++ b/system/core/Output.php
@@ -771,7 +771,7 @@ class CI_Output {
 		$cache_path .= md5($CI->config->item('base_url').$CI->config->item('index_page').$uri);
 		
 		$success = TRUE;
-		if ( ! @unlink($cache_path))
+		if (file_exists($cache_path) && ! @unlink($cache_path))
 		{
 			log_message('error', 'Unable to delete standard cache file for '.$uri);
 			$success = FALSE;
@@ -782,7 +782,7 @@ class CI_Output {
 			$mobile_uri = $uri . self::MOBILE_HASHTAG;
 			$mobile_cachepath .= md5($CI->config->item('base_url').$CI->config->item('index_page').$mobile_uri);
 			
-			if ( ! @unlink($mobile_cachepath))
+			if (file_exists($mobile_cache_path) && ! @unlink($mobile_cachepath))
 			{
 				log_message('error', 'Unable to delete mobile cache file for '.$uri);
 				$success = FALSE;

--- a/system/core/Output.php
+++ b/system/core/Output.php
@@ -576,10 +576,10 @@ class CI_Output {
 			$uri .= '?'.$_SERVER['QUERY_STRING'];
 		}
         
-        if ($CI->config->item('separate_mobile_cache') && $this->user_agent->is_mobile)
-        {
-            $uri .= self::MOBILE_HASHTAG;
-        }
+		if ($CI->config->item('separate_mobile_cache') && $this->user_agent->is_mobile)
+		{
+			$uri .= self::MOBILE_HASHTAG;
+		}
 
 		$cache_path .= md5($uri);
 

--- a/system/core/Output.php
+++ b/system/core/Output.php
@@ -737,7 +737,7 @@ class CI_Output {
 	/**
 	 * Delete cache
 	 *
-	 * @param	string	$uri  URI string
+	 * @param	string	$uri	URI string
 	 * @return	bool
 	 */
 	public function delete_cache($uri = '')

--- a/user_guide_src/source/general/caching.rst
+++ b/user_guide_src/source/general/caching.rst
@@ -69,3 +69,10 @@ method::
 
 	// Deletes cache for /foo/bar
 	$this->output->delete_cache('/foo/bar');
+
+Separate Mobile Cache
+=====================
+
+If you wish to serve files from a separate cache for mobile visitors, you can 
+set the *separate_mobile_cache* parameter in *application/config/config.php* 
+to TRUE.  Please note that this may produce up to twice as many cache files.


### PR DESCRIPTION
This feature allows the user to set the "separate_mobile_cache" config parameter.  When set to TRUE, CodeIgniter will server separate web page cache files for mobile devices.

To do this, when checking for the cache, a hashtag is added to the cache URI for mobile devices ("#mobile").  This way a separate cache file name will be generated and served for mobile requests.  To detect whether the request is mobile, an instance of CI_User_agent is created, and is later assigned to the controller automatically once it is initialized, whenever the feature is turned on.  This happens before the security classes are initialized, and so we may need to make sure this does not pose a security threat.