### PR TITLE
Catch redis exception

### DIFF
--- a/system/libraries/Cache/drivers/Cache_redis.php
+++ b/system/libraries/Cache/drivers/Cache_redis.php
@@ -123,8 +123,12 @@ class CI_Cache_redis extends CI_Driver
 			throw new RuntimeException('Cache: Redis connection refused ('.$e->getMessage().')');
 		}
 
-		if (isset($config['password']) && ! $this->_redis->auth($config['password']))
-		{
+		try {
+			if (isset($config['password']) && ! $this->_redis->auth($config['password']))
+			{
+				throw new RuntimeException('Cache: Redis authentication failed.');
+			}
+		} catch (RedisException $e) {
 			throw new RuntimeException('Cache: Redis authentication failed.');
 		}
 


### PR DESCRIPTION
RedisException occured when connected with ssl port.

 ```
An uncaught Exception was encountered

Type: RedisException

Message: read error on connection

Filename: /Users/trsw/work/php/codeigniter/ci-rest/vendor/codeigniter/framework/system/libraries/Cache/drivers/Cache_redis.php

Line Number: 126
```

There is a possiblity of RedisException of `$this->_redis->auth()`.
Phpredis does not support ssl port, so the above exception occurs when I try to connect to the SSL port.
