### PR TITLE
made all form helpers consistent regarding extra attributes

### DIFF
--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -483,8 +483,6 @@ if ( ! function_exists('form_radio'))
 		is_array($data) OR $data = array('name' => $data);
 		$data['type'] = 'radio';
 
-		$extra = _attributes_to_string($extra);
-
 		return form_checkbox($data, $value, $checked, $extra);
 	}
 }

--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -197,7 +197,7 @@ if ( ! function_exists('form_input'))
 	 *
 	 * @param	mixed
 	 * @param	string
-	 * @param	string
+	 * @param	mixed
 	 * @return	string
 	 */
 	function form_input($data = '', $value = '', $extra = '')
@@ -207,6 +207,8 @@ if ( ! function_exists('form_input'))
 			'name' => is_array($data) ? '' : $data,
 			'value' => $value
 		);
+
+		$extra = _attributes_to_string($extra);
 
 		return '<input '._parse_form_attributes($data, $defaults).$extra." />\n";
 	}
@@ -223,7 +225,7 @@ if ( ! function_exists('form_password'))
 	 *
 	 * @param	mixed
 	 * @param	string
-	 * @param	string
+	 * @param	mixed
 	 * @return	string
 	 */
 	function form_password($data = '', $value = '', $extra = '')
@@ -245,7 +247,7 @@ if ( ! function_exists('form_upload'))
 	 *
 	 * @param	mixed
 	 * @param	string
-	 * @param	string
+	 * @param	mixed
 	 * @return	string
 	 */
 	function form_upload($data = '', $value = '', $extra = '')
@@ -253,6 +255,9 @@ if ( ! function_exists('form_upload'))
 		$defaults = array('type' => 'file', 'name' => '');
 		is_array($data) OR $data = array('name' => $data);
 		$data['type'] = 'file';
+
+		$extra = _attributes_to_string($extra);
+		
 		return '<input '._parse_form_attributes($data, $defaults).$extra." />\n";
 	}
 }
@@ -266,7 +271,7 @@ if ( ! function_exists('form_textarea'))
 	 *
 	 * @param	mixed	$data
 	 * @param	string	$value
-	 * @param	string	$extra
+	 * @param	mixed	$extra
 	 * @return	string
 	 */
 	function form_textarea($data = '', $value = '', $extra = '')
@@ -287,6 +292,8 @@ if ( ! function_exists('form_textarea'))
 			unset($data['value']); // textareas don't use the value attribute
 		}
 
+		$extra = _attributes_to_string($extra);
+
 		return '<textarea '._parse_form_attributes($data, $defaults).$extra.'>'.html_escape($val)."</textarea>\n";
 	}
 }
@@ -301,11 +308,13 @@ if ( ! function_exists('form_multiselect'))
 	 * @param	string
 	 * @param	array
 	 * @param	mixed
-	 * @param	string
+	 * @param	mixed
 	 * @return	string
 	 */
 	function form_multiselect($name = '', $options = array(), $selected = array(), $extra = '')
 	{
+		$extra = _attributes_to_string($extra);
+
 		if ( ! strpos($extra, 'multiple'))
 		{
 			$extra .= ' multiple="multiple"';
@@ -420,7 +429,7 @@ if ( ! function_exists('form_checkbox'))
 	 * @param	mixed
 	 * @param	string
 	 * @param	bool
-	 * @param	string
+	 * @param	mixed
 	 * @return	string
 	 */
 	function form_checkbox($data = '', $value = '', $checked = FALSE, $extra = '')
@@ -450,6 +459,8 @@ if ( ! function_exists('form_checkbox'))
 			unset($defaults['checked']);
 		}
 
+		$extra = _attributes_to_string($extra);
+
 		return '<input '._parse_form_attributes($data, $defaults).$extra." />\n";
 	}
 }
@@ -464,13 +475,16 @@ if ( ! function_exists('form_radio'))
 	 * @param	mixed
 	 * @param	string
 	 * @param	bool
-	 * @param	string
+	 * @param	mixed
 	 * @return	string
 	 */
 	function form_radio($data = '', $value = '', $checked = FALSE, $extra = '')
 	{
 		is_array($data) OR $data = array('name' => $data);
 		$data['type'] = 'radio';
+
+		$extra = _attributes_to_string($extra);
+
 		return form_checkbox($data, $value, $checked, $extra);
 	}
 }
@@ -484,7 +498,7 @@ if ( ! function_exists('form_submit'))
 	 *
 	 * @param	mixed
 	 * @param	string
-	 * @param	string
+	 * @param	mixed
 	 * @return	string
 	 */
 	function form_submit($data = '', $value = '', $extra = '')
@@ -494,6 +508,8 @@ if ( ! function_exists('form_submit'))
 			'name' => is_array($data) ? '' : $data,
 			'value' => $value
 		);
+
+		$extra = _attributes_to_string($extra);
 
 		return '<input '._parse_form_attributes($data, $defaults).$extra." />\n";
 	}
@@ -508,7 +524,7 @@ if ( ! function_exists('form_reset'))
 	 *
 	 * @param	mixed
 	 * @param	string
-	 * @param	string
+	 * @param	mixed
 	 * @return	string
 	 */
 	function form_reset($data = '', $value = '', $extra = '')
@@ -518,6 +534,8 @@ if ( ! function_exists('form_reset'))
 			'name' => is_array($data) ? '' : $data,
 			'value' => $value
 		);
+
+		$extra = _attributes_to_string($extra);
 
 		return '<input '._parse_form_attributes($data, $defaults).$extra." />\n";
 	}
@@ -532,7 +550,7 @@ if ( ! function_exists('form_button'))
 	 *
 	 * @param	mixed
 	 * @param	string
-	 * @param	string
+	 * @param	mixed
 	 * @return	string
 	 */
 	function form_button($data = '', $content = '', $extra = '')
@@ -547,6 +565,8 @@ if ( ! function_exists('form_button'))
 			$content = $data['content'];
 			unset($data['content']); // content is not an attribute
 		}
+
+		$extra = _attributes_to_string($extra);
 
 		return '<button '._parse_form_attributes($data, $defaults).$extra.'>'.$content."</button>\n";
 	}

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -8,12 +8,18 @@ Version 3.0.1
 Release Date: Not Released
 
 -  Core
-
+   
    -  Added DoS mitigation to :php:func:`hash_pbkdf2()` :doc:`compatibility function <general/compatibility_functions>`.
 
-- Database
-
+-  Database
+   
    -  Added ``list_fields()`` support for SQLite ('sqlite3' and 'pdo_sqlite' drivers).
+
+-  Helpers
+   
+   -  :doc:`Form Helper <helpers/form_helper>` changes include:
+
+      -  Made all form helpers consistent by allowing an array to be passed for extra attributes.
 
 Bug fixes for 3.0.1
 -------------------

--- a/user_guide_src/source/helpers/form_helper.rst
+++ b/user_guide_src/source/helpers/form_helper.rst
@@ -191,7 +191,7 @@ The following functions are available:
 
 	:param	array	$data: Field attributes data
 	:param	string	$value: Field value
-	:param	string	$extra: Extra attributes to be added to the tag *as is*
+	:param	mixed	$extra: Extra attributes to be added to the tag *as is* either as array or string
 	:returns:	An HTML text input field tag
 	:rtype:	string
 
@@ -226,11 +226,16 @@ The following functions are available:
 		$js = 'onClick="some_function()"';
 		echo form_input('username', 'johndoe', $js);
 
+	Or you can pass it as an array::
+
+		$js = array('onClick' => "some_function()");
+		echo form_input('username', 'johndoe', $js);
+
 .. php:function:: form_password([$data = ''[, $value = ''[, $extra = '']]])
 
 	:param	array	$data: Field attributes data
 	:param	string	$value: Field value
-	:param	string	$extra: Extra attributes to be added to the tag *as is*
+	:param	mixed	$extra: Extra attributes to be added to the tag *as is* either as array or string
 	:returns:	An HTML password input field tag
 	:rtype:	string
 
@@ -242,7 +247,7 @@ The following functions are available:
 
 	:param	array	$data: Field attributes data
 	:param	string	$value: Field value
-	:param	string	$extra: Extra attributes to be added to the tag *as is*
+	:param	mixed	$extra: Extra attributes to be added to the tag *as is* either as array or string
 	:returns:	An HTML file upload input field tag
 	:rtype:	string
 
@@ -255,7 +260,7 @@ The following functions are available:
 
 	:param	array	$data: Field attributes data
 	:param	string	$value: Field value
-	:param	string	$extra: Extra attributes to be added to the tag *as is*
+	:param	mixed	$extra: Extra attributes to be added to the tag *as is* either as array or string
 	:returns:	An HTML textarea tag
 	:rtype:	string
 
@@ -270,7 +275,7 @@ The following functions are available:
 	:param	string	$name: Field name
 	:param	array	$options: An associative array of options to be listed
 	:param	array	$selected: List of fields to mark with the *selected* attribute
-	:param	string	$extra: Extra attributes to be added to the tag *as is*
+	:param	mixed	$extra: Extra attributes to be added to the tag *as is* either as array or string
 	:returns:	An HTML dropdown select field tag
 	:rtype:	string
 
@@ -324,6 +329,11 @@ The following functions are available:
 		$js = 'id="shirts" onChange="some_function();"';
 		echo form_dropdown('shirts', $options, 'large', $js);
 
+	Or you can pass it as an array::
+
+		$js = array('id' => "shirts", 'onChange' => "some_function();");
+		echo form_dropdown('shirts', $options, 'large', $js);
+
 	If the array passed as ``$options`` is a multidimensional array, then
 	``form_dropdown()`` will produce an <optgroup> with the array key as the
 	label.
@@ -334,7 +344,7 @@ The following functions are available:
 	:param	string	$name: Field name
 	:param	array	$options: An associative array of options to be listed
 	:param	array	$selected: List of fields to mark with the *selected* attribute
-	:param	string	$extra: Extra attributes to be added to the tag *as is*
+	:param	mixed	$extra: Extra attributes to be added to the tag *as is* either as array or string
 	:returns:	An HTML dropdown multiselect field tag
 	:rtype:	string
 
@@ -417,7 +427,7 @@ The following functions are available:
 	:param	array	$data: Field attributes data
 	:param	string	$value: Field value
 	:param	bool	$checked: Whether to mark the checkbox as being *checked*
-	:param	string	$extra: Extra attributes to be added to the tag *as is*
+	:param	mixed	$extra: Extra attributes to be added to the tag *as is* either as array or string
 	:returns:	An HTML checkbox input tag
 	:rtype:	string
 
@@ -450,13 +460,18 @@ The following functions are available:
 		$js = 'onClick="some_function()"';
 		echo form_checkbox('newsletter', 'accept', TRUE, $js)
 
+	Or you can pass it as an array::
+
+		$js = array('onClick' => "some_function()");
+		echo form_checkbox('newsletter', 'accept', TRUE, $js)
+
 
 .. php:function:: form_radio([$data = ''[, $value = ''[, $checked = FALSE[, $extra = '']]]])
 
 	:param	array	$data: Field attributes data
 	:param	string	$value: Field value
 	:param	bool	$checked: Whether to mark the radio button as being *checked*
-	:param	string	$extra: Extra attributes to be added to the tag *as is*
+	:param	mixed	$extra: Extra attributes to be added to the tag *as is* either as array or string
 	:returns:	An HTML radio input tag
 	:rtype:	string
 
@@ -495,7 +510,7 @@ The following functions are available:
 
 	:param	string	$data: Button name
 	:param	string	$value: Button value
-	:param	string	$extra: Extra attributes to be added to the tag *as is*
+	:param	mixed	$extra: Extra attributes to be added to the tag *as is* either as array or string
 	:returns:	An HTML input submit tag
 	:rtype:	string
 
@@ -513,7 +528,7 @@ The following functions are available:
 
 	:param	string	$data: Button name
 	:param	string	$value: Button value
-	:param	string	$extra: Extra attributes to be added to the tag *as is*
+	:param	mixed	$extra: Extra attributes to be added to the tag *as is* either as array or string
 	:returns:	An HTML input reset button tag
 	:rtype:	string
 
@@ -525,7 +540,7 @@ The following functions are available:
 
 	:param	string	$data: Button name
 	:param	string	$content: Button label
-	:param	string	$extra: Extra attributes to be added to the tag *as is*
+	:param	mixed	$extra: Extra attributes to be added to the tag *as is* either as array or string
 	:returns:	An HTML button tag
 	:rtype:	string
 

--- a/user_guide_src/source/helpers/form_helper.rst
+++ b/user_guide_src/source/helpers/form_helper.rst
@@ -191,7 +191,7 @@ The following functions are available:
 
 	:param	array	$data: Field attributes data
 	:param	string	$value: Field value
-	:param	mixed	$extra: Extra attributes to be added to the tag *as is* either as array or string
+	:param	mixed	$extra: Extra attributes to be added to the tag either as array or string
 	:returns:	An HTML text input field tag
 	:rtype:	string
 
@@ -235,7 +235,7 @@ The following functions are available:
 
 	:param	array	$data: Field attributes data
 	:param	string	$value: Field value
-	:param	mixed	$extra: Extra attributes to be added to the tag *as is* either as array or string
+	:param	mixed	$extra: Extra attributes to be added to the tag either as array or string
 	:returns:	An HTML password input field tag
 	:rtype:	string
 
@@ -247,7 +247,7 @@ The following functions are available:
 
 	:param	array	$data: Field attributes data
 	:param	string	$value: Field value
-	:param	mixed	$extra: Extra attributes to be added to the tag *as is* either as array or string
+	:param	mixed	$extra: Extra attributes to be added to the tag either as array or string
 	:returns:	An HTML file upload input field tag
 	:rtype:	string
 
@@ -260,7 +260,7 @@ The following functions are available:
 
 	:param	array	$data: Field attributes data
 	:param	string	$value: Field value
-	:param	mixed	$extra: Extra attributes to be added to the tag *as is* either as array or string
+	:param	mixed	$extra: Extra attributes to be added to the tag either as array or string
 	:returns:	An HTML textarea tag
 	:rtype:	string
 
@@ -275,7 +275,7 @@ The following functions are available:
 	:param	string	$name: Field name
 	:param	array	$options: An associative array of options to be listed
 	:param	array	$selected: List of fields to mark with the *selected* attribute
-	:param	mixed	$extra: Extra attributes to be added to the tag *as is* either as array or string
+	:param	mixed	$extra: Extra attributes to be added to the tag either as array or string
 	:returns:	An HTML dropdown select field tag
 	:rtype:	string
 
@@ -344,7 +344,7 @@ The following functions are available:
 	:param	string	$name: Field name
 	:param	array	$options: An associative array of options to be listed
 	:param	array	$selected: List of fields to mark with the *selected* attribute
-	:param	mixed	$extra: Extra attributes to be added to the tag *as is* either as array or string
+	:param	mixed	$extra: Extra attributes to be added to the tag either as array or string
 	:returns:	An HTML dropdown multiselect field tag
 	:rtype:	string
 
@@ -427,7 +427,7 @@ The following functions are available:
 	:param	array	$data: Field attributes data
 	:param	string	$value: Field value
 	:param	bool	$checked: Whether to mark the checkbox as being *checked*
-	:param	mixed	$extra: Extra attributes to be added to the tag *as is* either as array or string
+	:param	mixed	$extra: Extra attributes to be added to the tag either as array or string
 	:returns:	An HTML checkbox input tag
 	:rtype:	string
 
@@ -471,7 +471,7 @@ The following functions are available:
 	:param	array	$data: Field attributes data
 	:param	string	$value: Field value
 	:param	bool	$checked: Whether to mark the radio button as being *checked*
-	:param	mixed	$extra: Extra attributes to be added to the tag *as is* either as array or string
+	:param	mixed	$extra: Extra attributes to be added to the tag either as array or string
 	:returns:	An HTML radio input tag
 	:rtype:	string
 
@@ -510,7 +510,7 @@ The following functions are available:
 
 	:param	string	$data: Button name
 	:param	string	$value: Button value
-	:param	mixed	$extra: Extra attributes to be added to the tag *as is* either as array or string
+	:param	mixed	$extra: Extra attributes to be added to the tag either as array or string
 	:returns:	An HTML input submit tag
 	:rtype:	string
 
@@ -528,7 +528,7 @@ The following functions are available:
 
 	:param	string	$data: Button name
 	:param	string	$value: Button value
-	:param	mixed	$extra: Extra attributes to be added to the tag *as is* either as array or string
+	:param	mixed	$extra: Extra attributes to be added to the tag either as array or string
 	:returns:	An HTML input reset button tag
 	:rtype:	string
 
@@ -540,7 +540,7 @@ The following functions are available:
 
 	:param	string	$data: Button name
 	:param	string	$content: Button label
-	:param	mixed	$extra: Extra attributes to be added to the tag *as is* either as array or string
+	:param	mixed	$extra: Extra attributes to be added to the tag either as array or string
 	:returns:	An HTML button tag
 	:rtype:	string
 


### PR DESCRIPTION
Extra attributes in form methods can now all be passed as arrays or strings, form_dropdown and form_open already behaved that way.