### PR TITLE
Form Validation: Add native rule valid_mac

### DIFF
--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -568,6 +568,31 @@ class CI_Input {
 		return (bool) filter_var($ip, FILTER_VALIDATE_IP, $which);
 	}
 
+	// -------------------------------------------------------------------
+
+	/**
+	 * Validate MAC Adress
+	 *
+	 * @param $mac string	$mac MAC address
+	 * @return bool
+	 */
+	public function valid_mac($mac)
+	{
+		if(empty($mac))
+		{
+			return FALSE;
+		}
+
+		if(version_compare(PHP_VERSION, '5.5.0', ">="))
+		{
+			return (bool) filter_var($mac, FILTER_VALIDATE_MAC);
+		}else{
+			$mac_reg = '/^([0-9a-fA-F]{2})((([:][0-9a-fA-F]{2}){5})|(([-][0-9a-fA-F]{2}){5}))$/i';
+			return (bool) preg_match($mac_reg, $mac);
+		}
+
+	}
+
 	// --------------------------------------------------------------------
 
 	/**

--- a/system/language/english/form_validation_lang.php
+++ b/system/language/english/form_validation_lang.php
@@ -43,6 +43,7 @@ $lang['form_validation_valid_email']		= 'The {field} field must contain a valid 
 $lang['form_validation_valid_emails']		= 'The {field} field must contain all valid email addresses.';
 $lang['form_validation_valid_url']		= 'The {field} field must contain a valid URL.';
 $lang['form_validation_valid_ip']		= 'The {field} field must contain a valid IP.';
+$lang['form_validation_valid_mac']		= 'The {field} field must contain a valid MAC.';
 $lang['form_validation_min_length']		= 'The {field} field must be at least {param} characters in length.';
 $lang['form_validation_max_length']		= 'The {field} field cannot exceed {param} characters in length.';
 $lang['form_validation_exact_length']		= 'The {field} field must be exactly {param} characters in length.';

--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -1292,6 +1292,19 @@ class CI_Form_validation {
 	// --------------------------------------------------------------------
 
 	/**
+	 * Validate MAC Address
+	 *
+	 * @param $mac string $mac MAC address
+	 * @return bool
+	 */
+	public function valid_mac($mac)
+	{
+		return $this->CI->input->valid_mac($mac);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
 	 * Alpha
 	 *
 	 * @param	string


### PR DESCRIPTION
MAC validation is very common.
php version gt 5.5.0 use  filter_var others use  regular expressions
