### PR TITLE
sqlite < 3.3 unsuported `_drop_table_if`

### DIFF
--- a/system/database/drivers/pdo/subdrivers/pdo_sqlite_forge.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_sqlite_forge.php
@@ -89,6 +89,7 @@ class CI_DB_pdo_sqlite_forge extends CI_DB_pdo_forge {
 		if (version_compare($this->db->version(), '3.3', '<'))
 		{
 			$this->_create_table_if = FALSE;
+			$this->_drop_table_if   = FALSE;
 		}
 	}
 


### PR DESCRIPTION
http://www.sqlite.org/changes.html

> IF EXISTS and IF NOT EXISTS clauses on CREATE/DROP TABLE/INDEX.
