### PR TITLE
[ci skip] Make it clear that PHP <5.5 usage is discouraged

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -29,7 +29,7 @@ If you change anything that requires a change to documentation then you will nee
 
 ### Compatibility
 
-CodeIgniter recommends PHP 5.4 or newer to be used, but it should be
+CodeIgniter recommends PHP 5.5 or newer to be used, but it should be
 compatible with PHP 5.2.4 so all code supplied must stick to this
 requirement. If PHP 5.3 (and above) functions or features are used then
 there must be a fallback for PHP 5.2.4.

--- a/readme.rst
+++ b/readme.rst
@@ -29,7 +29,7 @@ guide change log <https://github.com/bcit-ci/CodeIgniter/blob/develop/user_guide
 Server Requirements
 *******************
 
-PHP version 5.4 or newer is recommended.
+PHP version 5.5 or newer is recommended.
 
 It should work on 5.2.4 as well, but we strongly advise you NOT to run
 such old versions of PHP, because of potential security and performance

--- a/user_guide_src/source/contributing/index.rst
+++ b/user_guide_src/source/contributing/index.rst
@@ -103,7 +103,7 @@ must also be updated for every change. Also PHPDoc blocks must be maintained.
 Compatibility
 =============
 
-CodeIgniter recommends PHP 5.4 or newer to be used, but it should be
+CodeIgniter recommends PHP 5.5 or newer to be used, but it should be
 compatible with PHP 5.2.4 so all code supplied must stick to this
 requirement. If PHP 5.3 (and above) functions or features are used then
 there must be a fallback for PHP 5.2.4.

--- a/user_guide_src/source/general/requirements.rst
+++ b/user_guide_src/source/general/requirements.rst
@@ -2,7 +2,7 @@
 Server Requirements
 ###################
 
-`PHP <http://php.net/>`_ version 5.4 or newer is recommended.
+`PHP <http://php.net/>`_ version 5.5 or newer is recommended.
 
 It should work on 5.2.4 as well, but we strongly advise you NOT to run
 such old versions of PHP, because of potential security and performance

--- a/user_guide_src/source/general/styleguide.rst
+++ b/user_guide_src/source/general/styleguide.rst
@@ -345,7 +345,7 @@ inability for CodeIgniter to send proper headers.
 Compatibility
 =============
 
-CodeIgniter recommends PHP 5.4 or newer to be used, but it should be
+CodeIgniter recommends PHP 5.5 or newer to be used, but it should be
 compatible with PHP 5.2.4. Your code must either be compatible with this
 requirement, provide a suitable fallback, or be an optional feature that
 dies quietly without affecting a user's application.


### PR DESCRIPTION
PHP 5.4 reached end of life

Signed-off-by: Claudio Galdiolo <claudio.galdiolo@gmail.com>