### PR TITLE
Add functionality to add output in <head> tag for Profiler

### DIFF
--- a/system/core/Output.php
+++ b/system/core/Output.php
@@ -508,9 +508,17 @@ class CI_Output {
 				$CI->profiler->set_sections($this->_profiler_sections);
 			}
 
+			$profiler = $CI->profiler->run();
+
+			if (is_array($profiler))
+			{
+				$output = preg_replace('|</head>|i', $profiler['head'].'</head>', $output, 1);
+				$profiler = $profiler['body'];
+			}
+
 			// If the output data contains closing </body> and </html> tags
 			// we will remove them and add them back after we insert the profile data
-			$output = preg_replace('|</body>.*?</html>|is', '', $output, -1, $count).$CI->profiler->run();
+			$output = preg_replace('|</body>.*?</html>|is', '', $output, -1, $count).$profiler;
 			if ($count > 0)
 			{
 				$output .= '</body></html>';

--- a/tests/codeigniter/core/Output_test.php
+++ b/tests/codeigniter/core/Output_test.php
@@ -60,4 +60,95 @@ HTML;
 		);
 	}
 
+	public function test_display_profiler()
+	{
+		$loader_cls = $this->ci_core_class('load');
+		$this->ci_instance_var('load', new $loader_cls);
+		$lang_cls = $this->ci_core_class('lang');
+		$this->ci_instance_var('lang', new $lang_cls);
+		$this->ci_vfs_clone('system/language/english/profiler_lang.php');
+		$bm_cls = $this->ci_core_class('benchmark');
+		$this->ci_instance_var('benchmark', new $bm_cls);
+
+		$this->ci_vfs_clone('system/core/Benchmark.php');
+		$this->ci_vfs_clone('system/core/Config.php');
+		$this->ci_vfs_clone('system/libraries/Profiler.php');
+
+		$this->ci_vfs_clone('system/core/Controller.php');
+		require_once BASEPATH.'core/Controller.php';
+
+		// Mock profiler class
+		$profiler = $this->getMock('CI_Profiler', array('run'));
+		$profiler->expects($this->once())
+			->method('run')
+			->will($this->returnValue('[profiler_output]...[/profiler_output]'));
+		$this->ci_instance_var('profiler', $profiler);
+
+		// Enable profiler
+		$this->output->enable_profiler(TRUE);
+
+		$expected =<<<HTML
+		<html>
+			<head>
+				<title>Basic HTML</title>
+			</head>
+			<body>
+				Test
+			[profiler_output]...[/profiler_output]</body></html>
+HTML;
+
+		ob_start();
+		$this->output->_display($this->_output_data);
+		$actual = ob_get_clean();
+		$this->assertEquals($expected, $actual);
+	}
+
+	public function test_display_profiler_array_output()
+	{
+		$loader_cls = $this->ci_core_class('load');
+		$this->ci_instance_var('load', new $loader_cls);
+		$lang_cls = $this->ci_core_class('lang');
+		$this->ci_instance_var('lang', new $lang_cls);
+		$this->ci_vfs_clone('system/language/english/profiler_lang.php');
+		$bm_cls = $this->ci_core_class('benchmark');
+		$this->ci_instance_var('benchmark', new $bm_cls);
+
+		$this->ci_vfs_clone('system/core/Benchmark.php');
+		$this->ci_vfs_clone('system/core/Config.php');
+		$this->ci_vfs_clone('system/libraries/Profiler.php');
+
+		$this->ci_vfs_clone('system/core/Controller.php');
+		require_once BASEPATH.'core/Controller.php';
+
+		// Mock profiler class
+		$profiler = $this->getMock('CI_Profiler', array('run'));
+		$profiler->expects($this->once())
+				->method('run')
+				->will($this->returnValue(
+					array(
+						'head' => '[profiler_header]...[/profiler_header]',
+						'body' => '[profiler_output]...[/profiler_output]'
+					)
+				)
+			);
+		$this->ci_instance_var('profiler', $profiler);
+
+		// Enable profiler
+		$this->output->enable_profiler(TRUE);
+
+		$expected =<<<HTML
+		<html>
+			<head>
+				<title>Basic HTML</title>
+			[profiler_header]...[/profiler_header]</head>
+			<body>
+				Test
+			[profiler_output]...[/profiler_output]</body></html>
+HTML;
+
+		ob_start();
+		$this->output->_display($this->_output_data);
+		$actual = ob_get_clean();
+		$this->assertEquals($expected, $actual);
+	}
 }


### PR DESCRIPTION
If you extends Profiler or use thrid-party profiler, you may want to add HTML for profiler in <head> tag.

This PR provides such functionality.
