### PR TITLE
Change if is not set or count equals zero into if empty

### DIFF
--- a/system/database/DB.php
+++ b/system/database/DB.php
@@ -82,7 +82,7 @@ function &DB($params = '', $query_builder_override = NULL)
 			}
 		}
 
-		if ( ! isset($db) OR count($db) === 0)
+		if (empty($db))
 		{
 			show_error('No database connection settings were found in the database config file.');
 		}


### PR DESCRIPTION
We can simplify this if statement since empty() is checking if variable is set and if it's empty in the same time.