### PR TITLE
DB_query_builder->_where_in() produce an db error if $values array is…

### DIFF
--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -785,7 +785,15 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 			return $this;
 		}
 
-		if ( ! is_array($values))
+		if (is_array($values))
+		{
+			// Empty $values array given, but this produce an empty IN() statement ==> db error.
+			if (count($values) == 0)
+			{
+				return $this;
+			}
+		}
+		else
 		{
 			$values = array($values);
 		}


### PR DESCRIPTION
Hi,

today I saw an database error coming up to me as a result of the DB_query_builder->_where_in() function.

The function only checks is the parameter $values !== NULL and is $values an array, but not the count of elements.

```
Error Number: 42601/7
ERROR: Syntaxerror at „)“ LINE 3: WHERE domain IN() ^
SELECT * FROM "domain" WHERE domain IN() AND "domain" NOT LIKE 'ALL'
Filename: F:/workspace/postfixadmin-ng/build/dev/application/models/Domains_model.php
Line Number: 56
```
