### PR TITLE
GitAttributes file to clean up composer installs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,3 +18,5 @@ readme.rst
 tests/codeigniter/ export-ignore
 tests/travis/ export-ignore
 
+# User Guide Source Files
+user_guide_src

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+# This file tells which files and folders should be ignored and
+# NOT downloaded when using composer to pull down a project with
+# the --prefer-dist option selected. Used to remove development
+# specific files so user has a clean download.
+
+# git files
+.gitattributes export-ignore
+# .gitignore
+
+# helper config files
+.travis.yml export-ignore
+phpdoc.dist.xml export-ignore
+
+# Misc other files
+readme.rst
+
+# They don't want all of our tests...
+tests/codeigniter/ export-ignore
+tests/travis/ export-ignore
+

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-# This file tells which files and folders should be ignored and
+# This file tells which files and directories should be ignored and
 # NOT downloaded when using composer to pull down a project with
 # the --prefer-dist option selected. Used to remove development
 # specific files so user has a clean download.


### PR DESCRIPTION
This basically just removes a number of development-only files (like the user guide source and our tests) from any installs made through composer with the --prefer-dist flag set. 

Helps create a faster install with less unnecessary files to new projects. 