### PR TITLE
Automate documentation building in Travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,14 +20,19 @@ env:
 
 sudo: false
 
+install:
+  - apt-get install python-sphinx=1.2.3
+  - apt-get install python-sphinxcontrib.phpdomain  
+
 before_script:
   - sh -c "if [ '$TRAVIS_PHP_VERSION' = '5.2' ]; then pear channel-discover pear.bovigo.org && pear install bovigo/vfsStream-beta; else composer install --dev --no-progress; fi"
   - sh -c "if [ '$DB' = 'pgsql' ] || [ '$DB' = 'pdo/pgsql' ]; then psql -c 'DROP DATABASE IF EXISTS ci_test;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'pgsql' ] || [ '$DB' = 'pdo/pgsql' ]; then psql -c 'create database ci_test;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'mysql' ] || [ '$DB' = 'mysqli' ] || [ '$DB' = 'pdo/mysql' ]; then mysql -e 'create database IF NOT EXISTS ci_test;'; fi"
 
-script: phpunit -d zend.enable_gc=0 -d date.timezone=UTC --coverage-text --configuration tests/travis/$DB.phpunit.xml
-# test travis, trivial change
+script: 
+  - phpunit -d zend.enable_gc=0 -d date.timezone=UTC --coverage-text --configuration tests/travis/$DB.phpunit.xml
+  - cd user_guide_src && make html
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,6 @@ env:
 
 sudo: true
 
-before_install:
-  - sudo apt-get install python-pip
-
 install:
   - sudo pip install sphinx==1.2.3
   - sudo pip install sphinxcontrib-phpdomain

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_script:
   - sh -c "if [ '$DB' = 'mysql' ] || [ '$DB' = 'mysqli' ] || [ '$DB' = 'pdo/mysql' ]; then mysql -e 'create database IF NOT EXISTS ci_test;'; fi"
 
 script: phpunit -d zend.enable_gc=0 -d date.timezone=UTC --coverage-text --configuration tests/travis/$DB.phpunit.xml
+# test travis, trivial change
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,3 +50,4 @@ branches:
   only:
     - develop
     - /^feature\/.+$/
+    - ci-doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,15 +20,13 @@ env:
 
 sudo: false
 
-install:
-  - apt-get install python-sphinx=1.2.3
-  - apt-get install python-sphinxcontrib.phpdomain  
-
 before_script:
   - sh -c "if [ '$TRAVIS_PHP_VERSION' = '5.2' ]; then pear channel-discover pear.bovigo.org && pear install bovigo/vfsStream-beta; else composer install --dev --no-progress; fi"
   - sh -c "if [ '$DB' = 'pgsql' ] || [ '$DB' = 'pdo/pgsql' ]; then psql -c 'DROP DATABASE IF EXISTS ci_test;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'pgsql' ] || [ '$DB' = 'pdo/pgsql' ]; then psql -c 'create database ci_test;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'mysql' ] || [ '$DB' = 'mysqli' ] || [ '$DB' = 'pdo/mysql' ]; then mysql -e 'create database IF NOT EXISTS ci_test;'; fi"
+  - sudo apt-get install python-sphinx=1.2.3
+  - sudo apt-get install python-sphinxcontrib.phpdomain  
 
 script: 
   - phpunit -d zend.enable_gc=0 -d date.timezone=UTC --coverage-text --configuration tests/travis/$DB.phpunit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
   - DB=pdo/pgsql
   - DB=pdo/sqlite
 
-sudo: false
+sudo: true
 
 before_script:
   - sh -c "if [ '$TRAVIS_PHP_VERSION' = '5.2' ]; then pear channel-discover pear.bovigo.org && pear install bovigo/vfsStream-beta; else composer install --dev --no-progress; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ before_install:
   - sudo apt-get install python-pip
 
 install:
-  - pip install sphinx==1.2.3
-  - pip install sphinxcontrib-phpdomain
+  - sudo pip install sphinx==1.2.3
+  - sudo pip install sphinxcontrib-phpdomain
 
 before_script:
   - sh -c "if [ '$TRAVIS_PHP_VERSION' = '5.2' ]; then pear channel-discover pear.bovigo.org && pear install bovigo/vfsStream-beta; else composer install --dev --no-progress; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,4 +55,3 @@ branches:
   only:
     - develop
     - /^feature\/.+$/
-    - ci-doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,12 @@ env:
 
 sudo: true
 
+before_install:
+  - sudo apt-get install python-pip
+
 install:
-  - sudo apt-get install python-sphinx
-  - sudo apt-get install python-sphinxcontrib.phpdomain  
+  - pip install sphinx==1.2.3
+  - pip install sphinxcontrib-phpdomain
 
 before_script:
   - sh -c "if [ '$TRAVIS_PHP_VERSION' = '5.2' ]; then pear channel-discover pear.bovigo.org && pear install bovigo/vfsStream-beta; else composer install --dev --no-progress; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,15 @@ env:
 
 sudo: true
 
+install:
+  - sudo apt-get install python-sphinx
+  - sudo apt-get install python-sphinxcontrib.phpdomain  
+
 before_script:
   - sh -c "if [ '$TRAVIS_PHP_VERSION' = '5.2' ]; then pear channel-discover pear.bovigo.org && pear install bovigo/vfsStream-beta; else composer install --dev --no-progress; fi"
   - sh -c "if [ '$DB' = 'pgsql' ] || [ '$DB' = 'pdo/pgsql' ]; then psql -c 'DROP DATABASE IF EXISTS ci_test;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'pgsql' ] || [ '$DB' = 'pdo/pgsql' ]; then psql -c 'create database ci_test;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'mysql' ] || [ '$DB' = 'mysqli' ] || [ '$DB' = 'pdo/mysql' ]; then mysql -e 'create database IF NOT EXISTS ci_test;'; fi"
-  - sudo apt-get install python-sphinx=1.2.3
-  - sudo apt-get install python-sphinxcontrib.phpdomain  
 
 script: 
   - phpunit -d zend.enable_gc=0 -d date.timezone=UTC --coverage-text --configuration tests/travis/$DB.phpunit.xml


### PR DESCRIPTION
Developers need to manually generate documents for now. It would be cool if we enable travis-ci to take care of this. My changes will allow travis-ci to autobuild documentation sources. Through this, we can verify whether the commits for documentations are valid. Furthermore, if it is viable, we should automate deployment of the generated documents as well.

Currently, I only tested the generation of html pages. Shall I include more?