### PR TITLE
Backwards compatibility for uppercase model/controller file names

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -496,3 +496,20 @@ $config['rewrite_short_tags'] = FALSE;
 | Array:		array('10.0.1.200', '192.168.5.0/24')
 */
 $config['proxy_ips'] = '';
+
+/*
+|--------------------------------------------------------------------------
+| Use ucfirst for controllers & models
+|--------------------------------------------------------------------------
+|
+| What to set the first letter uppercase for - models, controllers, filenames.
+| Implemented for backwards compatibility, when CI didn't require uppercase
+| for both class names and their files.
+|
+| Possible options:
+| 'class' - only uppercase first letter of classes (use this for backwards compatibility)
+| 'file' - only uppercase first letter of files
+| 'both' - uppercase first letter of both (CI default)
+|
+*/
+$config['uppercase_class_file'] = 'both';

--- a/system/core/CodeIgniter.php
+++ b/system/core/CodeIgniter.php
@@ -396,16 +396,18 @@ if ( ! is_php('5.4'))
  */
 
 	$e404 = FALSE;
-	$class = ucfirst($RTR->class);
+	$uc_config = $CFG->item('uppercase_class_file');
+	$class = ($uc_config == 'class' || $uc_config == 'both' ? ucfirst($RTR->class) : $RTR->class);
+	$class_file = ($uc_config == 'file' || $uc_config == 'both' ? ucfirst($RTR->class) : $RTR->class);
 	$method = $RTR->method;
 
-	if (empty($class) OR ! file_exists(APPPATH.'controllers/'.$RTR->directory.$class.'.php'))
+	if (empty($class) OR ! file_exists(APPPATH.'controllers/'.$RTR->directory.$class_file.'.php'))
 	{
 		$e404 = TRUE;
 	}
 	else
 	{
-		require_once(APPPATH.'controllers/'.$RTR->directory.$class.'.php');
+		require_once(APPPATH.'controllers/'.$RTR->directory.$class_file.'.php');
 
 		if ( ! class_exists($class, FALSE) OR $method[0] === '_' OR method_exists('CI_Controller', $method))
 		{
@@ -435,17 +437,18 @@ if ( ! is_php('5.4'))
 				$error_method = 'index';
 			}
 
-			$error_class = ucfirst($error_class);
+			$error_class = ($uc_config == 'class' || $uc_config == 'both' ? ucfirst($error_class) : strtolower($error_class));
+			$error_class_file = ($uc_config == 'file' || $uc_config == 'both' ? ucfirst($error_class) : strtolower($error_class));
 
 			if ( ! class_exists($error_class, FALSE))
 			{
-				if (file_exists(APPPATH.'controllers/'.$RTR->directory.$error_class.'.php'))
+				if (file_exists(APPPATH.'controllers/'.$RTR->directory.$error_class_file.'.php'))
 				{
-					require_once(APPPATH.'controllers/'.$RTR->directory.$error_class.'.php');
+					require_once(APPPATH.'controllers/'.$RTR->directory.$error_class_file.'.php');
 					$e404 = ! class_exists($error_class, FALSE);
 				}
 				// Were we in a directory? If so, check for a global override
-				elseif ( ! empty($RTR->directory) && file_exists(APPPATH.'controllers/'.$error_class.'.php'))
+				elseif ( ! empty($RTR->directory) && file_exists(APPPATH.'controllers/'.$error_class_file.'.php'))
 				{
 					require_once(APPPATH.'controllers/'.$error_class.'.php');
 					if (($e404 = ! class_exists($error_class, FALSE)) === FALSE)

--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -290,16 +290,18 @@ class CI_Loader {
 			load_class('Model', 'core');
 		}
 
-		$model = ucfirst(strtolower($model));
+		$uc_config = $CI->config->item('uppercase_class_file');
+		$model = ($uc_config == 'class' || $uc_config == 'both' ? ucfirst(strtolower($model)) : strtolower($model));
+		$model_file = ($uc_config == 'file' || $uc_config == 'both' ? ucfirst(strtolower($model)) : strtolower($model));
 
 		foreach ($this->_ci_model_paths as $mod_path)
 		{
-			if ( ! file_exists($mod_path.'models/'.$path.$model.'.php'))
+			if ( ! file_exists($mod_path.'models/'.$path.$model_file.'.php'))
 			{
 				continue;
 			}
 
-			require_once($mod_path.'models/'.$path.$model.'.php');
+			require_once($mod_path.'models/'.$path.$model_file.'.php');
 
 			$this->_ci_models[] = $name;
 			$CI->$name = new $model();

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -10,6 +10,7 @@ Release Date: Not Released
 -  Core
 
    -  Added DoS mitigation to :php:func:`hash_pbkdf2()` :doc:`compatibility function <general/compatibility_functions>`.
+   -  Added backwards compatibility config option for uppercase first letter of classes/files for models, controllers.
 
 - Database
 


### PR DESCRIPTION
Added backwards compatibility config item - for all my controller / models I don't have the file names upper case first - presumably others do too. Added the config item, implemented in model loader & controller route loading (and error class loading), updated the changelog hopefully correctly.