### PR TITLE
URL helper - Change redirect() signature

### DIFF
--- a/system/helpers/url_helper.php
+++ b/system/helpers/url_helper.php
@@ -524,13 +524,21 @@ if ( ! function_exists('redirect'))
 	 * Library's set_header() function.
 	 *
 	 * @param	string	$uri	URL
+	 * @param	int	$code	HTTP Response status code
 	 * @param	string	$method	Redirect method
 	 *			'auto', 'location' or 'refresh'
-	 * @param	int	$code	HTTP Response status code
 	 * @return	void
 	 */
-	function redirect($uri = '', $method = 'auto', $code = NULL)
+	function redirect($uri = '', $code = NULL, $method = 'auto')
 	{
+		// BC - support old function signature ($method before $code)
+		if (is_numeric($method))
+		{
+			$tmp = $code;
+			$code = $method;
+			$method = $tmp;
+		}
+
 		if ( ! preg_match('#^(\w+:)?//#i', $uri))
 		{
 			$uri = site_url($uri);


### PR DESCRIPTION
Just a proposal to have your opinion on this.
Refinements yet to be done (documentation, etc.)

This let us do `redirect('foobar', 301)` instead of `redirect('foobar', 'auto', 301)`, the "auto" parameter being quite superfluous.