### PR TITLE
[fix] migration function ``version``

### DIFF
--- a/system/libraries/Migration.php
+++ b/system/libraries/Migration.php
@@ -232,6 +232,11 @@ class CI_Migration {
 			return TRUE;
 		}
 
+		if ($target_version == $current_version)
+		{
+			return TRUE;
+		}
+
 		$previous = FALSE;
 
 		// Validate all available migrations, and run the ones within our target range

--- a/system/libraries/Migration.php
+++ b/system/libraries/Migration.php
@@ -209,10 +209,21 @@ class CI_Migration {
 
 		$migrations = $this->find_migrations();
 
+		if (empty($migrations))
+		{
+			$this->_error_string = $this->lang->line('migration_none_found');
+			return FALSE;
+		}
+
 		if ($target_version > 0 && ! isset($migrations[$target_version]))
 		{
 			$this->_error_string = sprintf($this->lang->line('migration_not_found'), $target_version);
 			return FALSE;
+		}
+
+		if ($target_version == $current_version)
+		{
+			return TRUE;
 		}
 
 		if ($target_version > $current_version)
@@ -225,16 +236,6 @@ class CI_Migration {
 			// Moving Down, apply in reverse order
 			$method = 'down';
 			krsort($migrations);
-		}
-
-		if (empty($migrations))
-		{
-			return TRUE;
-		}
-
-		if ($target_version == $current_version)
-		{
-			return TRUE;
 		}
 
 		$previous = FALSE;

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -16,6 +16,7 @@ Bug fixes for 3.0.1
 
 -  Fixed a bug (#3733) - Autoloading of libraries with aliases didn't work, although it was advertised to.
 -  Fixed a bug (#3744) - Redis :doc:`Caching <libraries/caching>` driver didn't handle authentication failures properly.
+-  Fixed a bug - :doc:`Migration Library <libraries/migration>` didn't return true if already latest.
 
 Version 3.0.0
 =============


### PR DESCRIPTION
The migration function ``version`` didn't return true if already latest.

```php
<?php
//IF $target_version == 10 AND $current_version == 10
//Run code.
var_dump($this->migration->version(10)); //return string(3) "010"
//fix
var_dump($this->migration->version(10)); //return bool(true)
//fix migration function `latest`,`current` too
?>