### PR TITLE
Update Input.php

### DIFF
--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -724,7 +724,7 @@ class CI_Input {
 	 */
 	protected function _clean_input_keys($str, $fatal = TRUE)
 	{
-		if ( ! preg_match('/^[a-z0-9:_\/|-]+$/i', $str))
+		if ( ! preg_match('/^~%[a-z0-9:_\/|-]+$/i', $str))
 		{
 			if ($fatal === TRUE)
 			{

--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -724,7 +724,7 @@ class CI_Input {
 	 */
 	protected function _clean_input_keys($str, $fatal = TRUE)
 	{
-		if ( ! preg_match('/^~%[a-z0-9:_\/|-]+$/i', $str))
+		if ( ! preg_match('/^[~%a-z0-9:_\/|-]+$/i', $str))
 		{
 			if ($fatal === TRUE)
 			{


### PR DESCRIPTION
We encountered a problem with tracking cookies which included the % character in the name. These cookies were not generated by our site but by a third party tracking company. After doing some searching I find that this is not the first time someone ran into this issue.

It is unreasonable to break the entire site with error output simply because a % character shows up in a cookie name. Especially for enterprise sites that have numerous tracking cookies set by third party applications.  

What would be reasonable is to do just about anything else besides hard fail.  This _clean_input_keys function should be more forgiving.

I've added % and ~ to the allowed chars regex. However a better solution would be not to hard fail ever. Rather just ignore that cookie in the application.

For reference:

https://en.wikipedia.org/wiki/HTTP_cookie#Cookie_attributes
The value of a cookie may consist of any printable ASCII character (! through ~, unicode \u0021through \u007E) excluding , and ; and excluding whitespace. The name of a cookie excludes the same characters, as well as =, since that is the delimiter between the name and value. The cookie standard RFC 2965 is more limiting but not implemented by browsers.

To recreate this problem do this:
* Go to a site running CI such as ExpressionEngine etc...
* Open your console
* Enter `document.cookie="asdf%asf=Goodbye world";`
* Refresh page
* Sigh