### PR TITLE
3.0 stable

### DIFF
--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -803,7 +803,7 @@ class CI_Input {
 
 		if ( ! isset($headers))
 		{
-			empty($this->headers) OR $this->request_headers();
+			empty($this->headers) && $this->request_headers();
 			foreach ($this->headers as $key => $value)
 			{
 				$headers[strtolower($key)] = $value;

--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -290,7 +290,7 @@ class CI_Loader {
 			load_class('Model', 'core');
 		}
 
-		$model = ucfirst(strtolower($model));
+		$model = ucfirst($model);
 		if ( ! class_exists($model))
 		{
 			foreach ($this->_ci_model_paths as $mod_path)

--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -1760,7 +1760,7 @@ abstract class CI_DB_driver {
 		}
 
 		// Convert tabs or multiple spaces into single spaces
-		$item = preg_replace('/\s+/', ' ', $item);
+		$item = preg_replace('/\s+/', ' ', trim($item));
 
 		// If the item has an alias declaration we remove it and set it aside.
 		// Note: strripos() is used in order to support spaces in table names

--- a/system/database/drivers/sqlsrv/sqlsrv_driver.php
+++ b/system/database/drivers/sqlsrv/sqlsrv_driver.php
@@ -141,13 +141,14 @@ class CI_DB_sqlsrv_driver extends CI_DB {
 			unset($connection['UID'], $connection['PWD']);
 		}
 
-		$this->conn_id = sqlsrv_connect($this->hostname, $connection);
-
-		// Determine how identifiers are escaped
-		$query = $this->query('SELECT CASE WHEN (@@OPTIONS | 256) = @@OPTIONS THEN 1 ELSE 0 END AS qi');
-		$query = $query->row_array();
-		$this->_quoted_identifier = empty($query) ? FALSE : (bool) $query['qi'];
-		$this->_escape_char = ($this->_quoted_identifier) ? '"' : array('[', ']');
+		if (FALSE !== ($this->conn_id = sqlsrv_connect($this->hostname, $connection)))
+		{
+			// Determine how identifiers are escaped
+			$query = $this->query('SELECT CASE WHEN (@@OPTIONS | 256) = @@OPTIONS THEN 1 ELSE 0 END AS qi');
+			$query = $query->row_array();
+			$this->_quoted_identifier = empty($query) ? FALSE : (bool) $query['qi'];
+			$this->_escape_char = ($this->_quoted_identifier) ? '"' : array('[', ']');
+		}
 
 		return $this->conn_id;
 	}

--- a/system/libraries/Cache/drivers/Cache_memcached.php
+++ b/system/libraries/Cache/drivers/Cache_memcached.php
@@ -106,7 +106,7 @@ class CI_Cache_memcached extends CI_Driver {
 		}
 		else
 		{
-			throw new RuntimeException('Cache: Failed to create Memcache(d) object; extension not loaded?');
+			log_message('error', 'Cache: Failed to create Memcache(d) object; extension not loaded?');
 		}
 
 		foreach ($this->_memcache_conf as $cache_server)
@@ -284,12 +284,6 @@ class CI_Cache_memcached extends CI_Driver {
 	 */
 	public function is_supported()
 	{
-		if ( ! extension_loaded('memcached') && ! extension_loaded('memcache'))
-		{
-			log_message('debug', 'The Memcached Extension must be loaded to use Memcached Cache.');
-			return FALSE;
-		}
-
-		return TRUE;
+		return (extension_loaded('memcached') OR extension_loaded('memcache'));
 	}
 }

--- a/system/libraries/Cache/drivers/Cache_redis.php
+++ b/system/libraries/Cache/drivers/Cache_redis.php
@@ -115,17 +115,17 @@ class CI_Cache_redis extends CI_Driver
 
 			if ( ! $success)
 			{
-				throw new RuntimeException('Cache: Redis connection failed. Check your configuration.');
+				log_message('error', 'Cache: Redis connection failed. Check your configuration.');
 			}
 		}
 		catch (RedisException $e)
 		{
-			throw new RuntimeException('Cache: Redis connection refused ('.$e->getMessage().')');
+			log_message('error', 'Cache: Redis connection refused ('.$e->getMessage().')');
 		}
 
 		if (isset($config['password']) && ! $this->_redis->auth($config['password']))
 		{
-			throw new RuntimeException('Cache: Redis authentication failed.');
+			log_message('error', 'Cache: Redis authentication failed.');
 		}
 
 		// Initialize the index of serialized values.
@@ -298,13 +298,7 @@ class CI_Cache_redis extends CI_Driver
 	 */
 	public function is_supported()
 	{
-		if ( ! extension_loaded('redis'))
-		{
-			log_message('debug', 'The Redis extension must be loaded to use Redis cache.');
-			return FALSE;
-		}
-
-		return TRUE;
+		return extension_loaded('redis');
 	}
 
 	// ------------------------------------------------------------------------

--- a/system/libraries/Email.php
+++ b/system/libraries/Email.php
@@ -1869,20 +1869,26 @@ class CI_Email {
 			return FALSE;
 		}
 
-		$this->_send_command('from', $this->clean_email($this->_headers['From']));
+		if ( ! $this->_send_command('from', $this->clean_email($this->_headers['From'])))
+		{
+			return FALSE;
+		}
 
 		foreach ($this->_recipients as $val)
 		{
-			$this->_send_command('to', $val);
+			if ( ! $this->_send_command('to', $val))
+			{
+				return FALSE;
+			}
 		}
 
 		if (count($this->_cc_array) > 0)
 		{
 			foreach ($this->_cc_array as $val)
 			{
-				if ($val !== '')
+				if ($val !== '' && ! $this->_send_command('to', $val))
 				{
-					$this->_send_command('to', $val);
+					return FALSE;
 				}
 			}
 		}
@@ -1891,14 +1897,17 @@ class CI_Email {
 		{
 			foreach ($this->_bcc_array as $val)
 			{
-				if ($val !== '')
+				if ($val !== '' && ! $this->_send_command('to', $val))
 				{
-					$this->_send_command('to', $val);
+					return FALSE;
 				}
 			}
 		}
 
-		$this->_send_command('data');
+		if ( ! $this->_send_command('data'))
+		{
+			return FALSE;
+		}
 
 		// perform dot transformation on any lines that begin with a dot
 		$this->_send_data($this->_header_str.preg_replace('/^\./m', '..$1', $this->_finalbody));

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -16,6 +16,7 @@ Bug fixes for 3.0.2
 
 -  Fixed a bug (#2284) - :doc:`Database <database/index>` method ``protect_identifiers()`` breaks when :doc:`Query Builder <database/query_builder>` isn't enabled.
 -  Fixed a bug (#4052) - :doc:`Routing <general/routing>` with anonymous functions didn't work for routes that don't use regular expressions.
+-  Fixed a bug (#4056) - :doc:`Input Library <libraries/input>` method ``get_request_header()`` could not return a value unless ``request_headers()`` was called beforehand.
 
 Version 3.0.1
 =============

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -19,6 +19,7 @@ Bug fixes for 3.0.2
 -  Fixed a bug (#4052) - :doc:`Routing <general/routing>` with anonymous functions didn't work for routes that don't use regular expressions.
 -  Fixed a bug (#4056) - :doc:`Input Library <libraries/input>` method ``get_request_header()`` could not return a value unless ``request_headers()`` was called beforehand.
 -  Fixed a bug where the :doc:`Database Class <database/index>` entered an endless loop if it fails to connect with the 'sqlsrv' driver.
+-  Fixed a bug (#4065) - :doc:`Database <database/index>` method ``protect_identifiers()`` treats a traling space as an alias separator if the input doesn't contain ' AS '.
 
 Version 3.0.1
 =============

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -18,6 +18,7 @@ Bug fixes for 3.0.2
 -  Fixed a bug (#2284) - :doc:`Database <database/index>` method ``protect_identifiers()`` breaks when :doc:`Query Builder <database/query_builder>` isn't enabled.
 -  Fixed a bug (#4052) - :doc:`Routing <general/routing>` with anonymous functions didn't work for routes that don't use regular expressions.
 -  Fixed a bug (#4056) - :doc:`Input Library <libraries/input>` method ``get_request_header()`` could not return a value unless ``request_headers()`` was called beforehand.
+-  Fixed a bug where the :doc:`Database Class <database/index>` entered an endless loop if it fails to connect with the 'sqlsrv' driver.
 
 Version 3.0.1
 =============

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -10,6 +10,7 @@ Release Date: Not Released
 -  General Changes
 
    -  Updated the *application/config/constants.php* file to check if constants aren't already defined before doing that.
+   -  Changed :doc:`Loader Library <libraries/loader>` method ``model()`` to only apply ``ucfirst()`` and not ``strtolower()`` to the requested class name.
 
 Bug fixes for 3.0.2
 -------------------

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -21,6 +21,7 @@ Bug fixes for 3.0.2
 -  Fixed a bug where the :doc:`Database Class <database/index>` entered an endless loop if it fails to connect with the 'sqlsrv' driver.
 -  Fixed a bug (#4065) - :doc:`Database <database/index>` method ``protect_identifiers()`` treats a traling space as an alias separator if the input doesn't contain ' AS '.
 -  Fixed a bug (#4066) - :doc:`Cache Library <libraries/caching>` couldn't fallback to a backup driver if the primary one is Memcache(d) or Redis.
+-  Fixed a bug (#4073) - :doc:`Email Library <libraries/email>` method ``send()`` could return TRUE in case of an actual failure when an SMTP command fails.
 
 Version 3.0.1
 =============

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -20,6 +20,7 @@ Bug fixes for 3.0.2
 -  Fixed a bug (#4056) - :doc:`Input Library <libraries/input>` method ``get_request_header()`` could not return a value unless ``request_headers()`` was called beforehand.
 -  Fixed a bug where the :doc:`Database Class <database/index>` entered an endless loop if it fails to connect with the 'sqlsrv' driver.
 -  Fixed a bug (#4065) - :doc:`Database <database/index>` method ``protect_identifiers()`` treats a traling space as an alias separator if the input doesn't contain ' AS '.
+-  Fixed a bug (#4066) - :doc:`Cache Library <libraries/caching>` couldn't fallback to a backup driver if the primary one is Memcache(d) or Redis.
 
 Version 3.0.1
 =============

--- a/user_guide_src/source/libraries/encryption.rst
+++ b/user_guide_src/source/libraries/encryption.rst
@@ -75,7 +75,7 @@ process that allows you to be the only one who is able to decrypt data
 that you've decided to hide from the eyes of the public.
 After one key is used to encrypt data, that same key provides the **only**
 means to decrypt it, so not only must you chose one carefully, but you
-must not lose it or you will also use the encrypted data.
+must not lose it or you will also lose access the data.
 
 It must be noted that to ensure maximum security, such key *should* not
 only be as strong as possible, but also often changed. Such behavior

--- a/user_guide_src/source/libraries/encryption.rst
+++ b/user_guide_src/source/libraries/encryption.rst
@@ -75,7 +75,7 @@ process that allows you to be the only one who is able to decrypt data
 that you've decided to hide from the eyes of the public.
 After one key is used to encrypt data, that same key provides the **only**
 means to decrypt it, so not only must you chose one carefully, but you
-must not lose it or you will also lose access the data.
+must not lose it or you will also lose access to the data.
 
 It must be noted that to ensure maximum security, such key *should* not
 only be as strong as possible, but also often changed. Such behavior


### PR DESCRIPTION
This days i migrated to CI and i found a really ugly bug in router.
I tried to setup $routing['directory'] based on subdomains in index.php like this:

if (($_SERVER['HTTP_HOST']=="www.test.com")  || (($_SERVER['HTTP_HOST']=="test.com")) ){
	$routing['directory'] = 'frontend';
}elseif ( $_SERVER['HTTP_HOST']=="backend.test.com" ){
	$routing['directory'] = 'backend';
}

And here started ugly problems, because in system/core/Router.php the directory is not set first and 
$this->_set_routing(); (in Router.php construct) call _set_default_controller() without calling set_directory() first.
So basically, we cannot setup defalt routes while working with subdomains (with folders works).

The hack i did is in MY_Router.php:
<?php
if (!defined("BASEPATH")) exit("No direct script access allowed");
class MY_Router extends CI_Router {
    function __construct($routing) {
		if (is_array($routing) && isset($routing['directory'])) {
				$this->set_directory($routing['directory']);
		}
		parent::__construct();
    }
}
And default routes worked like a charm.