### PR TITLE
Grammar correction in database configuration guide

### DIFF
--- a/user_guide_src/source/database/configuration.rst
+++ b/user_guide_src/source/database/configuration.rst
@@ -7,7 +7,7 @@ connection values (username, password, database name, etc.). The config
 file is located at application/config/database.php. You can also set
 database connection values for specific
 :doc:`environments <../libraries/config>` by placing **database.php**
-it the respective environment config folder.
+in the respective environment config folder.
 
 The config settings are stored in a multi-dimensional array with this
 prototype::


### PR DESCRIPTION
"it" changed to "in" on line 10. "in" seems like the correct word to be used there. Small change.