### PR TITLE
Improve the language support in migration library

### DIFF
--- a/system/language/english/migration_lang.php
+++ b/system/language/english/migration_lang.php
@@ -37,7 +37,6 @@
  */
 defined('BASEPATH') OR exit('No direct script access allowed');
 
-$lang['migration_initilization'] = 'Migrations Class Initialized';
 $lang['migration_none_found'] = 'No migrations were found.';
 $lang['migration_not_found'] = 'No migration could be found with the version number: %s.';
 $lang['migration_disabled'] = 'Migrations has been loaded but is disabled or set up incorrectly.';

--- a/system/language/english/migration_lang.php
+++ b/system/language/english/migration_lang.php
@@ -37,11 +37,15 @@
  */
 defined('BASEPATH') OR exit('No direct script access allowed');
 
+$lang['migration_initilization'] = 'Migrations Class Initialized';
 $lang['migration_none_found'] = 'No migrations were found.';
 $lang['migration_not_found'] = 'No migration could be found with the version number: %s.';
+$lang['migration_disabled'] = 'Migrations has been loaded but is disabled or set up incorrectly.';
 $lang['migration_sequence_gap'] = 'There is a gap in the migration sequence near version number: %s.';
 $lang['migration_multiple_version'] = 'There are multiple migrations with the same version number: %s.';
 $lang['migration_class_doesnt_exist'] = 'The migration class "%s" could not be found.';
 $lang['migration_missing_up_method'] = 'The migration class "%s" is missing an "up" method.';
 $lang['migration_missing_down_method'] = 'The migration class "%s" is missing a "down" method.';
 $lang['migration_invalid_filename'] = 'Migration "%s" has an invalid filename.';
+$lang['migration_table_name_setting'] = 'Migrations configuration file (migration.php) must have "migration_table" set.';
+$lang['migration_invalid_numbering_type'] = 'An invalid migration numbering type was specified: %s.';

--- a/system/libraries/Migration.php
+++ b/system/libraries/Migration.php
@@ -126,12 +126,15 @@ class CI_Migration {
 			$this->{'_'.$key} = $val;
 		}
 
-		log_message('info', 'Migrations Class Initialized');
+		// Load migration language
+		$this->lang->load('migration');
+
+		log_message('info', $this->lang->line('migration_initilization'));
 
 		// Are they trying to use migrations while it is disabled?
 		if ($this->_migration_enabled !== TRUE)
 		{
-			show_error('Migrations has been loaded but is disabled or set up incorrectly.');
+			show_error($this->lang->line('migration_disabled'));
 		}
 
 		// If not set, set it
@@ -140,16 +143,13 @@ class CI_Migration {
 		// Add trailing slash if not set
 		$this->_migration_path = rtrim($this->_migration_path, '/').'/';
 
-		// Load migration language
-		$this->lang->load('migration');
-
 		// They'll probably be using dbforge
 		$this->load->dbforge();
 
 		// Make sure the migration table name was set.
 		if (empty($this->_migration_table))
 		{
-			show_error('Migrations configuration file (migration.php) must have "migration_table" set.');
+			show_error($this->lang->line('migration_table_name_setting'));
 		}
 
 		// Migration basename regex
@@ -160,7 +160,7 @@ class CI_Migration {
 		// Make sure a valid migration numbering type was set.
 		if ( ! in_array($this->_migration_type, array('sequential', 'timestamp')))
 		{
-			show_error('An invalid migration numbering type was specified: '.$this->_migration_type);
+			show_error(sprintf($this->lang->line('migration_invalid_numbering_type'), $this->_migration_type));
 		}
 
 		// If the migrations table is missing, make it

--- a/system/libraries/Migration.php
+++ b/system/libraries/Migration.php
@@ -129,7 +129,7 @@ class CI_Migration {
 		// Load migration language
 		$this->lang->load('migration');
 
-		log_message('info', $this->lang->line('migration_initilization'));
+		log_message('info', 'Migrations Class Initialized');
 
 		// Are they trying to use migrations while it is disabled?
 		if ($this->_migration_enabled !== TRUE)


### PR DESCRIPTION
In the current migration library, the language feature is not fully utilised. Three of the error messages still use strings. I suggest to add these entries into `migration_lang.php` so that we can provide more support to multiple languages. Meanwhile, languages should be loaded before any error messages showing up.