### PR TITLE
Enhance/lang fallback

### DIFF
--- a/system/core/Lang.php
+++ b/system/core/Lang.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * CodeIgniter
  *
@@ -53,14 +54,21 @@ class CI_Lang {
 	 *
 	 * @var	array
 	 */
-	public $language =	array();
+	public $language = array();
 
 	/**
 	 * List of loaded language files
 	 *
 	 * @var	array
 	 */
-	public $is_loaded =	array();
+	public $is_loaded = array();
+
+	/**
+	 * Refactor: base language provided inside system/language
+	 * 
+	 * @var string
+	 */
+	public $base_language = 'english';
 
 	/**
 	 * Class constructor
@@ -101,15 +109,15 @@ class CI_Lang {
 
 		if ($add_suffix === TRUE)
 		{
-			$langfile = preg_replace('/_lang$/', '', $langfile).'_lang';
+			$langfile = preg_replace('/_lang$/', '', $langfile) . '_lang';
 		}
 
 		$langfile .= '.php';
 
 		if (empty($idiom) OR ! preg_match('/^[a-z_-]+$/i', $idiom))
 		{
-			$config =& get_config();
-			$idiom = empty($config['language']) ? 'english' : $config['language'];
+			$config = & get_config();
+			$idiom = empty($config['language']) ? $this->base_language : $config['language'];
 		}
 
 		if ($return === FALSE && isset($this->is_loaded[$langfile]) && $this->is_loaded[$langfile] === $idiom)
@@ -117,8 +125,16 @@ class CI_Lang {
 			return;
 		}
 
+		// load the default language first, if necessary
+		// only do this for the language files under system/
+		$basepath = SYSTEM_PATH . 'language/' . $this->base_language . '/' . $langfile;
+		if (($found = file_exists($basepath)) === TRUE)
+		{
+			include($basepath);
+		}
+
 		// Load the base file, so any others found can override it
-		$basepath = BASEPATH.'language/'.$idiom.'/'.$langfile;
+		$basepath = BASEPATH . 'language/' . $idiom . '/' . $langfile;
 		if (($found = file_exists($basepath)) === TRUE)
 		{
 			include($basepath);
@@ -127,18 +143,17 @@ class CI_Lang {
 		// Do we have an alternative path to look in?
 		if ($alt_path !== '')
 		{
-			$alt_path .= 'language/'.$idiom.'/'.$langfile;
+			$alt_path .= 'language/' . $idiom . '/' . $langfile;
 			if (file_exists($alt_path))
 			{
 				include($alt_path);
 				$found = TRUE;
 			}
-		}
-		else
+		} else
 		{
 			foreach (get_instance()->load->get_package_paths(TRUE) as $package_path)
 			{
-				$package_path .= 'language/'.$idiom.'/'.$langfile;
+				$package_path .= 'language/' . $idiom . '/' . $langfile;
 				if ($basepath !== $package_path && file_exists($package_path))
 				{
 					include($package_path);
@@ -150,12 +165,12 @@ class CI_Lang {
 
 		if ($found !== TRUE)
 		{
-			show_error('Unable to load the requested language file: language/'.$idiom.'/'.$langfile);
+			show_error('Unable to load the requested language file: language/' . $idiom . '/' . $langfile);
 		}
 
-		if ( ! isset($lang) OR ! is_array($lang))
+		if (!isset($lang) OR ! is_array($lang))
 		{
-			log_message('error', 'Language file contains no data: language/'.$idiom.'/'.$langfile);
+			log_message('error', 'Language file contains no data: language/' . $idiom . '/' . $langfile);
 
 			if ($return === TRUE)
 			{
@@ -172,7 +187,7 @@ class CI_Lang {
 		$this->is_loaded[$langfile] = $idiom;
 		$this->language = array_merge($this->language, $lang);
 
-		log_message('info', 'Language file loaded: language/'.$idiom.'/'.$langfile);
+		log_message('info', 'Language file loaded: language/' . $idiom . '/' . $langfile);
 		return TRUE;
 	}
 
@@ -194,7 +209,7 @@ class CI_Lang {
 		// Because killer robots like unicorns!
 		if ($value === FALSE && $log_errors === TRUE)
 		{
-			log_message('error', 'Could not find the language line "'.$line.'"');
+			log_message('error', 'Could not find the language line "' . $line . '"');
 		}
 
 		return $value;

--- a/tests/codeigniter/core/Lang_test.php
+++ b/tests/codeigniter/core/Lang_test.php
@@ -41,10 +41,24 @@ class Lang_test extends CI_TestCase {
 
 		// Non-existent file
 		$this->setExpectedException(
-			'RuntimeException',
-			'CI Error: Unable to load the requested language file: language/english/nonexistent_lang.php'
+				'RuntimeException', 'CI Error: Unable to load the requested language file: language/english/nonexistent_lang.php'
 		);
 		$this->lang->load('nonexistent');
+	}
+
+	// --------------------------------------------------------------------
+
+	public function test_fallback()
+	{
+		// settings in parent only
+		$this->ci_vfs_clone('system/language/english/number_lang.php', 'application/language/german/');
+		$this->assertTrue($this->lang->load('number', 'german'));
+		$this->assertEquals('Bytes', $this->lang->language['bytes']);
+
+		// settings in both places
+		$this->ci_vfs_create('application/language/german/email_lang.php', "<?php \$lang['fruit'] = 'Apfel';");
+		$this->assertTrue($this->lang->load('email', 'german'));
+		$this->assertEquals('Apfel', $this->lang->language['fruit']);
 	}
 
 	// --------------------------------------------------------------------
@@ -58,8 +72,7 @@ class Lang_test extends CI_TestCase {
 			1 => 'nonexistent'
 		);
 		$this->setExpectedException(
-			'RuntimeException',
-			'CI Error: Unable to load the requested language file: language/english/nonexistent_lang.php'
+				'RuntimeException', 'CI Error: Unable to load the requested language file: language/english/nonexistent_lang.php'
 		);
 		$this->lang->load($files, 'english');
 	}
@@ -86,4 +99,5 @@ class Lang_test extends CI_TestCase {
 		$this->assertFalse($this->lang->line('nonexistent_string'));
 		$this->assertFalse($this->lang->line(NULL));
 	}
+
 }

--- a/tests/codeigniter/core/Lang_test.php
+++ b/tests/codeigniter/core/Lang_test.php
@@ -50,15 +50,25 @@ class Lang_test extends CI_TestCase {
 
 	public function test_fallback()
 	{
-		// settings in parent only
-		$this->ci_vfs_clone('system/language/english/number_lang.php', 'application/language/german/');
-		$this->assertTrue($this->lang->load('number', 'german'));
+		// system target language file
+		$this->ci_vfs_create('system/language/martian/number_lang.php', "<?php \$lang['fruit'] = 'Apfel';");
+		$this->assertTrue($this->lang->load('number', 'martian'));
+		$this->assertEquals('Apfel', $this->lang->language['fruit']);
 		$this->assertEquals('Bytes', $this->lang->language['bytes']);
 
-		// settings in both places
-		$this->ci_vfs_create('application/language/german/email_lang.php', "<?php \$lang['fruit'] = 'Apfel';");
-		$this->assertTrue($this->lang->load('email', 'german'));
+		// application target language file
+		$this->ci_vfs_create('application/language/klingon/number_lang.php', "<?php \$lang['fruit'] = 'Apfel';");
+		$this->assertTrue($this->lang->load('number', 'klingon'));
 		$this->assertEquals('Apfel', $this->lang->language['fruit']);
+		$this->assertEquals('Bytes', $this->lang->language['bytes']);
+
+		// both system & application language files
+		$this->ci_vfs_create('system/language/romulan/number_lang.php', "<?php \$lang['apple'] = 'Core';");
+		$this->ci_vfs_create('application/language/romulan/number_lang.php', "<?php \$lang['fruit'] = 'Cherry';");
+		$this->assertTrue($this->lang->load('number', 'romulan'));
+		$this->assertEquals('Cherry', $this->lang->language['fruit']);
+		$this->assertEquals('Bytes', $this->lang->language['bytes']);
+		$this->assertEquals('Core', $this->lang->language['apple']);
 	}
 
 	// --------------------------------------------------------------------

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -16,6 +16,7 @@ Release Date: Not Released
 -  General Changes
 
    -  Updated the *application/config/constants.php* file to check if constants aren't already defined before doing that.
+   -  Enhanced *system/core/Lang.php* to fallback to english for missing language settings.
 
 Bug fixes for 3.0.2
 -------------------

--- a/user_guide_src/source/libraries/language.rst
+++ b/user_guide_src/source/libraries/language.rst
@@ -86,6 +86,19 @@ Example of switching languages
 	$oops = $this->lang->line('message_key');
 
 ********************
+Language Fallback
+********************
+
+When loading a language file, CodeIgniter will load first the english version,
+if appropriate, and then the one appropriate to the language you specify.
+This lets you define only the language settings that you wish to over-ride
+in your idiom-specific files.
+
+This has the added benefit of the language facility not breaking if a new
+language setting is added to the built-in ones (english), but not yet
+provided for in one of the translations.
+
+********************
 Internationalization
 ********************
 


### PR DESCRIPTION
Added language fallback handling.

When loading a language file, CodeIgniter will load first the english version, if appropriate, and then the one appropriate to the language you specify. This lets you define only the language settings that you wish to over-ride in your idiom-specific files.

This has the added benefit of the language facility not breaking if a new language setting is added to the built-in ones (english), but not yet provided for in one of the translations.