### PR TITLE
Update *Best Practices* parenthetical to refer to correct steps

### DIFF
--- a/user_guide_src/source/general/security.rst
+++ b/user_guide_src/source/general/security.rst
@@ -61,8 +61,8 @@ data from the SERVER array, you are encouraged to practice this three
 step approach:
 
 #. Validate the data to ensure it conforms to the correct type, length,
-   size, etc. (sometimes this step can replace step one)
-#. Filter the data as if it were tainted.
+   size, etc.
+#. Filter the data as if it were tainted. (sometimes this step can replace step one)
 #. Escape the data before submitting it into your database or outputting
    it to a browser.
 


### PR DESCRIPTION
In the documentation at user_guide/general/security.html#best-practices, the 3-item list has a misplaced parenthetical.

This parenthetical currently is at the end of the first list item, though it refers to a step that can replace the first item. It is meant to be placed after the 2nd list item: filtering data. This change correctly informs the user that filtering incoming application data (POST, COOKIE, URI, etc.) may sometimes take the place of the validation step, which is the first list item.

The change is:

BEFORE:
#. Validate the data to ensure it conforms to the correct type, length,
   size, etc. (sometimes this step can replace step one)
#. Filter the data as if it were tainted.
#. Escape the data before submitting it into your database or outputting
   it to a browser.

AFTER:
#. Validate the data to ensure it conforms to the correct type, length,
   size, etc.
#. Filter the data as if it were tainted. (sometimes this step can replace step one)
#. Escape the data before submitting it into your database or outputting
   it to a browser.