### PR TITLE
Check for empty values when setting method in Router in case of regex that uses wildcards

### DIFF
--- a/system/core/Router.php
+++ b/system/core/Router.php
@@ -471,6 +471,8 @@ class CI_Router {
 	 */
 	public function set_method($method)
 	{
+		if (empty($method)) return;
+
 		$this->method = $method;
 	}
 


### PR DESCRIPTION
For example, if I want to pass items to a product lookup method that may or may not have the value, and simply have the product lookup method deal with the error itself, I would use a regex like: 

`$route['product/?([^/]*)'] = 'catalog/product_lookup/$1';`

This results in an empty string when it gets to the routers `set_method()` function.

This fix simply checks that before setting it.