### PR TITLE
Edited the Loader

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -851,6 +851,12 @@ class CI_Loader {
 					$file_exists = TRUE;
 					break;
 				}
+				else if(file_exists($_ci_view_file.strtolower($_ci_file)))
+				{
+					$_ci_path = $_ci_view_file.strtolower($_ci_file);
+					$file_exists = TRUE;
+					break;
+				}
 
 				if ( ! $cascade)
 				{


### PR DESCRIPTION
Signed-off-by: Omar Essam <omar_2412@me.com>

This control block is my suggestion for solving a problem that arises when a CI website is developed in a Windows development environment and then uploaded to a Linux web host, Usually developers on Windows are inconsistent using lowercase filenames for views and then call them from within CI in UC format, This would work in Windows but would cause errors in a Linux environment.

According to the CI user guide 
http://www.codeigniter.com/userguide3/general/styleguide.html#file-naming
Views should be lowercase, So forcing lowercase would be a good idea to port the difference between Windows and Linux.

Adding this "Else if" block handles this case.