### PR TITLE
Eliminated dead code

### DIFF
--- a/system/database/DB_forge.php
+++ b/system/database/DB_forge.php
@@ -454,11 +454,8 @@ abstract class CI_DB_forge {
 		}
 
 		$query = $this->_drop_table($this->db->dbprefix.$table_name, $if_exists);
-		if ($query === FALSE)
-		{
-			return ($this->db->db_debug) ? $this->db->display_error('db_unsupported_feature') : FALSE;
-		}
-		elseif ($query === TRUE)
+
+		if ($query === TRUE)
 		{
 			return TRUE;
 		}


### PR DESCRIPTION
```php
		$query = $this->_drop_table($this->db->dbprefix.$table_name, $if_exists);

		if ($query === FALSE)
		{
			return ($this->db->db_debug) ? $this->db->display_error('db_unsupported_feature') : FALSE;
		}
		elseif ($query === TRUE)
		{
			return TRUE;
		}
```

> Use `$this->_drop_table`, return type **never equals FALSE**.


So 

```php
		if ($query === FALSE)
		{
			return ($this->db->db_debug) ? $this->db->display_error('db_unsupported_feature') : FALSE;
		}
```
 Eliminated  it.