### PR TITLE
Form validation library to allow the pipe character within brackets

### DIFF
--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -211,7 +211,7 @@ class CI_Form_validation {
 				return $this;
 			}
 
-			$rules = explode('|', $rules);
+			$rules = preg_split('/\|(?![^\[]*\])/', $rules);
 		}
 
 		// If the field label wasn't passed we use the field name


### PR DESCRIPTION
I ran into a problem where I wanted to use regex_match in the form validation library, but when I put a pipe character in my expression, things broke because set_rules() does a blind explode on pipe. I changed it so it will split the string on any pipe character not contained in square brackets.

Example:
```
$this->form_validation->set_rules('fru-rt-loan-type', 'Loan Type', 'required|regex_match[(refinance|purchase)]|alpha')
```

Causes:
```
Unable to access an error message corresponding to your field name Loan Type.(regex_match[(refinance)
```
