### PR TITLE
404_override route is now being parsed correctly, including controller method parameters.

### DIFF
--- a/system/core/CodeIgniter.php
+++ b/system/core/CodeIgniter.php
@@ -430,9 +430,23 @@ if ( ! is_php('5.4'))
 	{
 		if ( ! empty($RTR->routes['404_override']))
 		{
-			if (sscanf($RTR->routes['404_override'], '%[^/]/%s', $error_class, $error_method) !== 2)
+			$tokens = explode('/', trim($RTR->routes['404_override'], '/'));
+
+			$error_class = $tokens[0];
+
+			if (sizeof($tokens) >= 2)
+			{
+				$error_method = $tokens[1];
+			}
+			else
 			{
 				$error_method = 'index';
+			}
+
+			// Populate $error_params
+			for ($i = 2; $i < sizeof($tokens);$i++) 
+			{
+				$error_params[] = $tokens[$i];
 			}
 
 			$error_class = ucfirst($error_class);
@@ -470,6 +484,15 @@ if ( ! is_php('5.4'))
 				1 => $class,
 				2 => $method
 			);
+
+			// Add all controller method params to URI rsegments
+			if (isset($error_params)) 
+			{
+				for ($i = 0;$i<sizeof($error_params);$i++) 
+				{
+					$URI->rsegments[] = $error_params[$i];
+				}
+			}
 		}
 		else
 		{


### PR DESCRIPTION
Controller method parameters have not been parsed at all when it comes to the 404_override route.
$route['404_override'] = 'error/display/400';
When using an 404_override route like above, the '400' parameter is NOT passed to the controller method. Fixed that. For the future, it could be nice if we alter the route/URI in a cleaner way, the whole 404 handling code i saw feels like a hack.
