### PR TITLE
Fix sqlite list_fields [pdo_sqlite_driver]

### DIFF
--- a/system/database/drivers/pdo/subdrivers/pdo_sqlite_driver.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_sqlite_driver.php
@@ -130,6 +130,23 @@ class CI_DB_pdo_sqlite_driver extends CI_DB_pdo_driver {
 	 */
 	protected function _list_columns($table = '')
 	{
+		if ($table === "")
+		{
+			return FALSE;
+		}
+		
+		$field_data = $this->field_data($table);
+		
+		$fields = array();
+		foreach($field_data as $id => $col)
+		{
+			$fields[] = 'SELECT '.$id.' AS "COLUMN_ID", \''.$col->name.'\' AS "COLUMN_NAME"';
+		}
+		
+		if (!empty($fields))
+		{
+			return 'SELECT "COLUMN_NAME" FROM ('.implode(' UNION ',$fields).') AS "LIST_COLUMNS" ORDER BY "COLUMN_ID" ASC';
+		}
 		// Not supported
 		return FALSE;
 	}


### PR DESCRIPTION
I tried to migrate my CodeIgniter version to 3.0 with SQLite database. But some code for example 
`$this->db->list_fields("tablename")` returns the output like this 
```
This feature is not available for the database you are using.
...
```
I found `_list_columns` method return false only, which means not supported. I added a bit of code on `_list_columns` method of `CI_DB_pdo_sqlite_driver` class and it worked. 
```php
// Filename : system/database/drivers/pdo/subdrivers/pdo_sqlite_driver.php

protected function _list_columns($table = '')
{
		if ($table === "")
		{
			return FALSE;
		}

		$field_data = $this->field_data($table);
		
		$fields = array();
		foreach($field_data as $id => $col)
		{
			$fields[] = 'SELECT '.$id.' AS "COLUMN_ID", \''.$col->name.'\' AS "COLUMN_NAME"';
		}

		if (!empty($fields))
		{
			return 'SELECT "COLUMN_NAME" FROM ('.implode(' UNION ',$fields).') AS "LIST_COLUMNS" ORDER BY "COLUMN_ID" ASC';
		}
		// Not supported
		return FALSE;
}
```