### PR TITLE
Legacy flashdata corrections

### DIFF
--- a/system/libraries/Session/Session.php
+++ b/system/libraries/Session/Session.php
@@ -708,7 +708,6 @@ class CI_Session {
 				? $_SESSION['__ci_flash']['old'][$key]
 				: NULL;
 		}
-
 		return isset($_SESSION['__ci_flash'], $_SESSION['__ci_flash']['old']) 
                 ? $_SESSION['__ci_flash']['old'] 
                 : array();


### PR DESCRIPTION
Made it 100% behavior compatible with the Legacy flashdata system.
The way it was using the temp var __ci_vars flashdata, setting a flashdata variable would overwrite session root variables with the same key. Such behavior should not be expected from set_flashdata().
When calling flashdata() the returned value did not had into consideration the state of that value, if old or new.

I created a new session key __ci_flash to keep everything tidy and simple, no need to loop around the __ci_vars to find if it's flash or temp var.