### PR TITLE
Remove superfluous *Best Practices* parenthetical

### DIFF
--- a/user_guide_src/source/general/security.rst
+++ b/user_guide_src/source/general/security.rst
@@ -61,7 +61,7 @@ data from the SERVER array, you are encouraged to practice this three
 step approach:
 
 #. Validate the data to ensure it conforms to the correct type, length,
-   size, etc. (sometimes this step can replace step one)
+   size, etc.
 #. Filter the data as if it were tainted.
 #. Escape the data before submitting it into your database or outputting
    it to a browser.


### PR DESCRIPTION
In the documentation at user_guide/general/security.html#best-practices, the 3-item list has a superfluous parenthetical that is also misplaced.

This parenthetical currently is at the end of the first list item, though it refers to a step that can replace the first item. As per narfbg's request in PR https://github.com/bcit-ci/CodeIgniter/pull/3915, this change removes the parenthetical entirely.

The change is:

BEFORE:
#. Validate the data to ensure it conforms to the correct type, length,
size, etc. (sometimes this step can replace step one)
#. Filter the data as if it were tainted.
#. Escape the data before submitting it into your database or outputting
it to a browser.

AFTER:
#. Validate the data to ensure it conforms to the correct type, length,
size, etc.
#. Filter the data as if it were tainted.
#. Escape the data before submitting it into your database or outputting
it to a browser.