### PR TITLE
fix SQlite3 list_fields

### DIFF
--- a/system/database/drivers/pdo/subdrivers/pdo_sqlite_driver.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_sqlite_driver.php
@@ -140,7 +140,7 @@ class CI_DB_pdo_sqlite_driver extends CI_DB_pdo_driver {
 		}
 
 		$this->data_cache['field_names'][$table] = array();
-		foreach ($result as $row)
+		foreach ($result->result_array() as $row)
 		{
 			$this->data_cache['field_names'][$table][] = $row['name'];
 		}

--- a/system/database/drivers/sqlite3/sqlite3_driver.php
+++ b/system/database/drivers/sqlite3/sqlite3_driver.php
@@ -266,7 +266,7 @@ class CI_DB_sqlite3_driver extends CI_DB {
 		}
 
 		$this->data_cache['field_names'][$table] = array();
-		foreach ($result as $row)
+		foreach ($result->result_array() as $row)
 		{
 			$this->data_cache['field_names'][$table][] = $row['name'];
 		}

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -46,6 +46,7 @@ Bug fixes for 3.0.1
 -  Fixed a bug (#3913) - :doc:`Cache Library <libraries/caching>` didn't work with the direct ``$this->cache->$driver_name->method()`` syntax with Redis and Memcache(d).
 -  Fixed a bug (#3932) - :doc:`Query Builder <database/query_builder>` didn't properly compile WHERE and HAVING conditions for field names that end with "and", "or".
 -  Fixed a bug in :doc:`Query Builder <database/query_builder>` where ``delete()`` didn't properly work on multiple tables with a WHERE condition previously set via ``where()``.
+-  Fixed a bug (#3952) - ``list_fields()`` didn't work properly with the SQlite ('sqlite3' driver).
 
 Version 3.0.0
 =============

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -46,7 +46,7 @@ Bug fixes for 3.0.1
 -  Fixed a bug (#3913) - :doc:`Cache Library <libraries/caching>` didn't work with the direct ``$this->cache->$driver_name->method()`` syntax with Redis and Memcache(d).
 -  Fixed a bug (#3932) - :doc:`Query Builder <database/query_builder>` didn't properly compile WHERE and HAVING conditions for field names that end with "and", "or".
 -  Fixed a bug in :doc:`Query Builder <database/query_builder>` where ``delete()`` didn't properly work on multiple tables with a WHERE condition previously set via ``where()``.
--  Fixed a bug (#3952) - ``list_fields()`` didn't work properly with the SQlite ('sqlite3' driver).
+-  Fixed a bug (#3952) - :doc:`Database <database/index>` method ``list_fields()`` didn't work with SQLite3.
 
 Version 3.0.0
 =============


### PR DESCRIPTION
Fatal error: Cannot use object of type SQLite3 as array 