### PR TITLE
Added the option to set a session CSRF cookie

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -422,9 +422,14 @@ $config['global_xss_filtering'] = FALSE;
 |
 | 'csrf_token_name' = The token name
 | 'csrf_cookie_name' = The cookie name
-| 'csrf_expire' = The number in seconds the token should expire.
+| 'csrf_expire' = The number of seconds before token should expire.
 | 'csrf_regenerate' = Regenerate token on every submission
 | 'csrf_exclude_uris' = Array of URIs which ignore CSRF checks
+|
+| Options:
+|
+| Set 'csrf_expire' to 0 to mark the cookie as "session-only" which
+| will is a cookie that only expires when the browser is closed.
 */
 $config['csrf_protection'] = FALSE;
 $config['csrf_token_name'] = 'csrf_test_name';

--- a/system/core/Security.php
+++ b/system/core/Security.php
@@ -258,7 +258,15 @@ class CI_Security {
 	 */
 	public function csrf_set_cookie()
 	{
-		$expire = time() + $this->_csrf_expire;
+		if ($this->_csrf_expire==0)
+			{
+				$expire = 0;
+			}
+			else
+			{
+				$expire = time() + $this->_csrf_expire;
+			}
+		
 		$secure_cookie = (bool) config_item('cookie_secure');
 
 		if ($secure_cookie && ! is_https())

--- a/user_guide_src/source/libraries/security.rst
+++ b/user_guide_src/source/libraries/security.rst
@@ -90,6 +90,20 @@ may alter this behavior by editing the following config parameter
 
 	$config['csrf_regeneration'] = TRUE;
 
+You can set the CSRF cookie to either expire after a set number of
+seconds or as a session-only cookie (set as 0) and the CSRF cookie
+will expire when the browser is closed.
+
+	$config['csrf_expire'] = INT;
+
+.. note:: If you use the session-only option, please also make sure
+you set the 'cookie_httponly' config parameter to TRUE so that an
+attacker can't attack your users using an XSS vulnerability and
+retrieve their CSRF token using JavaScript. If you can't use 'HTTPonly'
+cookies because you're also using a JavaScript framework, it is
+probably better for the user's security that you set the CSRF cookie
+to expire set duration of an hour or two.
+
 Select URIs can be whitelisted from csrf protection (for example API
 endpoints expecting externally POSTed content). You can add these URIs
 by editing the 'csrf_exclude_uris' config parameter::


### PR DESCRIPTION
I have added an option that lets the developer set CSRF cookies to expire at the browser session's expiration, this behavior is widely used by many popular websites and it doesn't affect or diminish the efficiency of CSRF protection, but prevents "unauthorized" errors from throwing up to the average user who left a form open for a few hours before trying to submit it

It can be enabled by setting $config['csrf_expire'] to 0 in the application config.php file.

I hope someone will document this new feature provided by the Security library.