### PR TITLE
disable pulldown menu on mobile devices

### DIFF
--- a/user_guide_src/source/_themes/sphinx_rtd_theme/breadcrumbs.html
+++ b/user_guide_src/source/_themes/sphinx_rtd_theme/breadcrumbs.html
@@ -15,7 +15,7 @@
       {% endif %}
     </li>
     <div style="float:right;margin-left:5px;" id="closeMe">
-      <img title="Classic Layout" alt="classic layout" src="data:image/gif;base64,R0lGODlhFAAUAJEAAAAAADMzM////wAAACH5BAUUAAIALAAAAAAUABQAAAImlI+py+0PU5gRBRDM3DxbWoXis42X13USOLauUIqnlsaH/eY6UwAAOw==" />
+      <img title="Switch Layout" alt="switch layout" src="data:image/gif;base64,R0lGODlhFAAUAJEAAAAAADMzM////wAAACH5BAUUAAIALAAAAAAUABQAAAImlI+py+0PU5gRBRDM3DxbWoXis42X13USOLauUIqnlsaH/eY6UwAAOw==" />
     </div>
   </ul>
   <hr/>

--- a/user_guide_src/source/_themes/sphinx_rtd_theme/breadcrumbs.html
+++ b/user_guide_src/source/_themes/sphinx_rtd_theme/breadcrumbs.html
@@ -15,7 +15,7 @@
       {% endif %}
     </li>
     <div style="float:right;margin-left:5px;" id="closeMe">
-      <img title="Switch Layout" alt="switch layout" src="data:image/gif;base64,R0lGODlhFAAUAJEAAAAAADMzM////wAAACH5BAUUAAIALAAAAAAUABQAAAImlI+py+0PU5gRBRDM3DxbWoXis42X13USOLauUIqnlsaH/eY6UwAAOw==" />
+      <img title="Classic Layout" alt="classic layout" src="data:image/gif;base64,R0lGODlhFAAUAJEAAAAAADMzM////wAAACH5BAUUAAIALAAAAAAUABQAAAImlI+py+0PU5gRBRDM3DxbWoXis42X13USOLauUIqnlsaH/eY6UwAAOw==" />
     </div>
   </ul>
   <hr/>

--- a/user_guide_src/source/_themes/sphinx_rtd_theme/static/css/citheme.css
+++ b/user_guide_src/source/_themes/sphinx_rtd_theme/static/css/citheme.css
@@ -72,9 +72,17 @@ div#pulldown-menu {
 	color: #aaaaaa;
 }
 
-/*disable switch layout on mobile devices*/
-@media (max-width: 768px) { 
-  #closeMe {
-    display: none;
-  }
+/*hide pulldown menu on mobile devices*/
+@media (max-width: 768px) { /*tablet size defined by theme*/
+	#closeMe {
+		display: none;
+	}
+
+	#pulldown {
+		display: none;
+	}
+
+	#openToc {
+		display: none;
+	}
 }

--- a/user_guide_src/source/_themes/sphinx_rtd_theme/static/css/citheme.css
+++ b/user_guide_src/source/_themes/sphinx_rtd_theme/static/css/citheme.css
@@ -71,3 +71,10 @@ div#pulldown-menu {
 	font-family: Lucida Grande,Verdana,Geneva,sans-serif;
 	color: #aaaaaa;
 }
+
+/*disable switch layout on mobile devices*/
+@media (max-width: 768px) { 
+  #closeMe {
+    display: none;
+  }
+}

--- a/user_guide_src/source/_themes/sphinx_rtd_theme/static/js/theme.js
+++ b/user_guide_src/source/_themes/sphinx_rtd_theme/static/js/theme.js
@@ -25,7 +25,7 @@ $(document).ready(function () {
     $('#closeMe').toggle(
         function ()
         {
-            setCookie('ciNav', true, 365);
+            setCookie('ciNav', 'true', 365);
             $('#nav2').show();
             $('#topMenu').remove();
             $('body').css({background: 'none'});
@@ -35,7 +35,7 @@ $(document).ready(function () {
         },
         function ()
         {
-            setCookie('ciNav', false, 365);
+            setCookie('ciNav', 'false', 365);
             $('#topMenu').remove();
             $('#nav').hide();
             $('#nav2').hide();
@@ -50,14 +50,19 @@ $(document).ready(function () {
         //$('#nav').slideToggle();
     }
     // END MODIFICATION ---
+
 });
 
 // Rufnex Cookie functions
 function setCookie(cname, cvalue, exdays) {
+    // expire the old cookie if existed to avoid multiple cookies with the same name
+    if  (getCookie(cname) != false) {
+        document.cookie = cname + "=;expires=Thu, 01 Jan 1970 00:00:00 GMT";
+    }
     var d = new Date();
     d.setTime(d.getTime() + (exdays * 24 * 60 * 60 * 1000));
     var expires = "expires=" + d.toGMTString();
-    document.cookie = cname + "=" + cvalue + "; " + expires;
+    document.cookie = cname + "=" + cvalue + "; " + expires + "; path=/";
 }
 function getCookie(cname) {
     var name = cname + "=";
@@ -73,6 +78,27 @@ function getCookie(cname) {
     return false;
 }
 // End
+
+// resize window
+$(window).on('resize', function(){
+    // show side nav on small screens when pulldown is enabled
+    if (getCookie('ciNav') == 'true' && $(window).width() <= 768) { // 768px is the tablet size defined by the theme
+        $('.wy-nav-side').show();
+    }
+    // changing css with jQuenry seems to override the default css media query
+    // change margin
+    else if (getCookie('ciNav') == 'false' && $(window).width() <= 768) {
+        $('.wy-nav-content-wrap').css({'margin-left': 0});
+    }
+    // hide side nav on large screens when pulldown is enabled
+    else if (getCookie('ciNav') == 'true' && $(window).width() > 768) {
+        $('.wy-nav-side').hide();
+    }
+    // change margin
+    else if (getCookie('ciNav') == 'false' && $(window).width() > 768) {
+        $('.wy-nav-content-wrap').css({'margin-left': '300px'});
+    }
+});
 
 window.SphinxRtdTheme = (function (jquery) {
     var stickyNav = (function () {

--- a/user_guide_src/source/_themes/sphinx_rtd_theme/static/js/theme.js
+++ b/user_guide_src/source/_themes/sphinx_rtd_theme/static/js/theme.js
@@ -25,7 +25,7 @@ $(document).ready(function () {
     $('#closeMe').toggle(
         function ()
         {
-            setCookie('ciNav', 'true', 365);
+            setCookie('ciNav', 'yes', 365);
             $('#nav2').show();
             $('#topMenu').remove();
             $('body').css({background: 'none'});
@@ -35,7 +35,7 @@ $(document).ready(function () {
         },
         function ()
         {
-            setCookie('ciNav', 'false', 365);
+            setCookie('ciNav', 'no', 365);
             $('#topMenu').remove();
             $('#nav').hide();
             $('#nav2').hide();
@@ -44,7 +44,7 @@ $(document).ready(function () {
             $('.wy-nav-side').show();
         }
     );
-    if (getCookie('ciNav') == 'true')
+    if (getCookie('ciNav') == 'yes')
     {
         $('#closeMe').trigger('click');
         //$('#nav').slideToggle();
@@ -56,7 +56,7 @@ $(document).ready(function () {
 // Rufnex Cookie functions
 function setCookie(cname, cvalue, exdays) {
     // expire the old cookie if existed to avoid multiple cookies with the same name
-    if  (getCookie(cname) != false) {
+    if  (getCookie(cname)) {
         document.cookie = cname + "=;expires=Thu, 01 Jan 1970 00:00:00 GMT";
     }
     var d = new Date();
@@ -75,27 +75,27 @@ function getCookie(cname) {
             return c.substring(name.length, c.length);
         }
     }
-    return false;
+    return '';
 }
 // End
 
 // resize window
 $(window).on('resize', function(){
     // show side nav on small screens when pulldown is enabled
-    if (getCookie('ciNav') == 'true' && $(window).width() <= 768) { // 768px is the tablet size defined by the theme
+    if (getCookie('ciNav') == 'yes' && $(window).width() <= 768) { // 768px is the tablet size defined by the theme
         $('.wy-nav-side').show();
     }
     // changing css with jquery seems to override the default css media query
     // change margin
-    else if (getCookie('ciNav') == 'false' && $(window).width() <= 768) {
+    else if (getCookie('ciNav') == 'no' && $(window).width() <= 768) {
         $('.wy-nav-content-wrap').css({'margin-left': 0});
     }
     // hide side nav on large screens when pulldown is enabled
-    else if (getCookie('ciNav') == 'true' && $(window).width() > 768) {
+    else if (getCookie('ciNav') == 'yes' && $(window).width() > 768) {
         $('.wy-nav-side').hide();
     }
     // change margin
-    else if (getCookie('ciNav') == 'false' && $(window).width() > 768) {
+    else if (getCookie('ciNav') == 'no' && $(window).width() > 768) {
         $('.wy-nav-content-wrap').css({'margin-left': '300px'});
     }
 });

--- a/user_guide_src/source/_themes/sphinx_rtd_theme/static/js/theme.js
+++ b/user_guide_src/source/_themes/sphinx_rtd_theme/static/js/theme.js
@@ -85,7 +85,7 @@ $(window).on('resize', function(){
     if (getCookie('ciNav') == 'true' && $(window).width() <= 768) { // 768px is the tablet size defined by the theme
         $('.wy-nav-side').show();
     }
-    // changing css with jQuenry seems to override the default css media query
+    // changing css with jquery seems to override the default css media query
     // change margin
     else if (getCookie('ciNav') == 'false' && $(window).width() <= 768) {
         $('.wy-nav-content-wrap').css({'margin-left': 0});


### PR DESCRIPTION
I would like to suggest that we disable pulldown menu on small screens since this feature is designed for desktop devices and it does not function well on mobile devices.

For example, when enabling pulldown menu on mobile devices, the bar icon will not disappear and a blank side bar will show up after clicking the bar icon.
![screen shot 2015-10-11 at 16 02 33](https://cloud.githubusercontent.com/assets/3772296/10419617/8d9fdf38-7031-11e5-851f-cc6ee2dd3076.png)
And while the pulldown menu is helpful on large screens, it is not really easy to view on mobile devices.

As the recent release started to offer Epub version of docs so that users could have one more alternative on mobiles, I think it would be safe to remove this functionality on small screen.
