### PR TITLE
modify and add test cases for Loader class to test more exceptions

### DIFF
--- a/tests/codeigniter/core/Loader_test.php
+++ b/tests/codeigniter/core/Loader_test.php
@@ -48,14 +48,25 @@ class Loader_test extends CI_TestCase {
 		// Test a string given to params
 		$this->assertInstanceOf('CI_Loader', $this->load->library($lib, ' '));
 
-		// Create library w/o class
-		$lib = 'bad_test_lib';
-		$this->ci_vfs_create($lib, '', $this->ci_base_root, 'libraries');
+		// test non existent lib
+		$lib = 'non_existent_test_lib';
 
-		// Test non-existent class
 		$this->setExpectedException(
 			'RuntimeException',
 			'CI Error: Unable to load the requested class: '.ucfirst($lib)
+		);
+		$this->assertInstanceOf('CI_Loader', $this->load->library($lib));
+	}
+
+	// --------------------------------------------------------------------
+
+	public function test_bad_library()
+	{
+		$lib = 'bad_test_lib';
+		$this->ci_vfs_create(ucfirst($lib), '', $this->ci_app_root, 'libraries');
+		$this->setExpectedException(
+			'RuntimeException',
+			'CI Error: Non-existent class: '.ucfirst($lib)
 		);
 		$this->assertInstanceOf('CI_Loader', $this->load->library($lib));
 	}
@@ -131,6 +142,16 @@ class Loader_test extends CI_TestCase {
 
 		// Test is_loaded
 		$this->assertEquals($obj, $this->load->is_loaded(ucfirst($lib)));
+
+		// Test to load another class with the same object name
+		$lib = 'another_test_lib';
+		$class = ucfirst($lib);
+		$this->ci_vfs_create(ucfirst($lib), '<?php class '.$class.' { }', $this->ci_app_root, 'libraries');
+		$this->setExpectedException(
+			'RuntimeException',
+			"CI Error: Resource '".$obj."' already exists and is not a ".$class." instance."
+		);
+		$this->load->library($lib, NULL, $obj);
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
These changes are separated from #4220 as they are not targeting on error handling but improving test coverages. A specific explanation of the changes could be found in the comment. A note is that the prefix "CI Error" should be removed once the error handling code is merged.