### PR TITLE
Prevent double escaping of HTML entities in form helper attribute parsin...

### DIFF
--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -907,7 +907,7 @@ if ( ! function_exists('_parse_form_attributes'))
 		{
 			if ($key === 'value')
 			{
-				$val = html_escape($val);
+				$val = html_escape($val, FALSE);
 			}
 			elseif ($key === 'name' && ! strlen($default['name']))
 			{


### PR DESCRIPTION
Added FALSE as the second parameter to html_escape in _parse_form_attributes to prevent HTML entities being double encoded ie. &quot; being encoded to &amp;quot;