### PR TITLE
Important note on adding keys add_field() with strings

### DIFF
--- a/user_guide_src/source/database/forge.rst
+++ b/user_guide_src/source/database/forge.rst
@@ -143,7 +143,7 @@ string into the field definitions with add_field()
 	$this->dbforge->add_field("label varchar(100) NOT NULL DEFAULT 'default label'");
 
 
-.. note:: Passing strings as fields won't allow you to follow these calls by a add_key() call.
+..note:: Passing raw strings as fields cannot be followed by ``add_key()`` calls on those fields.
 
 .. note:: Multiple calls to add_field() are cumulative.
 

--- a/user_guide_src/source/database/forge.rst
+++ b/user_guide_src/source/database/forge.rst
@@ -143,6 +143,8 @@ string into the field definitions with add_field()
 	$this->dbforge->add_field("label varchar(100) NOT NULL DEFAULT 'default label'");
 
 
+.. note:: Passing strings as fields won't allow you to follow these calls by a add_key() call.
+
 .. note:: Multiple calls to add_field() are cumulative.
 
 Creating an id field

--- a/user_guide_src/source/database/forge.rst
+++ b/user_guide_src/source/database/forge.rst
@@ -143,7 +143,7 @@ string into the field definitions with add_field()
 	$this->dbforge->add_field("label varchar(100) NOT NULL DEFAULT 'default label'");
 
 
-..note:: Passing raw strings as fields cannot be followed by ``add_key()`` calls on those fields.
+.. note:: Passing raw strings as fields cannot be followed by ``add_key()`` calls on those fields.
 
 .. note:: Multiple calls to add_field() are cumulative.
 


### PR DESCRIPTION
If you pass strings to the add_field() methods you won't be able to follow those by add_key() methods on those fields.