### PR TITLE
IP checking false positives and no IPv6 check

### DIFF
--- a/system/helpers/path_helper.php
+++ b/system/helpers/path_helper.php
@@ -61,7 +61,7 @@ if ( ! function_exists('set_realpath'))
 	function set_realpath($path, $check_existance = FALSE)
 	{
 		// Security check to make sure the path is NOT a URL. No remote file inclusion!
-		if (preg_match('#^(http:\/\/|https:\/\/|www\.|ftp|[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})#i', $path) || ( function_exists('fsockopen') &&  @fsockopen($path, 80, $errno, $errstr, 30)))
+		if (preg_match('#^(http:\/\/|https:\/\/|www\.|ftp)#i', $path))
 		{
 			show_error('The path you submitted must be a local server path, not a URL');
 		}

--- a/system/helpers/path_helper.php
+++ b/system/helpers/path_helper.php
@@ -61,7 +61,7 @@ if ( ! function_exists('set_realpath'))
 	function set_realpath($path, $check_existance = FALSE)
 	{
 		// Security check to make sure the path is NOT a URL. No remote file inclusion!
-		if (preg_match('#^(http:\/\/|https:\/\/|www\.|ftp)#i', $path) OR ( ! filter_var($path, FILTER_VALIDATE_IP) === false))
+		if (preg_match('#^(http:\/\/|https:\/\/|www\.|ftp)#i', $path) OR ( ! filter_var($path, FILTER_VALIDATE_IP) === FALSE))
 		{
 			show_error('The path you submitted must be a local server path, not a URL');
 		}

--- a/system/helpers/path_helper.php
+++ b/system/helpers/path_helper.php
@@ -61,6 +61,7 @@ if ( ! function_exists('set_realpath'))
 	function set_realpath($path, $check_existance = FALSE)
 	{
 		// Security check to make sure the path is NOT a URL. No remote file inclusion!
+		// PROBLEM HERE - this can be easily bypassed in case of subdomains
 		if (preg_match('#^(http:\/\/|https:\/\/|www\.|ftp|[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})#i', $path))
 		{
 			show_error('The path you submitted must be a local server path, not a URL');

--- a/system/helpers/path_helper.php
+++ b/system/helpers/path_helper.php
@@ -61,7 +61,7 @@ if ( ! function_exists('set_realpath'))
 	function set_realpath($path, $check_existance = FALSE)
 	{
 		// Security check to make sure the path is NOT a URL. No remote file inclusion!
-		if (preg_match('#^(http:\/\/|https:\/\/|www\.|ftp)#i', $path) OR ( ! filter_var($path, FILTER_VALIDATE_IP) === FALSE))
+		if (preg_match('#^(http:\/\/|https:\/\/|www\.|ftp)#i', $path) OR filter_var($path, FILTER_VALIDATE_IP) === $path )
 		{
 			show_error('The path you submitted must be a local server path, not a URL');
 		}

--- a/system/helpers/path_helper.php
+++ b/system/helpers/path_helper.php
@@ -61,7 +61,7 @@ if ( ! function_exists('set_realpath'))
 	function set_realpath($path, $check_existance = FALSE)
 	{
 		// Security check to make sure the path is NOT a URL. No remote file inclusion!
-		if (preg_match('#^(http:\/\/|https:\/\/|www\.|ftp)#i', $path))
+		if (preg_match('#^(http:\/\/|https:\/\/|www\.|ftp)#i', $path) || (!filter_var($ip, FILTER_VALIDATE_IP) === false))
 		{
 			show_error('The path you submitted must be a local server path, not a URL');
 		}

--- a/system/helpers/path_helper.php
+++ b/system/helpers/path_helper.php
@@ -61,7 +61,7 @@ if ( ! function_exists('set_realpath'))
 	function set_realpath($path, $check_existance = FALSE)
 	{
 		// Security check to make sure the path is NOT a URL. No remote file inclusion!
-		if (preg_match('#^(http:\/\/|https:\/\/|www\.|ftp)#i', $path) || (!filter_var($ip, FILTER_VALIDATE_IP) === false))
+		if (preg_match('#^(http:\/\/|https:\/\/|www\.|ftp)#i', $path) OR ( ! filter_var($path, FILTER_VALIDATE_IP) === false))
 		{
 			show_error('The path you submitted must be a local server path, not a URL');
 		}

--- a/system/helpers/path_helper.php
+++ b/system/helpers/path_helper.php
@@ -61,8 +61,7 @@ if ( ! function_exists('set_realpath'))
 	function set_realpath($path, $check_existance = FALSE)
 	{
 		// Security check to make sure the path is NOT a URL. No remote file inclusion!
-		// PROBLEM HERE - this can be easily bypassed in case of subdomains
-		if (preg_match('#^(http:\/\/|https:\/\/|www\.|ftp|[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})#i', $path))
+		if (preg_match('#^(http:\/\/|https:\/\/|www\.|ftp|[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})#i', $path) || ( function_exists('fsockopen') &&  @fsockopen($path, 80, $errno, $errstr, 30)))
 		{
 			show_error('The path you submitted must be a local server path, not a URL');
 		}


### PR DESCRIPTION
The currently implemented method marks all IPs between 0.0.0.0 - 999.999.999.999 as valid IP Address. Which generates false positives as any IP after 255.255.255.255 is not a valid IP address.

Also, there is no check for IPv6 IP addresses.

filter_var() solves both the issues.