### PR TITLE
refactor exceptions for Loader

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -586,7 +586,7 @@ class CI_Loader {
 				$base_helper = BASEPATH.'helpers/'.$helper.'.php';
 				if ( ! file_exists($base_helper))
 				{
-					show_error('Unable to load the requested file: helpers/'.$helper.'.php');
+					throw new RuntimeException('Unable to load the requested file: helpers/'.$helper.'.php');
 				}
 
 				include_once($base_helper);
@@ -611,7 +611,7 @@ class CI_Loader {
 			// unable to load the helper
 			if ( ! isset($this->_ci_helpers[$helper]))
 			{
-				show_error('Unable to load the requested file: helpers/'.$helper.'.php');
+				throw new RuntimeException('Unable to load the requested file: helpers/'.$helper.'.php');
 			}
 		}
 
@@ -875,7 +875,7 @@ class CI_Loader {
 
 		if ( ! $file_exists && ! file_exists($_ci_path))
 		{
-			show_error('Unable to load the requested file: '.$_ci_file);
+			throw new RuntimeException('Unable to load the requested file: '.$_ci_file);
 		}
 
 		// This allows anything loaded using $this->load (views, files, etc.)
@@ -1050,7 +1050,7 @@ class CI_Loader {
 
 		// If we got this far we were unable to find the requested class.
 		log_message('error', 'Unable to load the requested class: '.$class);
-		show_error('Unable to load the requested class: '.$class);
+		throw new RuntimeException('Unable to load the requested class: '.$class);
 	}
 
 	// --------------------------------------------------------------------
@@ -1211,7 +1211,7 @@ class CI_Loader {
 		if ( ! class_exists($class_name, FALSE))
 		{
 			log_message('error', 'Non-existent class: '.$class_name);
-			show_error('Non-existent class: '.$class_name);
+			throw new RuntimeException('Non-existent class: '.$class_name);
 		}
 
 		// Set the variable name we will assign the class to
@@ -1235,7 +1235,7 @@ class CI_Loader {
 				return;
 			}
 
-			show_error("Resource '".$object_name."' already exists and is not a ".$class_name." instance.");
+			throw new RuntimeException("Resource '".$object_name."' already exists and is not a ".$class_name." instance.");
 		}
 
 		// Save the class name and object name

--- a/tests/codeigniter/core/Loader_test.php
+++ b/tests/codeigniter/core/Loader_test.php
@@ -48,14 +48,25 @@ class Loader_test extends CI_TestCase {
 		// Test a string given to params
 		$this->assertInstanceOf('CI_Loader', $this->load->library($lib, ' '));
 
-		// Create library w/o class
-		$lib = 'bad_test_lib';
-		$this->ci_vfs_create($lib, '', $this->ci_base_root, 'libraries');
+		// test non existent lib
+		$lib = 'non_existent_test_lib';
 
-		// Test non-existent class
 		$this->setExpectedException(
 			'RuntimeException',
-			'CI Error: Unable to load the requested class: '.ucfirst($lib)
+			'Unable to load the requested class: '.ucfirst($lib)
+		);
+		$this->assertInstanceOf('CI_Loader', $this->load->library($lib));
+	}
+
+	// --------------------------------------------------------------------
+
+	public function test_bad_library()
+	{
+		$lib = 'bad_test_lib';
+		$this->ci_vfs_create(ucfirst($lib), '', $this->ci_app_root, 'libraries');
+		$this->setExpectedException(
+			'RuntimeException',
+			'Non-existent class: '.ucfirst($lib)
 		);
 		$this->assertInstanceOf('CI_Loader', $this->load->library($lib));
 	}
@@ -99,7 +110,7 @@ class Loader_test extends CI_TestCase {
 		// Test missing base class
 		$this->setExpectedException(
 			'RuntimeException',
-			'CI Error: Unable to load the requested class: '.$lib
+			'Unable to load the requested class: '.$lib
 		);
 		$this->assertInstanceOf('CI_Loader', $this->load->library($lib));
 	}
@@ -131,6 +142,16 @@ class Loader_test extends CI_TestCase {
 
 		// Test is_loaded
 		$this->assertEquals($obj, $this->load->is_loaded(ucfirst($lib)));
+
+		// Test to load another class with the same object name
+		$lib = 'another_test_lib';
+		$class = ucfirst($lib);
+		$this->ci_vfs_create(ucfirst($lib), '<?php class '.$class.' { }', $this->ci_app_root, 'libraries');
+		$this->setExpectedException(
+			'RuntimeException',
+			"Resource '".$obj."' already exists and is not a ".$class." instance."
+		);
+		$this->load->library($lib, NULL, $obj);
 	}
 
 	// --------------------------------------------------------------------
@@ -284,7 +305,7 @@ class Loader_test extends CI_TestCase {
 	{
 		$this->setExpectedException(
 			'RuntimeException',
-			'CI Error: Unable to load the requested file: ci_test_nonexistent_view.php'
+			'Unable to load the requested file: ci_test_nonexistent_view.php'
 		);
 
 		$this->load->view('ci_test_nonexistent_view', array('foo' => 'bar'));
@@ -307,7 +328,7 @@ class Loader_test extends CI_TestCase {
 		// Test non-existent file
 		$this->setExpectedException(
 			'RuntimeException',
-			'CI Error: Unable to load the requested file: ci_test_file_not_exists'
+			'Unable to load the requested file: ci_test_file_not_exists'
 		);
 
 		$this->load->file('ci_test_file_not_exists', TRUE);
@@ -372,7 +393,7 @@ class Loader_test extends CI_TestCase {
 		// Test bad extension
 		$this->setExpectedException(
 			'RuntimeException',
-			'CI Error: Unable to load the requested file: helpers/'.$ext.'_helper.php'
+			'Unable to load the requested file: helpers/'.$ext.'_helper.php'
 		);
 		$this->load->helper($ext);
 	}
@@ -383,7 +404,7 @@ class Loader_test extends CI_TestCase {
 	{
 		$this->setExpectedException(
 			'RuntimeException',
-			'CI Error: Unable to load the requested file: helpers/bad_helper.php'
+			'Unable to load the requested file: helpers/bad_helper.php'
 		);
 		$this->load->helper('bad');
 	}
@@ -442,7 +463,7 @@ class Loader_test extends CI_TestCase {
 		// Test failed load without path
 		$this->setExpectedException(
 			'RuntimeException',
-			'CI Error: Unable to load the requested class: '.ucfirst($lib)
+			'Unable to load the requested class: '.ucfirst($lib)
 		);
 		$this->load->library($lib);
 

--- a/tests/codeigniter/core/Loader_test.php
+++ b/tests/codeigniter/core/Loader_test.php
@@ -48,25 +48,14 @@ class Loader_test extends CI_TestCase {
 		// Test a string given to params
 		$this->assertInstanceOf('CI_Loader', $this->load->library($lib, ' '));
 
-		// test non existent lib
-		$lib = 'non_existent_test_lib';
+		// Create library w/o class
+		$lib = 'bad_test_lib';
+		$this->ci_vfs_create($lib, '', $this->ci_base_root, 'libraries');
 
+		// Test non-existent class
 		$this->setExpectedException(
 			'RuntimeException',
 			'Unable to load the requested class: '.ucfirst($lib)
-		);
-		$this->assertInstanceOf('CI_Loader', $this->load->library($lib));
-	}
-
-	// --------------------------------------------------------------------
-
-	public function test_bad_library()
-	{
-		$lib = 'bad_test_lib';
-		$this->ci_vfs_create(ucfirst($lib), '', $this->ci_app_root, 'libraries');
-		$this->setExpectedException(
-			'RuntimeException',
-			'Non-existent class: '.ucfirst($lib)
 		);
 		$this->assertInstanceOf('CI_Loader', $this->load->library($lib));
 	}
@@ -142,16 +131,6 @@ class Loader_test extends CI_TestCase {
 
 		// Test is_loaded
 		$this->assertEquals($obj, $this->load->is_loaded(ucfirst($lib)));
-
-		// Test to load another class with the same object name
-		$lib = 'another_test_lib';
-		$class = ucfirst($lib);
-		$this->ci_vfs_create(ucfirst($lib), '<?php class '.$class.' { }', $this->ci_app_root, 'libraries');
-		$this->setExpectedException(
-			'RuntimeException',
-			"Resource '".$obj."' already exists and is not a ".$class." instance."
-		);
-		$this->load->library($lib, NULL, $obj);
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
- Change show_error() to throw exceptions in system/core/Loader
- Changes in tests
    - "CI: Error" prefix is removed.
    - fixed one test of test_library(): the previous test tried to create a library without class, but it did not call `ci_vfs_create()` properly(no `ucfirst()` is used), so it actually was testing non-existent library files.
   - added a test case to test loading an empty library file. A RuntimeException with message `'Non-existent class: '.ucfirst($lib)` is excepted.
   - added a test case to test loading a new library with previously used object name. An exception with message `"Resource '".$obj."' already exists and is not a ".$class." instance."` is expected.
- No changes are needed for user guides
 
