### PR TITLE
Added function show_flashdata() to system/libraries/Session/Session.php

### DIFF
--- a/system/libraries/Session/Session.php
+++ b/system/libraries/Session/Session.php
@@ -888,9 +888,11 @@ class CI_Session {
 	}
 	
 	/**
+	 * Show flashdata
+	 * 
 	 * Calling flasdata, and avoiding if-else check
 	 * 
-	 * Can be called as foolwing in the view file.
+	 * Can be called as follwing in the view file.
 	 * <?= $this->session->show_flashdata('login_success', 'alert success'); ?>
 	 * 
 	 */

--- a/system/libraries/Session/Session.php
+++ b/system/libraries/Session/Session.php
@@ -886,5 +886,20 @@ class CI_Session {
 	{
 		$this->unmark_temp($key);
 	}
+	
+	/**
+	 * Calling flasdata, and avoiding if-else check
+	 * 
+	 * Can be called as foolwing in the view file.
+	 * <?= $this->session->show_flashdata('login_success', 'alert success'); ?>
+	 * 
+	 */
+	public function show_flashdata($key, $classes='success', $tag='p')
+	{
+		$ci =& get_instance();
+		if ($ci->session->flashdata($key)) {
+			return '<'.$tag.' class="'.$classes.'">'.$ci->session->flashdata($key).'</'.$tag.'>';
+		}
+	}
 
 }


### PR DESCRIPTION
Normally we call a flashdata in the view file as follows,

<?php if($this->session->flashdata('login_success')): ?>
  <p class="alert success"><?= $this->session->flashdata('login_success') ?></p>
<?php endif; ?>

But by using this function the view file will be more cleaner and its easier to call as follows,
<?= $this->session->show_flashdata('login_success', 'alert success'); ?>

for only a single if-else block of flashdata its OK, but when we have 5 or more if-else blocks in our view for the flashdata, then it looks very cluttered, this function is to clean it up.