### PR TITLE
remove references

### DIFF
--- a/system/core/compat/standard.php
+++ b/system/core/compat/standard.php
@@ -104,7 +104,7 @@ if ( ! function_exists('array_column'))
 		}
 
 		$result = array();
-		foreach ($array as &$a)
+		foreach ($array as $a)
 		{
 			if ($column_key === NULL)
 			{


### PR DESCRIPTION
return ``$result`` not ``$array``, 
so  ``foreach ($array as &$a)`` remove references