### PR TITLE
Added truncate function in string helper and updated relative documentation

### DIFF
--- a/system/helpers/string_helper.php
+++ b/system/helpers/string_helper.php
@@ -303,3 +303,22 @@ if ( ! function_exists('repeater'))
 		return ($num > 0) ? str_repeat($data, $num) : '';
 	}
 }
+
+// ------------------------------------------------------------------------
+
+if ( ! function_exists('truncate'))
+{
+	/**
+	 * Limit the number of characters in a string.
+	 *
+	 * @param  string  $str
+	 * @param  int     $limit
+	 * @param  string  $end
+	 * @return string
+	 */
+	function truncate($str, $limit = 100, $end = '...')
+	{
+		if (mb_strlen($str) <= $limit) return $str;
+		return rtrim(mb_substr($str, 0, $limit, 'UTF-8')).$end;
+	}
+}

--- a/user_guide_src/source/helpers/string_helper.rst
+++ b/user_guide_src/source/helpers/string_helper.rst
@@ -221,3 +221,17 @@ The following functions are available:
 
 		$string = "Joe's \"dinner\"";
 		$string = strip_quotes($string); //results in "Joes dinner"
+		
+
+.. php:function:: truncate($str)
+
+	:param	string	$str: Input string
+	:param int $limit: maximum number of resulting characters to show
+	:param	string	$end: option argument string that concatenated with the end of the truncated string. Default value is "..."
+	:returns:	Limited character string concatenated with end string
+	:rtype:	string
+
+	Limits the number of characters in a string. Example::
+
+		$string = "Hello CodeIgniter, I am developer";
+		$string = truncate($string,17); //results in "Hello CodeIgniter..."


### PR DESCRIPTION
Added truncate function.
Limits the number of characters in a string.
Example::
		$string = "Hello CodeIgniter, I am developer";
		$string = truncate($string,17); //results in "Hello CodeIgniter..."

Signed-off-by: pmbaldha <pmbaldha@gmail.com>