### PR TITLE
Cache Library Clean-up

### DIFF
--- a/system/libraries/Cache/Cache.php
+++ b/system/libraries/Cache/Cache.php
@@ -100,27 +100,18 @@ class CI_Cache extends CI_Driver_Library {
 	 */
 	public function __construct($config = array())
 	{
-		$default_config = array(
-			'adapter',
-			'memcached'
-		);
-
-		foreach ($default_config as $key)
+		// Loop through the available driver types and overwrite them as they're found.
+		foreach (array('adapter', 'backup') as $driver_type)
 		{
-			if (isset($config[$key]))
+			if (isset($config[$driver_type]) && in_array($config[$driver_type], $this->valid_drivers))
 			{
-				$param = '_'.$key;
-
-				$this->{$param} = $config[$key];
+				$option = '_'.$driver_type;
+				$this->{$option} = $config[$driver_type];
 			}
 		}
 
+		// Overwrite the default key prefix.
 		isset($config['key_prefix']) && $this->key_prefix = $config['key_prefix'];
-
-		if (isset($config['backup']) && in_array($config['backup'], $this->valid_drivers))
-		{
-			$this->_backup = $config['backup'];
-		}
 
 		// If the specified adapter isn't available, check the backup.
 		if ( ! $this->is_supported($this->_adapter))

--- a/system/libraries/Cache/Cache.php
+++ b/system/libraries/Cache/Cache.php
@@ -81,7 +81,7 @@ class CI_Cache extends CI_Driver_Library {
 	 *
 	 * @var string
 	 */
-	protected $_backup_driver = 'dummy';
+	protected $_backup = 'dummy';
 
 	/**
 	 * Cache key prefix
@@ -119,23 +119,23 @@ class CI_Cache extends CI_Driver_Library {
 
 		if (isset($config['backup']) && in_array($config['backup'], $this->valid_drivers))
 		{
-			$this->_backup_driver = $config['backup'];
+			$this->_backup = $config['backup'];
 		}
 
 		// If the specified adapter isn't available, check the backup.
 		if ( ! $this->is_supported($this->_adapter))
 		{
-			if ( ! $this->is_supported($this->_backup_driver))
+			if ( ! $this->is_supported($this->_backup))
 			{
 				// Backup isn't supported either. Default to 'Dummy' driver.
-				log_message('error', 'Cache adapter "'.$this->_adapter.'" and backup "'.$this->_backup_driver.'" are both unavailable. Cache is now using "Dummy" adapter.');
+				log_message('error', 'Cache adapter "'.$this->_adapter.'" and backup "'.$this->_backup.'" are both unavailable. Cache is now using "Dummy" adapter.');
 				$this->_adapter = 'dummy';
 			}
 			else
 			{
 				// Backup is supported. Set it to primary.
-				log_message('debug', 'Cache adapter "'.$this->_adapter.'" is unavailable. Falling back to "'.$this->_backup_driver.'" backup adapter.');
-				$this->_adapter = $this->_backup_driver;
+				log_message('debug', 'Cache adapter "'.$this->_adapter.'" is unavailable. Falling back to "'.$this->_backup.'" backup adapter.');
+				$this->_adapter = $this->_backup;
 			}
 		}
 	}

--- a/system/libraries/Cache/Cache.php
+++ b/system/libraries/Cache/Cache.php
@@ -74,7 +74,7 @@ class CI_Cache extends CI_Driver_Library {
 	 *
 	 * @var mixed
 	 */
-	protected $_adapter = 'dummy';
+	protected $_driver = 'dummy';
 
 	/**
 	 * Fallback driver
@@ -114,19 +114,19 @@ class CI_Cache extends CI_Driver_Library {
 		isset($config['key_prefix']) && $this->key_prefix = $config['key_prefix'];
 
 		// If the specified adapter isn't available, check the backup.
-		if ( ! $this->is_supported($this->_adapter))
+		if ( ! $this->is_supported($this->_driver))
 		{
 			if ( ! $this->is_supported($this->_backup))
 			{
 				// Backup isn't supported either. Default to 'Dummy' driver.
-				log_message('error', 'Cache adapter "'.$this->_adapter.'" and backup "'.$this->_backup.'" are both unavailable. Cache is now using "Dummy" adapter.');
-				$this->_adapter = 'dummy';
+				log_message('error', 'Cache adapter "'.$this->_driver.'" and backup "'.$this->_backup.'" are both unavailable. Cache is now using "Dummy" adapter.');
+				$this->_driver = 'dummy';
 			}
 			else
 			{
 				// Backup is supported. Set it to primary.
-				log_message('debug', 'Cache adapter "'.$this->_adapter.'" is unavailable. Falling back to "'.$this->_backup.'" backup adapter.');
-				$this->_adapter = $this->_backup;
+				log_message('debug', 'Cache adapter "'.$this->_driver.'" is unavailable. Falling back to "'.$this->_backup.'" backup adapter.');
+				$this->_driver = $this->_backup;
 			}
 		}
 	}
@@ -144,7 +144,7 @@ class CI_Cache extends CI_Driver_Library {
 	 */
 	public function get($id)
 	{
-		return $this->{$this->_adapter}->get($this->key_prefix.$id);
+		return $this->{$this->_driver}->get($this->key_prefix.$id);
 	}
 
 	// ------------------------------------------------------------------------
@@ -160,7 +160,7 @@ class CI_Cache extends CI_Driver_Library {
 	 */
 	public function save($id, $data, $ttl = 60, $raw = FALSE)
 	{
-		return $this->{$this->_adapter}->save($this->key_prefix.$id, $data, $ttl, $raw);
+		return $this->{$this->_driver}->save($this->key_prefix.$id, $data, $ttl, $raw);
 	}
 
 	// ------------------------------------------------------------------------
@@ -173,7 +173,7 @@ class CI_Cache extends CI_Driver_Library {
 	 */
 	public function delete($id)
 	{
-		return $this->{$this->_adapter}->delete($this->key_prefix.$id);
+		return $this->{$this->_driver}->delete($this->key_prefix.$id);
 	}
 
 	// ------------------------------------------------------------------------
@@ -187,7 +187,7 @@ class CI_Cache extends CI_Driver_Library {
 	 */
 	public function increment($id, $offset = 1)
 	{
-		return $this->{$this->_adapter}->increment($id, $offset);
+		return $this->{$this->_driver}->increment($id, $offset);
 	}
 
 	// ------------------------------------------------------------------------
@@ -201,7 +201,7 @@ class CI_Cache extends CI_Driver_Library {
 	 */
 	public function decrement($id, $offset = 1)
 	{
-		return $this->{$this->_adapter}->decrement($id, $offset);
+		return $this->{$this->_driver}->decrement($id, $offset);
 	}
 
 	// ------------------------------------------------------------------------
@@ -213,7 +213,7 @@ class CI_Cache extends CI_Driver_Library {
 	 */
 	public function clean()
 	{
-		return $this->{$this->_adapter}->clean();
+		return $this->{$this->_driver}->clean();
 	}
 
 	// ------------------------------------------------------------------------
@@ -226,7 +226,7 @@ class CI_Cache extends CI_Driver_Library {
 	 */
 	public function cache_info($type = 'user')
 	{
-		return $this->{$this->_adapter}->cache_info($type);
+		return $this->{$this->_driver}->cache_info($type);
 	}
 
 	// ------------------------------------------------------------------------
@@ -239,7 +239,7 @@ class CI_Cache extends CI_Driver_Library {
 	 */
 	public function get_metadata($id)
 	{
-		return $this->{$this->_adapter}->get_metadata($this->key_prefix.$id);
+		return $this->{$this->_driver}->get_metadata($this->key_prefix.$id);
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
Made a few small changes to the cache library:

- Renames the `$_adapter` variable to `$_driver` because we don't call it an adapter anywhere else.
- Renames the `$_backup_driver` variable to `$_backup` for easier initializing, and because it matches the configuration key passed in.
- Validates the primary driver **and** the backup driver against the `$valid_drivers` array.
- No longer attempts to set an undefined `$_memcached` class variable.
- Renames the `$key` variable to `$driver_type` to be more descriptive.

I've done some light testing, but it would be great if someone else could try it out as well.