### PR TITLE
refactor error handling in /core/Common

### DIFF
--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -393,11 +393,13 @@ if ( ! function_exists('show_error'))
 	/**
 	 * Error Handler
 	 *
-	 * This function lets us invoke the exception class and
-	 * display errors using the standard error template located
-	 * in application/views/errors/error_general.php
-	 * This function will send the error page directly to the
-	 * browser and exit.
+	 * This function will be deprecated in version 3.1.0.
+	 * It is encouraged to use PHP exceptions in your application.
+	 * If there is a need to render error page accordingly, you will need to 
+	 * invoke the exception class and display errors using the 
+	 * standard error template located in 
+	 * application/views/errors/error_general.php
+	 * This function will simply throw an exception for smooth transition.
 	 *
 	 * @param	string
 	 * @param	int
@@ -406,25 +408,7 @@ if ( ! function_exists('show_error'))
 	 */
 	function show_error($message, $status_code = 500, $heading = 'An Error Was Encountered')
 	{
-		$status_code = abs($status_code);
-		if ($status_code < 100)
-		{
-			$exit_status = $status_code + 9; // 9 is EXIT__AUTO_MIN
-			if ($exit_status > 125) // 125 is EXIT__AUTO_MAX
-			{
-				$exit_status = 1; // EXIT_ERROR
-			}
-
-			$status_code = 500;
-		}
-		else
-		{
-			$exit_status = 1; // EXIT_ERROR
-		}
-
-		$_error =& load_class('Exceptions', 'core');
-		echo $_error->show_error($heading, $message, 'error_general', $status_code);
-		exit($exit_status);
+		throw new RuntimeException('CI Error: '.$message, $status_code);
 	}
 }
 

--- a/tests/codeigniter/core/Common_test.php
+++ b/tests/codeigniter/core/Common_test.php
@@ -49,4 +49,21 @@ class Common_test extends CI_TestCase {
 		);
 	}
 
+	// ------------------------------------------------------------------------
+
+	public function test_show_error()
+	{
+		$error_message = "test show_error exception";
+		$error_code = 403;
+		try
+		{
+			show_error($error_message, 403);
+		}
+		catch (Exception $e)
+		{
+			$this->assertEquals('CI Error: '.$error_message, $e->getMessage());
+			$this->assertEquals($error_code, $e->getCode());
+		}
+	}
+
 }

--- a/tests/mocks/core/common.php
+++ b/tests/mocks/core/common.php
@@ -92,14 +92,6 @@ if ( ! function_exists('load_class'))
 // Clean up error messages
 // --------------------------------------------------------------------
 
-if ( ! function_exists('show_error'))
-{
-	function show_error($message, $status_code = 500, $heading = 'An Error Was Encountered')
-	{
-		throw new RuntimeException('CI Error: '.$message);
-	}
-}
-
 if ( ! function_exists('show_404'))
 {
 	function show_404($page = '', $log_error = TRUE)

--- a/user_guide_src/source/general/errors.rst
+++ b/user_guide_src/source/general/errors.rst
@@ -2,10 +2,12 @@
 Error Handling
 ##############
 
-CodeIgniter lets you build error reporting into your applications using
-the functions described below. In addition, it has an error logging
-class that permits error and debugging messages to be saved as text
-files.
+In CodeIgniter, it is encouraged to use PHP exceptions to perform
+error handling. CodeIgniter provides an error template page to
+display error messages to end users. You will need to invoke Exceptions
+class to render the error template. In addition, CodeIgniter has an error
+logging class that permits error and debugging messages to be saved
+as text files.
 
 .. note:: By default, CodeIgniter displays all PHP errors. You might
 	wish to change this behavior once your development is complete. You'll
@@ -18,41 +20,21 @@ procedural interfaces that are available globally throughout the
 application. This approach permits error messages to get triggered
 without having to worry about class/function scoping.
 
-CodeIgniter also returns a status code whenever a portion of the core
-calls ``exit()``. This exit status code is separate from the HTTP status
-code, and serves as a notice to other processes that may be watching of
-whether the script completed successfully, or if not, what kind of
-problem it encountered that caused it to abort. These values are
-defined in *application/config/constants.php*. While exit status codes
-are most useful in CLI settings, returning the proper code helps server
-software keep track of your scripts and the health of your application.
+Example of rendering general error page::
+
+	$_error =& load_class('Exceptions', 'core');
+	echo $_error->show_error($heading, $message, 'error_general', $status_code);
+
+This above code will display the error message supplied to it using
+the error template appropriate to your execution::
+
+	application/views/errors/html/error_general.php
+
+or::
+
+	application/views/errors/cli/error_general.php
 
 The following functions let you generate errors:
-
-.. php:function:: show_error($message, $status_code, $heading = 'An Error Was Encountered')
-
-	:param	mixed	$message: Error message
-	:param	int	$status_code: HTTP Response status code
-	:param	string	$heading: Error page heading
-	:rtype:	void
-
-	This function will display the error message supplied to it using
-	the error template appropriate to your execution::
-
-		application/views/errors/html/error_general.php
-
-	or:
-
-		application/views/errors/cli/error_general.php
-
-	The optional parameter ``$status_code`` determines what HTTP status
-	code should be sent with the error. If ``$status_code`` is less
-	than 100, the HTTP status code will be set to 500, and the exit
-	status code will be set to ``$status_code + EXIT__AUTO_MIN``.
-	If that value is larger than ``EXIT__AUTO_MAX``, or if
-	``$status_code`` is 100 or higher, the exit status code will be set
-	to ``EXIT_ERROR``.
-	You can check in *application/config/constants.php* for more detail.
 
 .. php:function:: show_404($page = '', $log_error = TRUE)
 


### PR DESCRIPTION
Change show_error function in /core/Common to just throw new exception according to issue #4189.

- make show_error() simply throw new exceptions. If an error template rendering is needed, users can call the rendering function when an exception is caught.
- remove test mocking function for show_error()
- the error handling part of user guide is modified accordingly
- a trivial test case is added which tests nothing more than PHP just to validate my changes.(It could be removed after the change is finalized.)