### PR TITLE
Fix migration_type default value

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -29,7 +29,7 @@ $config['migration_enabled'] = FALSE;
 | to 'sequential' for backward compatibility.
 |
 */
-$config['migration_type'] = 'timestamp';
+$config['migration_type'] = 'sequential';
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
The default value for migration_type was set as timestamp, but all documentation says that is sequential. So, there was some people that was unaccustomed with this problem than they not find where is wrong.