### PR TITLE
Fix issue introduced in v3 with QB Cache

### DIFF
--- a/system/libraries/Session/drivers/Session_database_driver.php
+++ b/system/libraries/Session/drivers/Session_database_driver.php
@@ -230,6 +230,7 @@ class CI_Session_database_driver extends CI_Session_driver implements SessionHan
 			return FALSE;
 		}
 
+		$this->_db->flush_cache();
 		$this->_db->where('id', $session_id);
 		if ($this->_config['match_ip'])
 		{


### PR DESCRIPTION
If CI_DB_query_builder qb_caching is TRUE and a query has been executed prior to the session save, the parameters can bleed into the session saving to DB.

Ideally, developers will use `stop_cache()` and `flush_cache()` but this issue did not occur in v2 and was not noted in upgrade instructions.

Only potential improvement to the pull request may be to store the cached query, flush, then reapply, in case the session write is called before the end of the page.