### PR TITLE
Build base_url correctly if SERVER_ADDR is IPv6

### DIFF
--- a/system/core/Config.php
+++ b/system/core/Config.php
@@ -98,6 +98,7 @@ class CI_Config {
 				{
 					$server_addr = $_SERVER['SERVER_ADDR'];
 				}
+
 				$base_url = (is_https() ? 'https' : 'http').'://'.$server_addr
 					.substr($_SERVER['SCRIPT_NAME'], 0, strpos($_SERVER['SCRIPT_NAME'], basename($_SERVER['SCRIPT_FILENAME'])));
 			}

--- a/system/core/Config.php
+++ b/system/core/Config.php
@@ -90,7 +90,15 @@ class CI_Config {
 		{
 			if (isset($_SERVER['SERVER_ADDR']))
 			{
-				$base_url = (is_https() ? 'https' : 'http').'://'.$_SERVER['SERVER_ADDR']
+				if ((bool) filter_var($_SERVER['SERVER_ADDR'], FILTER_VALIDATE_IP, FILTER_FLAG_IPV6))
+				{
+					$server_addr = '[' . $_SERVER['SERVER_ADDR'] . ']';
+				}
+				else
+				{
+					$server_addr = $_SERVER['SERVER_ADDR'];
+				}
+				$base_url = (is_https() ? 'https' : 'http').'://'.$server_addr
 					.substr($_SERVER['SCRIPT_NAME'], 0, strpos($_SERVER['SCRIPT_NAME'], basename($_SERVER['SCRIPT_FILENAME'])));
 			}
 			else

--- a/system/core/Config.php
+++ b/system/core/Config.php
@@ -90,7 +90,7 @@ class CI_Config {
 		{
 			if (isset($_SERVER['SERVER_ADDR']))
 			{
-				if ((bool) filter_var($_SERVER['SERVER_ADDR'], FILTER_VALIDATE_IP, FILTER_FLAG_IPV6))
+				if (strpos($_SERVER['SERVER_ADDR'], ':') !== FALSE)
 				{
 					$server_addr = '[' . $_SERVER['SERVER_ADDR'] . ']';
 				}

--- a/system/core/Config.php
+++ b/system/core/Config.php
@@ -92,7 +92,7 @@ class CI_Config {
 			{
 				if (strpos($_SERVER['SERVER_ADDR'], ':') !== FALSE)
 				{
-					$server_addr = '[' . $_SERVER['SERVER_ADDR'] . ']';
+					$server_addr = '['.$_SERVER['SERVER_ADDR'].']';
 				}
 				else
 				{


### PR DESCRIPTION
Now that `base_url` is being calculated using `SERVER_ADDR` instead of `HTTP_HOST`, it no longer works on IPv6 hosts. This fixes the problem by surrounding literal IPv6 addresses with proper [square brackets]. IPv4 addresses are not affected.

`http://::1/some/controller` ← this is not valid
`http://[::1]/some/controller` ← this is valid
