### PR TITLE
Fixed bug - using field_data() on Oracle databases

### DIFF
--- a/system/database/drivers/oci8/oci8_driver.php
+++ b/system/database/drivers/oci8/oci8_driver.php
@@ -573,7 +573,7 @@ class CI_DB_oci8_driver extends CI_DB {
 			{
 				$default = '';
 			}
-			$retval[$i]->default		= $query[$i]->COLUMN_DEFAULT;
+			$retval[$i]->default = $default;
 		}
 
 		return $retval;

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -18,6 +18,7 @@ Release Date: Not Released
 Bug fixes for 3.0.1
 -------------------
 
+-  Fixed a bug (#3854) - Using field_data() on Oracle databases
 -  Fixed a bug (#3733) - Autoloading of libraries with aliases didn't work, although it was advertised to.
 -  Fixed a bug (#3744) - Redis :doc:`Caching <libraries/caching>` driver didn't handle authentication failures properly.
 -  Fixed a bug (#3761) - :doc:`URL Helper <helpers/url_helper>` function :php:func:`anchor()` didn't work with array inputs.

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -18,7 +18,6 @@ Release Date: Not Released
 Bug fixes for 3.0.1
 -------------------
 
--  Fixed a bug (#3854) - Using field_data() on Oracle databases
 -  Fixed a bug (#3733) - Autoloading of libraries with aliases didn't work, although it was advertised to.
 -  Fixed a bug (#3744) - Redis :doc:`Caching <libraries/caching>` driver didn't handle authentication failures properly.
 -  Fixed a bug (#3761) - :doc:`URL Helper <helpers/url_helper>` function :php:func:`anchor()` didn't work with array inputs.
@@ -29,6 +28,7 @@ Bug fixes for 3.0.1
 -  Fixed a bug (#3816) - :doc:`Form Validation Library <libraries/form_validation>` treated empty string values as non-existing ones.
 -  Fixed a bug (#3823) - :doc:`Session Library <libraries/sessions>` drivers Redis and Memcached didn't properly handle locks that are blocking the request for more than 30 seconds.
 -  Fixed a bug (#3846) - :doc:`Image Manipulation Library <libraries/image_lib>` method `image_mirror_gd()` didn't properly initialize its variables.
+-  Fixed a bug (#3854) - `field_data()` didn't work properly with the Oracle (OCI8) database driver.
 
 Version 3.0.0
 =============


### PR DESCRIPTION
When you're using oracle databases and want to retrieve column information through the function field_data($table) you get the following notice: 

- Notice: Undefined property: stdClass::$COLUMN_DEFAULT in system/database/drivers/oci8/oci8_driver.php on line 576;

This happens because the oci8 driver tries to access a property that does not exist on query used to get field information. Checking the code we see a small validation to set default value, but the variable $default is not used. So we fix this bug by simply changing:

$retval[$i]->default = $query[$i]->COLUMN_DEFAULT;
to 
$retval[$i]->default = $default;

Bug fixed. No more notices and the properly value is set.