### PR TITLE
Fix for HTTP_RAW_POST_DATA on newer PHP; it is often not populated.

### DIFF
--- a/system/libraries/Xmlrpcs.php
+++ b/system/libraries/Xmlrpcs.php
@@ -174,15 +174,20 @@ class CI_Xmlrpcs extends CI_Xmlrpc
 	 */
 	function parseRequest($data='')
 	{
-		global $HTTP_RAW_POST_DATA;
-
 		//-------------------------------------
 		//  Get Data
 		//-------------------------------------
 
 		if ($data == '')
 		{
-			$data = $HTTP_RAW_POST_DATA;
+			if (isset($GLOBALS['HTTP_RAW_POST_DATA']))
+			{
+				$data = $GLOBALS['HTTP_RAW_POST_DATA'];
+			}
+			else
+			{
+				$data = file_get_contents('php://input');
+			}
 		}
 
 		//-------------------------------------


### PR DESCRIPTION
PHP 5.6 complains about deprecation if `$HTTP_RAW_POST_DATA` is used. Fix to use `php://input` if `$HTTP_RAW_POST_DATA` is unset. If `$HTTP_RAW_POST_DATA` is set, the old behavior is used, so this should have no impact if it's set. If unset, the current code would be broken as `$HTTP_RAW_POST_DATA`  is not defined, and now it will work. Thanks!