### PR TITLE
Fix coding style in CLI error templates

### DIFF
--- a/application/views/errors/cli/error_exception.php
+++ b/application/views/errors/cli/error_exception.php
@@ -2,9 +2,9 @@
 
 An uncaught Exception was encountered
 
-Type:     <?php echo get_class($exception), "\n"; ?>
-Message:  <?php echo $message, "\n"; ?>
-Filename: <?php echo $exception->getFile(), "\n"; ?>
+Type:        <?php echo get_class($exception), "\n"; ?>
+Message:     <?php echo $message, "\n"; ?>
+Filename:    <?php echo $exception->getFile(), "\n"; ?>
 Line Number: <?php echo $exception->getLine(); ?>
 
 <?php if (defined('SHOW_DEBUG_BACKTRACE') && SHOW_DEBUG_BACKTRACE === TRUE): ?>

--- a/application/views/errors/cli/error_exception.php
+++ b/application/views/errors/cli/error_exception.php
@@ -2,10 +2,10 @@
 
 An uncaught Exception was encountered
 
-Type: <?php echo get_class($exception), "\n"; ?>
-Message: <?php echo $message, "\n"; ?>
+Type:     <?php echo get_class($exception), "\n"; ?>
+Message:  <?php echo $message, "\n"; ?>
 Filename: <?php echo $exception->getFile(), "\n"; ?>
-Line Number: <?php echo $exception->getLine(), "\n"; ?>
+Line Number: <?php echo $exception->getLine(); ?>
 
 <?php if (defined('SHOW_DEBUG_BACKTRACE') && SHOW_DEBUG_BACKTRACE === TRUE): ?>
 

--- a/application/views/errors/cli/error_php.php
+++ b/application/views/errors/cli/error_php.php
@@ -2,9 +2,9 @@
 
 A PHP Error was encountered
 
-Severity: <?php echo $severity, "\n"; ?>
-Message:  <?php echo $message, "\n"; ?>
-Filename: <?php echo $filepath, "\n"; ?>
+Severity:    <?php echo $severity, "\n"; ?>
+Message:     <?php echo $message, "\n"; ?>
+Filename:    <?php echo $filepath, "\n"; ?>
 Line Number: <?php echo $line; ?>
 
 <?php if (defined('SHOW_DEBUG_BACKTRACE') && SHOW_DEBUG_BACKTRACE === TRUE): ?>

--- a/application/views/errors/cli/error_php.php
+++ b/application/views/errors/cli/error_php.php
@@ -2,19 +2,19 @@
 
 A PHP Error was encountered
 
-Severity: <?php echo $severity, "\n";?>
-Message:  <?php echo $message, "\n";?>
-Filename: <?php echo $filepath, "\n";?>
-Line Number: <?php echo $line;?>
+Severity: <?php echo $severity, "\n"; ?>
+Message:  <?php echo $message, "\n"; ?>
+Filename: <?php echo $filepath, "\n"; ?>
+Line Number: <?php echo $line; ?>
 
 <?php if (defined('SHOW_DEBUG_BACKTRACE') && SHOW_DEBUG_BACKTRACE === TRUE): ?>
 
 Backtrace:
 <?php	foreach (debug_backtrace() as $error): ?>
 <?php		if (isset($error['file']) && strpos($error['file'], realpath(BASEPATH)) !== 0): ?>
-	File: <?php echo $error['file'], "\n";?>
-	Line: <?php echo $error['line'], "\n";?>
-	Function: <?php echo $error['function'], "\n\n";?>
+	File: <?php echo $error['file'], "\n"; ?>
+	Line: <?php echo $error['line'], "\n"; ?>
+	Function: <?php echo $error['function'], "\n\n"; ?>
 <?php		endif ?>
 <?php	endforeach ?>
 


### PR DESCRIPTION
Fix coding style exactly the same in two error templates.

~~~diff
--- error_exception.php	2015-07-21 08:21:16.000000000 +0900
+++ error_php.php	2015-07-21 08:13:20.000000000 +0900
@@ -1,16 +1,16 @@
 <?php defined('BASEPATH') OR exit('No direct script access allowed'); ?>
 
-An uncaught Exception was encountered
+A PHP Error was encountered
 
-Type:     <?php echo get_class($exception), "\n"; ?>
+Severity: <?php echo $severity, "\n"; ?>
 Message:  <?php echo $message, "\n"; ?>
-Filename: <?php echo $exception->getFile(), "\n"; ?>
-Line Number: <?php echo $exception->getLine(); ?>
+Filename: <?php echo $filepath, "\n"; ?>
+Line Number: <?php echo $line; ?>
 
 <?php if (defined('SHOW_DEBUG_BACKTRACE') && SHOW_DEBUG_BACKTRACE === TRUE): ?>
 
 Backtrace:
-<?php	foreach ($exception->getTrace() as $error): ?>
+<?php	foreach (debug_backtrace() as $error): ?>
 <?php		if (isset($error['file']) && strpos($error['file'], realpath(BASEPATH)) !== 0): ?>
 	File: <?php echo $error['file'], "\n"; ?>
 	Line: <?php echo $error['line'], "\n"; ?>
~~~

Related: #3983
