### PR TITLE
supported key_prefix on `increment` and `decrement`

### DIFF
--- a/system/libraries/Cache/Cache.php
+++ b/system/libraries/Cache/Cache.php
@@ -178,7 +178,7 @@ class CI_Cache extends CI_Driver_Library {
 	 */
 	public function increment($id, $offset = 1)
 	{
-		return $this->{$this->_adapter}->increment($id, $offset);
+		return $this->{$this->_adapter}->increment($this->key_prefix.$id, $offset);
 	}
 
 	// ------------------------------------------------------------------------
@@ -192,7 +192,7 @@ class CI_Cache extends CI_Driver_Library {
 	 */
 	public function decrement($id, $offset = 1)
 	{
-		return $this->{$this->_adapter}->decrement($id, $offset);
+		return $this->{$this->_adapter}->decrement($this->key_prefix.$id, $offset);
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
```php
$this->load->driver('cache',
    array('adapter' => 'redis', 'backup' => 'file', 'key_prefix' => 'my_')
);

$this->cache->save('test', 100);
$this->cache->get('test'); //100

/*
 * increment test
 * Expected result: 101
 * Actual result: 1
 */
$this->cache->increment('test');

```