### PR TITLE
Fix typos in user guide.

### DIFF
--- a/user_guide_src/source/general/controllers.rst
+++ b/user_guide_src/source/general/controllers.rst
@@ -138,7 +138,7 @@ present, as will be the case when only your site root URL is requested.
 To specify a default controller, open your **application/config/routes.php**
 file and set this variable::
 
-	$route['default_controller'] = 'Blog';
+	$route['default_controller'] = 'blog';
 
 Where Blog is the name of the controller class you want used. If you now
 load your main index.php file without specifying any URI segments you'll

--- a/user_guide_src/source/libraries/security.rst
+++ b/user_guide_src/source/libraries/security.rst
@@ -88,7 +88,7 @@ may alter this behavior by editing the following config parameter
 
 ::
 
-	$config['csrf_regeneration'] = TRUE;
+	$config['csrf_regenerate'] = TRUE;
 
 Select URIs can be whitelisted from csrf protection (for example API
 endpoints expecting externally POSTed content). You can add these URIs


### PR DESCRIPTION
Corrected "csrf_regenerate" in libraries/security.rst (it read "csrf_regeneration", incorrect per source code).
Corrected "blog" as default controller in general/controllers.rst (it read "Blog", not per convention).