### PR TITLE
Add missing NULL to defaults for Input methods

### DIFF
--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -259,7 +259,7 @@ class CI_Input {
 	 * @param	bool	$xss_clean	Whether to apply XSS filtering
 	 * @return	mixed
 	 */
-	public function post_get($index, $xss_clean = NULL)
+	public function post_get($index = NULL, $xss_clean = NULL)
 	{
 		return isset($_POST[$index])
 			? $this->post($index, $xss_clean)
@@ -275,7 +275,7 @@ class CI_Input {
 	 * @param	bool	$xss_clean	Whether to apply XSS filtering
 	 * @return	mixed
 	 */
-	public function get_post($index, $xss_clean = NULL)
+	public function get_post($index = NULL, $xss_clean = NULL)
 	{
 		return isset($_GET[$index])
 			? $this->get($index, $xss_clean)
@@ -305,7 +305,7 @@ class CI_Input {
 	 * @param	bool	$xss_clean	Whether to apply XSS filtering
 	 * @return	mixed
 	 */
-	public function server($index, $xss_clean = NULL)
+	public function server($index = NULL, $xss_clean = NULL)
 	{
 		return $this->_fetch_from_array($_SERVER, $index, $xss_clean);
 	}


### PR DESCRIPTION
Added $index = NULL to the following methods:
* post_get
* get_post
* cookies
* server

It avoids the php warning when getting the various input arrays.  Matches the behaviour of the get and post methods.