### PR TITLE
Cookie lifetime in Session bugfix

### DIFF
--- a/system/libraries/Session/Session.php
+++ b/system/libraries/Session/Session.php
@@ -267,7 +267,7 @@ class CI_Session {
 		}
 		else
 		{
-			$params['cookie_lifetime'] = ( ! isset($expiration) && config_item('sess_expire_on_close'))
+			$params['cookie_lifetime'] = ( empty($expiration) && config_item('sess_expire_on_close'))
 				? 0 : (int) $expiration;
 		}
 


### PR DESCRIPTION
Since the $expiration variable is set on line 262, there will never be a time when the ternary operator evaluation lets the cookie lifetime be set to 0, unless the config item sess_expiration was specifically set to 0.