### PR TITLE
Optimize csv_from_result speed.

### DIFF
--- a/system/database/DB_utility.php
+++ b/system/database/DB_utility.php
@@ -254,11 +254,12 @@ abstract class CI_DB_utility {
 		// Next blast through the result array and build out the rows
 		while ($row = $query->unbuffered_row('array'))
 		{
+			$line = array();
 			foreach ($row as $item)
 			{
-				$out .= $enclosure.str_replace($enclosure, $enclosure.$enclosure, $item).$enclosure.$delim;
+				$line[] = $enclosure.str_replace($enclosure, $enclosure.$enclosure, $item).$enclosure;
 			}
-			$out = substr($out, 0, -strlen($delim)).$newline;
+			$out .= implode($delim, $line).$newline;
 		}
 
 		return $out;


### PR DESCRIPTION
After applying this change, I am able to export 50K rows at around 5 seconds. meanwhile the old version is giving me timeouts.

