### PR TITLE
Reduce once $config['query_toggle_count'] checking

### DIFF
--- a/system/libraries/Profiler.php
+++ b/system/libraries/Profiler.php
@@ -100,12 +100,6 @@ class CI_Profiler {
 		$this->CI =& get_instance();
 		$this->CI->load->language('profiler');
 
-		if (isset($config['query_toggle_count']))
-		{
-			$this->_query_toggle_count = (int) $config['query_toggle_count'];
-			unset($config['query_toggle_count']);
-		}
-
 		// default all sections to display
 		foreach ($this->_available_sections as $section)
 		{


### PR DESCRIPTION
This checking can be done by calling set_sections method when initialize profiler .