### PR TITLE
Fix fatal error for PHP 5.3 on Windows.

### DIFF
--- a/system/core/Security.php
+++ b/system/core/Security.php
@@ -575,7 +575,14 @@ class CI_Security {
 		}
 
 		// Unfortunately, none of the following PRNGs is guaranteed to exist ...
-		if (defined('MCRYPT_DEV_URANDOM') && ($output = mcrypt_create_iv($length, MCRYPT_DEV_URANDOM)) !== FALSE)
+		if (is_php('5.3') && stripos(php_uname('a'), 'win') === 0)
+		{
+			if (defined('MCRYPT_RAND') && ($output = mcrypt_create_iv($length, MCRYPT_RAND)) !== FALSE)
+			{
+				return $output;
+			}
+		}
+		else if (defined('MCRYPT_DEV_URANDOM') && ($output = mcrypt_create_iv($length, MCRYPT_DEV_URANDOM)) !== FALSE)
 		{
 			return $output;
 		}


### PR DESCRIPTION
There is an issue with PHP 5.3 running on Windows where utilizing the MCRYPT_DEV_URANDOM algorithm results in a Fatal error with the message "Could not gather sufficient random data".

This proposed change tests for 5.3 on windows, and attempts to utilize a different algorithm.

The official documentation outlining the function http://php.net/manual/en/function.mcrypt-create-iv.php claims that MCRYPT_DEV_URANDOM should be sufficient, however with earlier versions of PHP 5.3 this is simply un-true.

This is especially bothersome to developers deploying to a RHEL 5 or 6 environment, but developing on Windows.  At the moment we are stuck on PHP 5.3.3, and this bug causes all kinds of issues.