### PR TITLE
parse_url of a valid url was returning FALSE when a colon existed in the path or query

### DIFF
--- a/system/core/URI.php
+++ b/system/core/URI.php
@@ -201,7 +201,7 @@ class CI_URI {
 			return '';
 		}
 
-		$uri = parse_url($_SERVER['REQUEST_URI']);
+		$uri = parse_url($_SERVER['SERVER_NAME'] . ':' . $_SERVER['SERVER_PORT'] . $_SERVER['REQUEST_URI']);
 		$query = isset($uri['query']) ? $uri['query'] : '';
 		$uri = isset($uri['path']) ? $uri['path'] : '';
 


### PR DESCRIPTION
MJZ: i changed this line on 7-27-15 to properly parse a url. It was erroring out if the path or query had a colon in the string. The function was assuming it's a port number following and bombed out... so i added the protocol and port to the front of the string

this string returns FALSE because the parse gets confused "/932?numeric_filters_name[]=Number+of+Members+Holding&numeric_filters_value[]=35:69"