### PR TITLE
Session file driver use system temporary directory

### DIFF
--- a/system/libraries/Session/drivers/Session_files_driver.php
+++ b/system/libraries/Session/drivers/Session_files_driver.php
@@ -93,9 +93,14 @@ class CI_Session_files_driver extends CI_Session_driver implements SessionHandle
 			$this->_config['save_path'] = rtrim($this->_config['save_path'], '/\\');
 			ini_set('session.save_path', $this->_config['save_path']);
 		}
-		else
+		elseif (ini_get('session.save_path'))
 		{
 			$this->_config['save_path'] = rtrim(ini_get('session.save_path'), '/\\');
+		}
+		else
+		{
+			$this->_config['save_path'] = sys_get_temp_dir();
+			ini_set('session.save_path', $this->_config['save_path']);
 		}
 	}
 


### PR DESCRIPTION
If `$config['sess_save_path']` and `session.save_path`
in `php.ini` not set, then use the system temporary directory.

Signed-off-by: Mulia Arifandi Nasution <mul14.net@gmail.com>