### PR TITLE
Make sure not to show Error on production environment

### DIFF
--- a/system/core/Exceptions.php
+++ b/system/core/Exceptions.php
@@ -182,7 +182,12 @@ class CI_Exceptions {
 		include($templates_path.$template.'.php');
 		$buffer = ob_get_contents();
 		ob_end_clean();
-		return $buffer;
+
+		if (str_ireplace(array('off', 'none', 'no', 'false', 'null'), '', ini_get('display_errors')))
+		{
+			return $buffer;
+		}
+		return;
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
I got the error display on production environment.

```
A Database Error Occurred

Error Number: HY000/1
no such table: project
SELECT * FROM "project" ORDER BY "score" DESC, "url" ASC LIMIT 100
Filename: models/ProjectRepository.php
Line Number: 70
```
