### PR TITLE
refactor error handling in /core/Security

### DIFF
--- a/system/core/Security.php
+++ b/system/core/Security.php
@@ -289,7 +289,7 @@ class CI_Security {
 	 */
 	public function csrf_show_error()
 	{
-		show_error('The action you have requested is not allowed.', 403);
+		throw new RuntimeException('The action you have requested is not allowed.', 403);
 	}
 
 	// --------------------------------------------------------------------

--- a/tests/codeigniter/core/Security_test.php
+++ b/tests/codeigniter/core/Security_test.php
@@ -31,7 +31,7 @@ class Security_test extends CI_TestCase {
 		// Without issuing $_POST[csrf_token_name], this request will triggering CSRF error
 		$_SERVER['REQUEST_METHOD'] = 'POST';
 
-		$this->setExpectedException('RuntimeException', 'CI Error: The action you have requested is not allowed');
+		$this->setExpectedException('RuntimeException', 'The action you have requested is not allowed', 403);
 
 		$this->security->csrf_verify();
 	}


### PR DESCRIPTION
- refactor error handling
- remove error message prefix
- no changes for user guide