### PR TITLE
Fix count_all_results when ordering

### DIFF
--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -1379,9 +1379,20 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 			$this->from($table);
 		}
 
+  		$tmp_order = $this->qb_orderby;
+        	$tmp_order_cache = $this->qb_cache_orderby;
+        	$this->qb_orderby = array();
+        	$this->qb_cache_orderby = array();
+        
 		$result = ($this->qb_distinct === TRUE)
 			? $this->query($this->_count_string.$this->protect_identifiers('numrows')."\nFROM (\n".$this->_compile_select()."\n) CI_count_all_results")
 			: $this->query($this->_compile_select($this->_count_string.$this->protect_identifiers('numrows')));
+
+		
+        	$this->qr_orderby = $tmp_order;
+        	$this->qr_cache_orderby = $tmp_order_cache;
+        	unset($tmp_order);
+        	unset($tmp_order_cache);
 
 		if ($reset === TRUE)
 		{

--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -1389,8 +1389,8 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 			: $this->query($this->_compile_select($this->_count_string.$this->protect_identifiers('numrows')));
 
 		
-        	$this->qr_orderby = $tmp_order;
-        	$this->qr_cache_orderby = $tmp_order_cache;
+        	$this->qb_orderby = $tmp_order;
+        	$this->qb_cache_orderby = $tmp_order_cache;
         	unset($tmp_order);
         	unset($tmp_order_cache);
 


### PR DESCRIPTION
Fixes error introduced in v3 when there is a pending qr_order_by (used typically in pagination to get a count before results)

Method adapted from v2 DB_active_rec line 911