### PR TITLE
MIMES : added new mime type for 3gp based video file upload

### DIFF
--- a/application/config/mimes.php
+++ b/application/config/mimes.php
@@ -127,7 +127,7 @@ return array(
 	'rsa'   =>	'application/x-pkcs7',
 	'cer'   =>	array('application/pkix-cert', 'application/x-x509-ca-cert'),
 	'3g2'   =>	'video/3gpp2',
-	'3gp'   =>	array('video/3gp','video/3gpp'),
+	'3gp'   =>	array('video/3gp', 'video/3gpp'),
 	'mp4'   =>	'video/mp4',
 	'm4a'   =>	'audio/x-m4a',
 	'f4v'   =>	'video/mp4',

--- a/application/config/mimes.php
+++ b/application/config/mimes.php
@@ -127,7 +127,7 @@ return array(
 	'rsa'   =>	'application/x-pkcs7',
 	'cer'   =>	array('application/pkix-cert', 'application/x-x509-ca-cert'),
 	'3g2'   =>	'video/3gpp2',
-	'3gp'   =>	'video/3gp',
+	'3gp'   =>	array('video/3gp','video/3gpp'),
 	'mp4'   =>	'video/mp4',
 	'm4a'   =>	'audio/x-m4a',
 	'f4v'   =>	'video/mp4',


### PR DESCRIPTION
i was facing error while uploading 3GP based video file using codeigniter based upload class because of MIMES check failure, while cross-checking the form POST request i notice that mime type of 3GP video file is sending as "video/3gpp" which is missing from mimes config file, so i added the same into mimes config file.