### PR TITLE
Persist config file settings when resetting form_validation

### DIFF
--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -1584,14 +1584,16 @@ class CI_Form_validation {
 	 * @param	bool
 	 * @return	CI_Form_validation
 	 */
-	public function reset_validation($keep_config=false)
+	public function reset_validation($keep_config = FALSE)
 	{
 		$this->_field_data = array();
-		if( ! $keep_config)
-			$this->_config_rules = array();
 		$this->_error_array = array();
 		$this->_error_messages = array();
 		$this->error_string = '';
+		if ( ! $keep_config)
+		{
+			$this->_config_rules = array();
+		}
 		return $this;
 	}
 

--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -1581,19 +1581,14 @@ class CI_Form_validation {
 	 * Prevents subsequent validation routines from being affected by the
 	 * results of any previous validation routine due to the CI singleton.
 	 *
-	 * @param	bool
 	 * @return	CI_Form_validation
 	 */
-	public function reset_validation($keep_config = FALSE)
+	public function reset_validation()
 	{
 		$this->_field_data = array();
 		$this->_error_array = array();
 		$this->_error_messages = array();
 		$this->error_string = '';
-		if ( ! $keep_config)
-		{
-			$this->_config_rules = array();
-		}
 		return $this;
 	}
 

--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -68,7 +68,6 @@ class CI_Form_validation {
 	 * @var array
 	 */
 	protected $_config_rules	= array();
-	private $_default_config_rules = array();
 
 	/**
 	 * Array of validation errors
@@ -142,7 +141,7 @@ class CI_Form_validation {
 		}
 
 		// Validation rules can be stored in a config file.
-		$this->_default_config_rules = $this->_config_rules = $rules;
+		$this->_config_rules = $rules;
 
 		// Automatically load the form helper
 		$this->CI->load->helper('form');
@@ -1582,12 +1581,14 @@ class CI_Form_validation {
 	 * Prevents subsequent validation routines from being affected by the
 	 * results of any previous validation routine due to the CI singleton.
 	 *
+	 * @param	bool
 	 * @return	CI_Form_validation
 	 */
-	public function reset_validation()
+	public function reset_validation($keep_config=false)
 	{
 		$this->_field_data = array();
-		$this->_config_rules = $this->_default_config_rules;
+		if( ! $keep_config)
+			$this->_config_rules = array();
 		$this->_error_array = array();
 		$this->_error_messages = array();
 		$this->error_string = '';

--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -68,6 +68,7 @@ class CI_Form_validation {
 	 * @var array
 	 */
 	protected $_config_rules	= array();
+	private $_default_config_rules = array();
 
 	/**
 	 * Array of validation errors
@@ -141,7 +142,7 @@ class CI_Form_validation {
 		}
 
 		// Validation rules can be stored in a config file.
-		$this->_config_rules = $rules;
+		$this->_default_config_rules = $this->_config_rules = $rules;
 
 		// Automatically load the form helper
 		$this->CI->load->helper('form');
@@ -1586,7 +1587,7 @@ class CI_Form_validation {
 	public function reset_validation()
 	{
 		$this->_field_data = array();
-		$this->_config_rules = array();
+		$this->_config_rules = $this->_default_config_rules;
 		$this->_error_array = array();
 		$this->_error_messages = array();
 		$this->error_string = '';

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -16,13 +16,13 @@ Release Date: Not Released
 -  General Changes
 
    -  Updated the *application/config/constants.php* file to check if constants aren't already defined before doing that.
+   -  Added optional parameter to ``reset_validation()`` in :doc:`form validation<libraries/form_validation>` that stops ``_config_rules`` from being cleared.
 
 Bug fixes for 3.0.2
 -------------------
 
 -  Fixed a bug (#2284) - :doc:`Database <database/index>` method ``protect_identifiers()`` breaks when :doc:`Query Builder <database/query_builder>` isn't enabled.
 -  Fixed a bug (#4052) - :doc:`Routing <general/routing>` with anonymous functions didn't work for routes that don't use regular expressions.
--  Fixed a bug (#4126) - Added optional parameter to ``reset_validation()`` in ``Form_validation`` that stops ``_config_rules`` from being cleared.
 
 Version 3.0.1
 =============

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -16,13 +16,13 @@ Release Date: Not Released
 -  General Changes
 
    -  Updated the *application/config/constants.php* file to check if constants aren't already defined before doing that.
-   -  Added optional parameter to ``reset_validation()`` in :doc:`form validation<libraries/form_validation>` that stops ``_config_rules`` from being cleared.
 
 Bug fixes for 3.0.2
 -------------------
 
 -  Fixed a bug (#2284) - :doc:`Database <database/index>` method ``protect_identifiers()`` breaks when :doc:`Query Builder <database/query_builder>` isn't enabled.
 -  Fixed a bug (#4052) - :doc:`Routing <general/routing>` with anonymous functions didn't work for routes that don't use regular expressions.
+-  Fixed a bug (#4126) - :doc:`Form Validation Library <libraries/form_validation>` was needlessly clearing ``$_config_rules`` when calling ``reset_validation()`` method.
 
 Version 3.0.1
 =============

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -22,7 +22,6 @@ Bug fixes for 3.0.2
 
 -  Fixed a bug (#2284) - :doc:`Database <database/index>` method ``protect_identifiers()`` breaks when :doc:`Query Builder <database/query_builder>` isn't enabled.
 -  Fixed a bug (#4052) - :doc:`Routing <general/routing>` with anonymous functions didn't work for routes that don't use regular expressions.
--  Fixed a bug (#4126) - :doc:`Form Validation Library <libraries/form_validation>` was needlessly clearing ``$_config_rules`` when calling ``reset_validation()`` method.
 
 Version 3.0.1
 =============

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -22,6 +22,7 @@ Bug fixes for 3.0.2
 
 -  Fixed a bug (#2284) - :doc:`Database <database/index>` method ``protect_identifiers()`` breaks when :doc:`Query Builder <database/query_builder>` isn't enabled.
 -  Fixed a bug (#4052) - :doc:`Routing <general/routing>` with anonymous functions didn't work for routes that don't use regular expressions.
+-  Fixed a bug (#4126) - Added optional parameter to ``reset_validation()`` in ``Form_validation`` that stops ``_config_rules`` from being cleared.
 
 Version 3.0.1
 =============

--- a/user_guide_src/source/libraries/form_validation.rst
+++ b/user_guide_src/source/libraries/form_validation.rst
@@ -714,8 +714,6 @@ file. You can organize these rules into "groups". These groups can
 either be loaded automatically when a matching controller/method is
 called, or you can manually call each set as needed.
 
-.. important:: Make sure that when using the ``reset_validation()`` method you pass ``true`` as a parameter.  If you do not then all the validation rules loaded from the config file will be cleared as well!
-
 How to save your rules
 ======================
 
@@ -1078,9 +1076,9 @@ Class Reference
 		Permits you to set an array for validation, instead of using the default
 		``$_POST`` array.
 
-	.. php:method:: reset_validation($keep_config=false)
+	.. php:method:: reset_validation($keep_config = FALSE)
 
-		:param	bool	$keep_config: Will leave configured validation rules alone when true or clear them when false.  This parameter must be true if your rules are being loaded from a config file
+		:param	bool	$keep_config: Whether to reset validation rules from config files
 		:returns:	CI_Form_validation instance (method chaining)
 		:rtype:	CI_Form_validation
 

--- a/user_guide_src/source/libraries/form_validation.rst
+++ b/user_guide_src/source/libraries/form_validation.rst
@@ -1076,9 +1076,8 @@ Class Reference
 		Permits you to set an array for validation, instead of using the default
 		``$_POST`` array.
 
-	.. php:method:: reset_validation($keep_config = FALSE)
+	.. php:method:: reset_validation()
 
-		:param	bool	$keep_config: Whether to reset validation rules from config files
 		:returns:	CI_Form_validation instance (method chaining)
 		:rtype:	CI_Form_validation
 

--- a/user_guide_src/source/libraries/form_validation.rst
+++ b/user_guide_src/source/libraries/form_validation.rst
@@ -714,6 +714,8 @@ file. You can organize these rules into "groups". These groups can
 either be loaded automatically when a matching controller/method is
 called, or you can manually call each set as needed.
 
+.. important:: Make sure that when using the ``reset_validation()`` method you pass ``true`` as a parameter.  If you do not then all the validation rules loaded from the config file will be cleared as well!
+
 How to save your rules
 ======================
 
@@ -1076,8 +1078,9 @@ Class Reference
 		Permits you to set an array for validation, instead of using the default
 		``$_POST`` array.
 
-	.. php:method:: reset_validation()
+	.. php:method:: reset_validation($keep_config=false)
 
+		:param	bool	$keep_config: Will leave configured validation rules alone when true or clear them when false.  This parameter must be true if your rules are being loaded from a config file
 		:returns:	CI_Form_validation instance (method chaining)
 		:rtype:	CI_Form_validation
 


### PR DESCRIPTION
When checking multiple arrays using form_validation you have to call reset_validation between each separate check due to the instance of the library being a singleton.  The issue comes in when the settings are loaded from a config file as they are initially loaded from a parameter in the constructor, but are set to an empty array when resetting the class.  To get around this issue a copy of the config parameter is made and then the copy is used to reset the rules when clearing.