### PR TITLE
Pass query argument with '=' to QUERY_STRING

### DIFF
--- a/system/core/URI.php
+++ b/system/core/URI.php
@@ -284,6 +284,22 @@ class CI_URI {
 	protected function _parse_argv()
 	{
 		$args = array_slice($_SERVER['argv'], 1);
+		$get = array();
+
+		foreach ($args as $key => $value) {
+			if (strpos($value, '=') !== false) {
+				$value = ltrim($value, '-');
+				list($req, $val) = explode('=', $value);
+				$get[$req] = $val;
+				unset($args[$key]);
+			}
+		}
+
+		if ($get) {
+			$_SERVER['QUERY_STRING'] = http_build_query($get);
+			parse_str($_SERVER['QUERY_STRING'], $_GET);
+		}
+
 		return $args ? implode('/', $args) : '';
 	}
 

--- a/tests/codeigniter/core/URI_test.php
+++ b/tests/codeigniter/core/URI_test.php
@@ -251,4 +251,27 @@ class URI_test extends CI_TestCase {
 		$this->assertEquals('segment/', $this->uri->slash_rsegment(1, 'trailing'));
 	}
 
+	// --------------------------------------------------------------------
+
+	public function test_cli_query_string()
+	{
+		$mock = new ReflectionMethod('CI_URI', '_parse_argv');
+		$mock->setAccessible(true);
+
+		$this->ci_set_config('charset', 'UTF-8');
+		$security = new Mock_Core_Security();
+		$utf8 = new Mock_Core_Utf8();
+		$input = new Mock_Core_Input($security, $utf8);
+
+		$_SERVER['argv'] = array('index.php', 'one', 'two', '-key=value');
+		$this->assertEquals('one/two', $mock->invoke($this->uri));
+		$this->assertEquals('value', $_GET['key']);
+		$this->assertEquals('value', $input->get('key'));
+
+		$_SERVER['argv'] = array('index.php', 'one', 'two', '-key=value', '--foo=bar');
+		$this->assertEquals('one/two', $mock->invoke($this->uri));
+		$this->assertEquals('bar', $_GET['foo']);
+		$this->assertEquals('bar', $input->get('foo'));
+	}
+
 }


### PR DESCRIPTION
Hi,

I make all CLI argument contains `=` character to `$_SERVER['QUERY_STRING']` so you can get the value using `$_GET['key']` or `$this->input->get('key')`.

Anyway, I know it's not realy nessesary but would be great if we have this feature (I guess).

Best. :grin: 