### PR TITLE
Removing use of ->num_rows() in DB results docs.

### DIFF
--- a/user_guide_src/source/database/results.rst
+++ b/user_guide_src/source/database/results.rst
@@ -33,16 +33,14 @@ If you run queries that might **not** produce a result, you are
 encouraged to test the result first::
 
 	$query = $this->db->query("YOUR QUERY");
-	
-	if ($query->num_rows() > 0)
+
+	foreach ($query->result() as $row)
 	{
-		foreach ($query->result() as $row)
-		{
-			echo $row->title;
-			echo $row->name;
-			echo $row->body;
-		}
+		echo $row->title;
+		echo $row->name;
+		echo $row->body;
 	}
+
 
 You can also pass a string to result() which represents a class to
 instantiate for each result object (note: this class must be loaded)
@@ -83,11 +81,11 @@ one row, it returns only the first row. The result is returned as an
 **object**. Here's a usage example::
 
 	$query = $this->db->query("YOUR QUERY");
-	
-	if ($query->num_rows() > 0)
+
+	$row = $query->row();
+
+	if (is_object($row))
 	{
-		$row = $query->row();
-		
 		echo $row->title;
 		echo $row->name;
 		echo $row->body;
@@ -113,11 +111,11 @@ Identical to the above ``row()`` method, except it returns an array.
 Example::
 
 	$query = $this->db->query("YOUR QUERY");
-	
-	if ($query->num_rows() > 0)
+
+	$row = $query->row_array();
+
+	if (is_array($row))
 	{
-		$row = $query->row_array();
-		
 		echo $row['title'];
 		echo $row['name'];
 		echo $row['body'];

--- a/user_guide_src/source/database/results.rst
+++ b/user_guide_src/source/database/results.rst
@@ -41,7 +41,6 @@ encouraged to test the result first::
 		echo $row->body;
 	}
 
-
 You can also pass a string to result() which represents a class to
 instantiate for each result object (note: this class must be loaded)
 

--- a/user_guide_src/source/database/results.rst
+++ b/user_guide_src/source/database/results.rst
@@ -83,7 +83,7 @@ one row, it returns only the first row. The result is returned as an
 
 	$row = $query->row();
 
-	if (is_object($row))
+	if (isset($row))
 	{
 		echo $row->title;
 		echo $row->name;
@@ -113,7 +113,7 @@ Example::
 
 	$row = $query->row_array();
 
-	if (is_array($row))
+	if (isset($row))
 	{
 		echo $row['title'];
 		echo $row['name'];


### PR DESCRIPTION
Since some drivers must prefetch the entire result set and count the results, this practice should not be encouraged in the user guide since: 

- `result()`, `result_array()`, and `result_object()` will return an empty array with no results
- `row`, `row_array()` and `row_object()` will return NULL if no result. 