### PR TITLE
Trusted Hosts

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -21,6 +21,28 @@ $config['base_url'] = '';
 
 /*
 |--------------------------------------------------------------------------
+| Trusted Hosts
+|--------------------------------------------------------------------------
+|
+| In case you want to leave the base_url configuration empty for portability,
+| it involves a risk:
+|
+| http://www.skeletonscribe.net/2013/05/practical-http-host-header-attacks.html	
+|
+| To avoid security issues, you may want to configure a list of "trusted hosts".
+| (for dev and test environments or multi-domain sites)
+|
+| Elements of this list imply you accept any subdomain it has. 
+| For example domain.com also accepts <whatever.>domain.com
+|
+| Array:		array('localhost', 'my-development.com', 'my-production.com', 'subdomain.domain.com')
+|
+*/
+
+$config['trusted_hosts'] = array();
+
+/*
+|--------------------------------------------------------------------------
 | Index File
 |--------------------------------------------------------------------------
 |

--- a/system/core/Config.php
+++ b/system/core/Config.php
@@ -92,8 +92,35 @@ class CI_Config {
 			// It's not exhaustive, only checks for valid characters.
 			if (isset($_SERVER['HTTP_HOST']) && preg_match('/^((\[[0-9a-f:]+\])|(\d{1,3}(\.\d{1,3}){3})|[a-z0-9\-\.]+)(:\d+)?$/i', $_SERVER['HTTP_HOST']))
 			{
-				$base_url = (is_https() ? 'https' : 'http').'://'.$_SERVER['HTTP_HOST']
-					.substr($_SERVER['SCRIPT_NAME'], 0, strpos($_SERVER['SCRIPT_NAME'], basename($_SERVER['SCRIPT_FILENAME'])));
+				//Check if the SERVER_HOST is a trusted host to avoid HTTP Host header attacks 
+				//TODO: improve this by checking the ENVIRONMENT variable and ignore trusted_hosts when is testing or development
+				$trusted = false;
+				if(!empty($this->config['trusted_hosts']))
+				{
+					foreach($this->config['trusted_hosts'] as $trusted_host)
+					{
+						$parsed_url = parse_url(trim($trusted_host));
+						$path_explode = explode('/', $parsed_url['path'], 2);
+						$real_trusted_host = trim( isset($parsed_url['host'])? $parsed_url['host'] : array_shift($path_explode));
+						if( $trusted = preg_match("/^((.*?)\.)?".$real_trusted_host."$/i", $_SERVER['HTTP_HOST']) )
+						{
+							break;
+						}
+					}
+				}
+				else
+				{
+					$trusted = true;
+				}
+				
+				if ( $trusted ) {
+					$base_url = (is_https() ? 'https' : 'http').'://'.$_SERVER['HTTP_HOST']
+						.substr($_SERVER['SCRIPT_NAME'], 0, strpos($_SERVER['SCRIPT_NAME'], basename($_SERVER['SCRIPT_FILENAME'])));
+				}
+				else
+				{
+					$base_url = 'http://localhost/';
+				}
 			}
 			else
 			{


### PR DESCRIPTION
In case you want to leave the base_url configuration empty for portability, it involves a risk:
http://www.skeletonscribe.net/2013/05/practical-http-host-header-attacks.html

To avoid security issues, you may want to configure a list of "trusted hosts".
(for dev and test environments or multi-domain sites)