### PR TITLE
Add public function for unloading a model.

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -821,6 +821,19 @@ class CI_Loader {
 		return $this;
 	}
 
+	/**
+	 * Unset Model by Name
+	 *
+	 * Once a Model is not needed it is unloaded from ci_models
+	 *
+	 * @param	string The model alias for removing it from the _ci_models array
+	 * @return	void
+	 */
+	public function unload_model($model_name)
+	{
+		unset($this->_ci_models[array_search($model_name,$this->_ci_models)]);
+	}
+	
 	// --------------------------------------------------------------------
 
 	/**


### PR DESCRIPTION
Because ```_ci_models``` is a protected property a public function was added for manipulating it, in this case, the function takes a parameter to search a model in the ```_ci_models``` array and then apply an ```unset``` in it.

It was added because sometimes we need to work with multiple models inside a ```foreach``` loop, i.e:
``` php
foreach($models as $m):
{
    $this->load->model($m['path'], 'mymodel');
    $tmp = $this->mymodel->getSomeInfo();
    processData($tmp);
}
```
But the function ```getSomeInfo``` was always obtaining the same info from the first model loaded. Then with this function the correct behavior can be achieved.

``` php
foreach($models as $m):
{
    $this->load->model($m['path'], 'mymodel');
    $tmp = $this->mymodel->getSomeInfo();
    processData($tmp);
    unset($this->mymodel);
    $this->load->unload_model('mymodel'); // -- added
}
```