### PR TITLE
Output cache: Fixing a wrong timestamp. Credits to khoggatt (CodeIgniter forum).

### DIFF
--- a/system/core/Output.php
+++ b/system/core/Output.php
@@ -674,7 +674,7 @@ class CI_Output {
 		$cache_info = unserialize($match[1]);
 		$expire = $cache_info['expire'];
 
-		$last_modified = filemtime($cache_path);
+		$last_modified = filemtime($filepath);
 
 		// Has the file expired?
 		if ($_SERVER['REQUEST_TIME'] >= $expire && is_really_writable($cache_path))

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -20,7 +20,7 @@ Bug fixes for 3.0.1
 -  Fixed a bug (#3773) - ``db_select()`` didn't work for MySQL with the PDO :doc:`Database <database/index>` driver.
 -  Fixed a bug (#3771) - :doc:`Form Validation Library <libraries/form_validation>` was looking for a 'form_validation_' prefix when trying to translate field name labels.
 -  Fixed a bug (#3787) - :doc:`FTP Library <libraries/ftp>` method ``delete_dir()`` failed when the target has subdirectories.
--  Fixed a bug (#3801) - :doc: The `Output class <libraries/output>` method ``_display_cache()`` failed to read timestamps correctly.
+-  Fixed a bug (#3801) - :doc:`Output Library <libraries/output>` method ``_display_cache()`` incorrectly looked for the last modified time of a directory instead of the cache file.
 
 Version 3.0.0
 =============

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -20,6 +20,7 @@ Bug fixes for 3.0.1
 -  Fixed a bug (#3773) - ``db_select()`` didn't work for MySQL with the PDO :doc:`Database <database/index>` driver.
 -  Fixed a bug (#3771) - :doc:`Form Validation Library <libraries/form_validation>` was looking for a 'form_validation_' prefix when trying to translate field name labels.
 -  Fixed a bug (#3787) - :doc:`FTP Library <libraries/ftp>` method ``delete_dir()`` failed when the target has subdirectories.
+-  Fixed a bug (#3801) - :doc: The `Output class <libraries/output>` method ``_display_cache()`` assigned incorrect timestamps.
 
 Version 3.0.0
 =============

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -20,7 +20,7 @@ Bug fixes for 3.0.1
 -  Fixed a bug (#3773) - ``db_select()`` didn't work for MySQL with the PDO :doc:`Database <database/index>` driver.
 -  Fixed a bug (#3771) - :doc:`Form Validation Library <libraries/form_validation>` was looking for a 'form_validation_' prefix when trying to translate field name labels.
 -  Fixed a bug (#3787) - :doc:`FTP Library <libraries/ftp>` method ``delete_dir()`` failed when the target has subdirectories.
--  Fixed a bug (#3801) - :doc: The `Output class <libraries/output>` method ``_display_cache()`` assigned incorrect timestamps.
+-  Fixed a bug (#3801) - :doc: The `Output class <libraries/output>` method ``_display_cache()`` failed to read timestamps correctly.
 
 Version 3.0.0
 =============


### PR DESCRIPTION
The timestamp of the created cache file should be taken, instead of the cache directory.
Reported at CodeIgniter forum: http://forum.codeigniter.com/thread-61534.html