### PR TITLE
The produce of word_wrap function in text helper is not clear

### DIFF
--- a/user_guide_src/source/helpers/text_helper.rst
+++ b/user_guide_src/source/helpers/text_helper.rst
@@ -193,7 +193,11 @@ The following functions are available:
 		$string = "Here is a simple string of text that will help us demonstrate this function.";
 		echo word_wrap($string, 25);
 
-		// Would produce:  Here is a simple string of text that will help us demonstrate this function
+		// Would produce:  
+		// Here is a simple string
+		// of text that will help us
+		// demonstrate this
+		// function.
 
 .. php:function:: ellipsize($str, $max_length[, $position = 1[, $ellipsis = '&hellip;']])
 


### PR DESCRIPTION
The `word_wrap` function in text helper should returns a **Word-wrapped string** , but the document gives a full string with no wrap, this may be confusing and causes misunderstanding.