### PR TITLE
fix E_NOTICE error "Undefined index: REMOTE_ADDR"

### DIFF
--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -349,7 +349,7 @@ class CI_Input {
 		}
 		else
 		{
-			$this->ip_address = $_SERVER['REMOTE_ADDR'];
+			$this->ip_address = $this->server('REMOTE_ADDR');
 		}
 
 		if ( ! $this->valid_ip($this->ip_address))


### PR DESCRIPTION
when requesting `$this->input->ip_address()` on CLI

This is essentially a backport from line 429 in Input.php from develop branch