### PR TITLE
Update postgre_driver.php

### DIFF
--- a/system/database/drivers/postgre/postgre_driver.php
+++ b/system/database/drivers/postgre/postgre_driver.php
@@ -239,7 +239,22 @@ class CI_DB_postgre_driver extends CI_DB {
 	 */
 	protected function _execute($sql)
 	{
-		return pg_query($this->conn_id, $sql);
+            /** Send query */
+            pg_send_query($this->conn_id, $sql);
+
+            /** Get the result */
+            $result = pg_get_result($this->conn_id);
+
+            /** Set the result resource to a variable that can be used later on error() */
+            $this->result_resource = $result;
+
+            /** Verify if state is 0 which means OK, else return false */
+            $state = pg_result_error_field($result, PGSQL_DIAG_SQLSTATE);
+            if ($state == 0) {
+                return $result;
+            }else{
+                return false;
+            }	
 	}
 
 	// --------------------------------------------------------------------
@@ -496,7 +511,10 @@ class CI_DB_postgre_driver extends CI_DB {
 	 */
 	public function error()
 	{
-		return array('code' => '', 'message' => pg_last_error($this->conn_id));
+		return array(
+                    'code' => pg_result_error_field($this->result_resource, PGSQL_DIAG_SQLSTATE), 
+                    'message' => pg_result_error_field($this->result_resource, PGSQL_DIAG_MESSAGE_PRIMARY)
+                    );
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
Updated function _execute() - The previews function return a resource or throw a PHP error if Postgres returned an error. Now its do a pg_send_query and get back the result from pg_get_result, with pg_result_error_field we can verify if Postgres returned an error, if yes, send back FALSE and the db_driver class will do the rest like all in others drivers (mysql, oracle, etc) not halting the execution with a PHP error.

Updated function error() - Return the correct CODE and MESSAGE result resource.