### PR TITLE
Bug Fix

### DIFF
--- a/system/libraries/Cache/drivers/Cache_memcached.php
+++ b/system/libraries/Cache/drivers/Cache_memcached.php
@@ -82,6 +82,13 @@ class CI_Cache_memcached extends CI_Driver {
 	}
 
 	// ------------------------------------------------------------------------
+	
+	// force setup of server
+	public function  __construct() 
+	{
+		$this->_setup_memcached();
+	}
+
 
 	/**
 	 * Save

--- a/system/libraries/Cache/drivers/Cache_memcached.php
+++ b/system/libraries/Cache/drivers/Cache_memcached.php
@@ -83,10 +83,10 @@ class CI_Cache_memcached extends CI_Driver {
 
 	// ------------------------------------------------------------------------
 	
-	// force setup of server
-	public function  __construct() 
-	{
-		$this->_setup_memcached();
+	public function  __construct() {
+		// force setup of server
+	        if(empty($this->_memcached))
+	        	$this->_setup_memcached();
 	}
 
 


### PR DESCRIPTION
This actually does not work (as told in documentation)

##################################################

All of the methods listed above can be accessed without passing a specific adapter to the driver loader as follows:

$this->load->driver('cache');
$this->cache->memcached->save('foo', 'bar', 10);

##################################################

We need to force setup in order to assign $_memcached, else caching will not work, and all function associated to it. Please do your testing, you will see I'm right.