### PR TITLE
Bug Fix manually delete caching method and improving Cache Query String behaviour

### DIFF
--- a/system/core/Output.php
+++ b/system/core/Output.php
@@ -556,9 +556,16 @@ class CI_Output {
 			.$CI->config->item('index_page')
 			.$CI->uri->uri_string();
 
-		if ($CI->config->item('cache_query_string') && ! empty($_SERVER['QUERY_STRING']))
+		if (($cache_query_string = $CI->config->item('cache_query_string')) && !empty($_SERVER['QUERY_STRING']))
 		{
-			$uri .= '?'.$_SERVER['QUERY_STRING'];
+			if (is_array($cache_query_string))
+			{
+				$uri .= '?'.http_build_query(array_intersect_key($_GET, array_flip($cache_query_string)));
+			}
+			else
+			{
+				$uri .= '?'.$_SERVER['QUERY_STRING'];
+			}
 		}
 
 		$cache_path .= md5($uri);
@@ -646,9 +653,16 @@ class CI_Output {
 		// Build the file path. The file name is an MD5 hash of the full URI
 		$uri = $CFG->item('base_url').$CFG->item('index_page').$URI->uri_string;
 
-		if ($CFG->item('cache_query_string') && ! empty($_SERVER['QUERY_STRING']))
+		if (($cache_query_string = $CFG->item('cache_query_string')) && !empty($_SERVER['QUERY_STRING']))
 		{
-			$uri .= '?'.$_SERVER['QUERY_STRING'];
+			if (is_array($cache_query_string))
+			{
+				$uri .= '?'.http_build_query(array_intersect_key($_GET, array_flip($cache_query_string)));
+			}
+			else
+			{
+				$uri .= '?'.$_SERVER['QUERY_STRING'];
+			}
 		}
 
 		$filepath = $cache_path.md5($uri);
@@ -729,9 +743,16 @@ class CI_Output {
 		{
 			$uri = $CI->uri->uri_string();
 
-			if ($CI->config->item('cache_query_string') && ! empty($_SERVER['QUERY_STRING']))
+			if (($cache_query_string = $CI->config->item('cache_query_string')) && !empty($_SERVER['QUERY_STRING']))
 			{
-				$uri .= '?'.$_SERVER['QUERY_STRING'];
+				if (is_array($cache_query_string))
+				{
+					$uri .= '?'.http_build_query(array_intersect_key($_GET, array_flip($cache_query_string)));
+				}
+				else
+				{
+					$uri .= '?'.$_SERVER['QUERY_STRING'];
+				}
 			}
 		}
 

--- a/system/core/Output.php
+++ b/system/core/Output.php
@@ -735,7 +735,7 @@ class CI_Output {
 			}
 		}
 
-		$cache_path .= md5($CI->config->item('base_url').$CI->config->item('index_page').$uri);
+		$cache_path .= md5($CI->config->item('base_url').$CI->config->item('index_page').ltrim($uri, '/'));
 
 		if ( ! @unlink($cache_path))
 		{


### PR DESCRIPTION
According to documentation, to manually delete cache for page `/foo/bar` we should run `$this->output->delete_cache('/foo/bar')`, but in this case MD5 hash will be calculated for `http://site.com//foo/bar` and this is why, we should pass `$uri` without beginning slash (ie, `foo/bar`). But the problem is that there is no way to delete cache for home page because:
1) `$this->output->delete_cache('/')` — MD5 hash will be calculated for `http://site.com//` and cache file will not be deleted.
2) `$this->output->delete_cache('')` — MD5 hash will be calculated for `http://site.com/%CURRENT_PAGE%` and again, cache file will not be deleted.

Trimming the beginning slash, we enable ability to delete cache for home page by calling `$this->output->delete_cache('/')`. Also, this method will work as specified in the documentation.