### PR TITLE
Image_lib, the default value of the option 'wm_shadow_distance' is 2 actually.

### DIFF
--- a/user_guide_src/source/libraries/image_lib.rst
+++ b/user_guide_src/source/libraries/image_lib.rst
@@ -282,7 +282,7 @@ Preference              Default Value       Options             Description
 **wm_shadow_color**     None                None                The color of the drop shadow, specified in hex. If you leave this blank
                                                                 a drop shadow will not be used. Both the full 6-length (ie, 993300) and
                                                                 the short three character abbreviated version (ie, fff) are supported.
-**wm_shadow_distance**  3                   None                The distance (in pixels) from the font that the drop shadow should
+**wm_shadow_distance**  2                   None                The distance (in pixels) from the font that the drop shadow should
                                                                 appear.
 ======================= =================== =================== ==========================================================================
 


### PR DESCRIPTION
The mentioned default value has been corrected within the documentation accordingly.

https://github.com/bcit-ci/CodeIgniter/blob/develop/system/libraries/Image_lib.php#L264