### PR TITLE
Fix prefix and suffix bug.

### DIFF
--- a/system/libraries/Pagination.php
+++ b/system/libraries/Pagination.php
@@ -148,10 +148,6 @@ class CI_Pagination {
 			if ($CI->input->get($this->query_string_segment) != $base_page)
 			{
 				$this->cur_page = $CI->input->get($this->query_string_segment);
-				
-				// Remove the affix letters
-				$this->cur_page = ltrim( $this->cur_page, $this->prefix);
-				$this->cur_page = rtrim( $this->cur_page, $this->suffix);
 
 				// Prep the current page - no funny business!
 				$this->cur_page = (int) $this->cur_page;
@@ -163,9 +159,11 @@ class CI_Pagination {
 			{
 				$this->cur_page = $CI->uri->segment($this->uri_segment);
 				
-				// Remove the affix letters
-				$this->cur_page = ltrim( $this->cur_page, $this->prefix);
-				$this->cur_page = rtrim( $this->cur_page, $this->suffix);
+				// Remove any specified prefix/suffix from the segment.
+				if ($this->prefix !== '' OR $this->suffix !== '')
+				{
+					$this->cur_page = str_replace(array($this->prefix, $this->suffix), '', $this->cur_page);
+				}
 				
 				// Prep the current page - no funny business!
 				$this->cur_page = (int) $this->cur_page;

--- a/system/libraries/Pagination.php
+++ b/system/libraries/Pagination.php
@@ -148,6 +148,10 @@ class CI_Pagination {
 			if ($CI->input->get($this->query_string_segment) != $base_page)
 			{
 				$this->cur_page = $CI->input->get($this->query_string_segment);
+				
+				// Remove the affix letters
+				$this->cur_page = ltrim( $this->cur_page, $this->prefix);
+				$this->cur_page = rtrim( $this->cur_page, $this->suffix);
 
 				// Prep the current page - no funny business!
 				$this->cur_page = (int) $this->cur_page;
@@ -158,7 +162,11 @@ class CI_Pagination {
 			if ($CI->uri->segment($this->uri_segment) != $base_page)
 			{
 				$this->cur_page = $CI->uri->segment($this->uri_segment);
-
+				
+				// Remove the affix letters
+				$this->cur_page = ltrim( $this->cur_page, $this->prefix);
+				$this->cur_page = rtrim( $this->cur_page, $this->suffix);
+				
 				// Prep the current page - no funny business!
 				$this->cur_page = (int) $this->cur_page;
 			}


### PR DESCRIPTION
This bug occurs when using a custom prefix and suffix in the pagination class, $this->cur_page will always equal to 1.
$config['prefix'] = 'page_';
$config['suffix'] = '/';