### PR TITLE
Adds SQL Explain option to query()

### DIFF
--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -593,7 +593,7 @@ abstract class CI_DB_driver {
 	 * @param	bool	$return_object = NULL
 	 * @return	mixed
 	 */
-	public function query($sql, $binds = FALSE, $return_object = NULL)
+	public function query($sql, $binds = FALSE, $return_object = NULL, $explain = FALSE)
 	{
 		if ($sql === '')
 		{
@@ -615,6 +615,17 @@ abstract class CI_DB_driver {
 		if ($binds !== FALSE)
 		{
 			$sql = $this->compile_binds($sql, $binds);
+		}
+		
+		// Add explain syntax if needed
+		if ($explain)
+		{
+			if (FALSE === ($sql = $this->_explain($sql)))
+			{
+				// Log error
+				log_message('error', 'explain not supported for driver: ' . $this->dbdriver);
+				return FALSE;
+			}
 		}
 
 		// Is query caching enabled? If the query is a "read type"
@@ -733,6 +744,19 @@ abstract class CI_DB_driver {
 		return $RES;
 	}
 
+	// --------------------------------------------------------------------
+
+	/**
+	 * _explain function that will be overwritten by individual drivers
+	 * 
+	 * @param	string	query to be explained
+	 * @return	boolean
+	 */
+	protected function _explain($sql)
+	{
+		return FALSE;
+	}
+	
 	// --------------------------------------------------------------------
 
 	/**

--- a/system/database/drivers/mysql/mysql_driver.php
+++ b/system/database/drivers/mysql/mysql_driver.php
@@ -231,6 +231,19 @@ class CI_DB_mysql_driver extends CI_DB {
 
 		return $this->data_cache['version'] = $version;
 	}
+	
+	// --------------------------------------------------------------------
+
+	/**
+	 * Execute the query
+	 *
+	 * @param	string	$sql	an SQL query
+	 * @return	string
+	 */
+	protected function _explain($sql)
+	{
+		return 'EXPLAIN ' . $sql;
+	}
 
 	// --------------------------------------------------------------------
 

--- a/system/database/drivers/mysqli/mysqli_driver.php
+++ b/system/database/drivers/mysqli/mysqli_driver.php
@@ -250,6 +250,19 @@ class CI_DB_mysqli_driver extends CI_DB {
 
 		return $this->data_cache['version'] = $this->conn_id->server_info;
 	}
+	
+	// --------------------------------------------------------------------
+
+	/**
+	 * Execute the query
+	 *
+	 * @param	string	$sql	an SQL query
+	 * @return	string
+	 */
+	protected function _explain($sql)
+	{
+		return 'EXPLAIN ' . $sql;
+	}
 
 	// --------------------------------------------------------------------
 

--- a/system/database/drivers/oci8/oci8_driver.php
+++ b/system/database/drivers/oci8/oci8_driver.php
@@ -261,6 +261,19 @@ class CI_DB_oci8_driver extends CI_DB {
 	}
 
 	// --------------------------------------------------------------------
+	
+	/**
+	 * Execute the query
+	 *
+	 * @param	string	$sql	an SQL query
+	 * @return	string
+	 */
+	protected function _explain($sql)
+	{
+		return 'EXPLAIN PLAN ' . $sql;
+	}
+
+	// --------------------------------------------------------------------
 
 	/**
 	 * Execute the query

--- a/system/database/drivers/postgre/postgre_driver.php
+++ b/system/database/drivers/postgre/postgre_driver.php
@@ -230,6 +230,19 @@ class CI_DB_postgre_driver extends CI_DB {
 	}
 
 	// --------------------------------------------------------------------
+	
+	/**
+	 * Execute the query
+	 *
+	 * @param	string	$sql	an SQL query
+	 * @return	string
+	 */
+	protected function _explain($sql)
+	{
+		return 'EXPLAIN ' . $sql;
+	}
+	
+	// --------------------------------------------------------------------
 
 	/**
 	 * Execute the query

--- a/system/database/drivers/sqlite/sqlite_driver.php
+++ b/system/database/drivers/sqlite/sqlite_driver.php
@@ -103,6 +103,19 @@ class CI_DB_sqlite_driver extends CI_DB {
 	}
 
 	// --------------------------------------------------------------------
+	 
+	/**
+	 * Execute the query
+	 *
+	 * @param	string	$sql	an SQL query
+	 * @return	string
+	 */
+	protected function _explain($sql)
+	{
+		return 'EXPLAIN QUERY PLAN ' . $sql;
+	}
+	
+	// --------------------------------------------------------------------
 
 	/**
 	 * Execute the query

--- a/system/database/drivers/sqlite3/sqlite3_driver.php
+++ b/system/database/drivers/sqlite3/sqlite3_driver.php
@@ -112,6 +112,19 @@ class CI_DB_sqlite3_driver extends CI_DB {
 		$version = SQLite3::version();
 		return $this->data_cache['version'] = $version['versionString'];
 	}
+	
+	// --------------------------------------------------------------------
+	 
+	/**
+	 * Execute the query
+	 *
+	 * @param	string	$sql	an SQL query
+	 * @return	string
+	 */
+	protected function _explain($sql)
+	{
+		return 'EXPLAIN QUERY PLAN ' . $sql;
+	}
 
 	// --------------------------------------------------------------------
 

--- a/user_guide_src/source/database/db_driver_reference.rst
+++ b/user_guide_src/source/database/db_driver_reference.rst
@@ -83,11 +83,12 @@ This article is intended to be a reference for them.
 
 		Database version number.
 
-	.. php:method:: query($sql[, $binds = FALSE[, $return_object = NULL]]])
+	.. php:method:: query($sql[, $binds = FALSE[, $return_object = NULL[, $explain = FALSE]]]])
 
 		:param	string	$sql: The SQL statement to execute
 		:param	array	$binds: An array of binding data
 		:param	bool	$return_object: Whether to return a result object or not
+                :param  bool    $explain: Whether to return the query plan or execute the query
 		:returns:	TRUE for successful "write-type" queries, CI_DB_result instance (method chaining) on "query" success, FALSE on failure
 		:rtype:	mixed
 


### PR DESCRIPTION
This PR addresses #1534. I've implemented an explain function for all of the drivers with simple explain syntax. Others will require a little more thought. I haven't touched the PDO subdrivers or any databases that require settings changes to show query plans like cubrid or sqlsrv. 