### PR TITLE
Load Migrations On Demand

### DIFF
--- a/system/libraries/Migration.php
+++ b/system/libraries/Migration.php
@@ -244,16 +244,6 @@ class CI_Migration {
 				return FALSE;
 			}
 
-			include_once($file);
-			$class = 'Migration_'.ucfirst(strtolower($this->_get_migration_name(basename($file, '.php'))));
-
-			// Validate the migration file structure
-			if ( ! class_exists($class, FALSE))
-			{
-				$this->_error_string = sprintf($this->lang->line('migration_class_doesnt_exist'), $class);
-				return FALSE;
-			}
-
 			$previous = $number;
 
 			// Run migrations that are inside the target range
@@ -262,6 +252,16 @@ class CI_Migration {
 				($method === 'down' && $number <= $current_version && $number > $target_version)
 			)
 			{
+				include_once($file);
+				$class = 'Migration_'.ucfirst(strtolower($this->_get_migration_name(basename($file, '.php'))));
+
+				// Validate the migration file structure
+				if ( ! class_exists($class, FALSE))
+				{
+					$this->_error_string = sprintf($this->lang->line('migration_class_doesnt_exist'), $class);
+					return FALSE;
+				}
+
 				$instance = new $class();
 				if ( ! is_callable(array($instance, $method)))
 				{

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -417,6 +417,7 @@ Release Date: Not Released
 
       -  Added support for timestamp-based migrations (enabled by default).
       -  Added ``$config['migration_type']`` to allow switching between *sequential* and *timestamp* migrations.
+      -  Load Migrations On Demand.
 
    -  :doc:`XML-RPC Library <libraries/xmlrpc>` changes include:
 


### PR DESCRIPTION
Always `include_once` all migration files （：Not based on valid version

```php
<?php
# $this->migration->version(999);
for($i=1; $i < 999; $i++) {
    include_once($file.'.php');
}
?>
```
---
https://robert.accettura.com/blog/2011/06/11/phps-include_once-is-insanely-expensive/
