### PR TITLE
refactor exceptions for core/Lang

### DIFF
--- a/system/core/Lang.php
+++ b/system/core/Lang.php
@@ -150,7 +150,7 @@ class CI_Lang {
 
 		if ($found !== TRUE)
 		{
-			throw new RuntimeException('CI Error: Unable to load the requested language file: language/'.$idiom.'/'.$langfile);
+			throw new RuntimeException('Unable to load the requested language file: language/'.$idiom.'/'.$langfile);
 		}
 
 		if ( ! isset($lang) OR ! is_array($lang))

--- a/system/core/Lang.php
+++ b/system/core/Lang.php
@@ -150,7 +150,7 @@ class CI_Lang {
 
 		if ($found !== TRUE)
 		{
-			show_error('Unable to load the requested language file: language/'.$idiom.'/'.$langfile);
+			throw new RuntimeException('CI Error: Unable to load the requested language file: language/'.$idiom.'/'.$langfile);
 		}
 
 		if ( ! isset($lang) OR ! is_array($lang))

--- a/tests/codeigniter/core/Lang_test.php
+++ b/tests/codeigniter/core/Lang_test.php
@@ -37,7 +37,7 @@ class Lang_test extends CI_TestCase {
 		// Non-existent file
 		$this->setExpectedException(
 			'RuntimeException',
-			'CI Error: Unable to load the requested language file: language/english/nonexistent_lang.php'
+			'Unable to load the requested language file: language/english/nonexistent_lang.php'
 		);
 		$this->lang->load('nonexistent');
 	}
@@ -71,7 +71,7 @@ class Lang_test extends CI_TestCase {
 		);
 		$this->setExpectedException(
 			'RuntimeException',
-			'CI Error: Unable to load the requested language file: language/english/nonexistent_lang.php'
+			'Unable to load the requested language file: language/english/nonexistent_lang.php'
 		);
 		$this->lang->load($files, 'english');
 	}


### PR DESCRIPTION
related to issue #4189 

When the lang file could not be found, an exception will be thrown. Test cases already exist. By doing this, the error page would not be automatically rendered. If there is a need, user should call error page rendering in their exception handler(not sure if this is an issue). 

No particular changes are needed for the user guide. 