### PR TITLE
Fix #3890 secondary bug with 'OR'

### DIFF
--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -803,7 +803,7 @@ class CI_Input {
 
 		if ( ! isset($headers))
 		{
-			empty($this->headers) OR $this->request_headers();
+			empty($this->headers) AND $this->request_headers();
 			foreach ($this->headers as $key => $value)
 			{
 				$headers[strtolower($key)] = $value;


### PR DESCRIPTION
Change `OR` with `AND`, because if `$this->headers` is empty the second statement is not executed.

**EXAMPLE**:
```php
public function test()
{
    $test = [];
    empty($test) AND $test = ['test'];
    print_r($test);
}

// Prints: Array ( [0] => test )

```

```php
public function test()
{
    $test = [];
    empty($test) OR $test = ['test'];
    print_r($test);
}

// Prints: Array ( )

```