### PR TITLE
Don't trigger double queries.

### DIFF
--- a/system/database/drivers/pdo/pdo_driver.php
+++ b/system/database/drivers/pdo/pdo_driver.php
@@ -194,7 +194,7 @@ class CI_DB_pdo_driver extends CI_DB {
 
 		if (is_object($result_id) && $result_id->execute())
 		{
-			if (is_numeric(stripos($sql, 'SELECT')))
+			if (stripos($sql, 'SELECT') === 0)
 			{
 				$this->affect_rows = count($result_id->fetchAll());
 			}


### PR DESCRIPTION
No longer runs query twice when working with a column that contains "select". For instance:
INSERT INTO params (param) VALUES ('param_selector');