### PR TITLE
fix OCI8 driver default escape character, as stated in issue #3757

### DIFF
--- a/system/database/drivers/oci8/oci8_driver.php
+++ b/system/database/drivers/oci8/oci8_driver.php
@@ -102,6 +102,15 @@ class CI_DB_oci8_driver extends CI_DB {
 	// --------------------------------------------------------------------
 
 	/**
+	 * Identifier escape character
+	 *
+	 * Must be empty for OCI8.
+	 *
+	 * @var	string
+	 */
+	protected $_escape_char = '';
+
+	/**
 	 * List of reserved identifiers
 	 *
 	 * Identifiers that must NOT be escaped.


### PR DESCRIPTION
With the default DB escape character, the SQL statement generated by the oci8 driver was producing an **ORA-00904:invalid identifier** error. ie:
```
SELECT "code", "description" FROM "SALES"."EXCHANGE" WHERE "company" = 'GOOG'
```
The problem was that the escaping char was not defined as in the other drivers, which should be empty, so the query would be:
```
SELECT code, description FROM SALES.EXCHANGE WHERE company = 'GOOG'
```
