### PR TITLE
Path helper remote file inclusion security check fail

### DIFF
--- a/system/helpers/path_helper.php
+++ b/system/helpers/path_helper.php
@@ -61,6 +61,7 @@ if ( ! function_exists('set_realpath'))
 	function set_realpath($path, $check_existance = FALSE)
 	{
 		// Security check to make sure the path is NOT a URL. No remote file inclusion!
+		// PROBLEM HERE - this can be easily bypassed in case of subdomains
 		if (preg_match('#^(http:\/\/|https:\/\/|www\.|ftp|[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})#i', $path))
 		{
 			show_error('The path you submitted must be a local server path, not a URL');

--- a/system/helpers/path_helper.php
+++ b/system/helpers/path_helper.php
@@ -61,8 +61,7 @@ if ( ! function_exists('set_realpath'))
 	function set_realpath($path, $check_existance = FALSE)
 	{
 		// Security check to make sure the path is NOT a URL. No remote file inclusion!
-		// PROBLEM HERE - this can be easily bypassed in case of subdomains
-		if (preg_match('#^(http:\/\/|https:\/\/|www\.|ftp|[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})#i', $path))
+		if (preg_match('#^(http:\/\/|https:\/\/|www\.|ftp|[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})#i', $path) || ( function_exists('fsockopen') &&  @fsockopen($path, 80, $errno, $errstr, 30)))
 		{
 			show_error('The path you submitted must be a local server path, not a URL');
 		}


### PR DESCRIPTION
The currently implemented security check to make sure the path is NOT a URL can easily be bypassed (gives false negative) for all subdomains. 
Eg "subdomain.domain.com" should ideally show an error but it does not.

The new security check (in addition to the previous one) tries to make a fsockopen connection to validate whether the URL is external or not.