### PR TITLE
$this->db->replace_string() for creating "REPLACE INTO" SQL queries

### DIFF
--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -1395,6 +1395,45 @@ abstract class CI_DB_driver {
 	// --------------------------------------------------------------------
 
 	/**
+	 * Generate a replace string
+	 *
+	 * @param	string	the table upon which the query will be performed
+	 * @param	array	an associative array data of key/values
+	 * @return	string
+	 */
+	public function replace_string($table, $data)
+	{
+		$fields = $values = array();
+
+		foreach ($data as $key => $val)
+		{
+			$fields[] = $this->escape_identifiers($key);
+			$values[] = $this->escape($val);
+		}
+
+		return $this->_replace($this->protect_identifiers($table, TRUE, NULL, FALSE), $fields, $values);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Replace statement
+	 *
+	 * Generates a platform-specific replace string from the supplied data
+	 *
+	 * @param	string	the table name
+	 * @param	array	the replace keys
+	 * @param	array	the replace values
+	 * @return	string
+	 */
+	protected function _replace($table, $keys, $values)
+	{
+		return 'REPLACE INTO '.$table.' ('.implode(', ', $keys).') VALUES ('.implode(', ', $values).')';
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
 	 * Generate an update string
 	 *
 	 * @param	string	the table upon which the query will be performed

--- a/user_guide_src/source/database/helpers.rst
+++ b/user_guide_src/source/database/helpers.rst
@@ -80,6 +80,22 @@ array with the data to be inserted. The above example produces::
 
 .. note:: Values are automatically escaped, producing safer queries.
 
+**$this->db->replace_string()**
+
+This function simplifies the process of writing database replaces. It
+returns a correctly formatted SQL replace string. Example::
+
+	$data = array('name' => $name, 'email' => $email, 'url' => $url);
+	
+	$str = $this->db->replace_string('table_name', $data);
+
+The first parameter is the table name, the second is an associative
+array with the data to be replaced. The above example produces::
+
+	REPLACE INTO table_name (name, email, url) VALUES ('Rick', 'rick@example.com', 'example.com')
+
+.. note:: Values are automatically escaped, producing safer queries.
+
 **$this->db->update_string()**
 
 This function simplifies the process of writing database updates. It


### PR DESCRIPTION
This is based on insert_string(), but modified to generate "REPLACE INTO" instead of "INSERT_INTO".

As you know, REPLACE INTO behaves differently to INSERT INTO in that if there is an existing row with the same primary key or unique key, the existing row will be replaced with the new data, otherwise it will be inserted.

Also, Some MySQL storage backends like TokuDB perform faster when using REPLACE INTO instead of INSERT INTO.

For these reasons, this is a useful helper.

Without this function, a "REPLACE INTO" query can only be generated in CodeIgniter by performing a string replace on the output of insert_string(), which is messy.
