### PR TITLE
config directory constants

### DIFF
--- a/system/core/CodeIgniter.php
+++ b/system/core/CodeIgniter.php
@@ -66,8 +66,10 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 	{
 		require_once(APPPATH.'config/'.ENVIRONMENT.'/constants.php');
 	}
-
-	require_once(APPPATH.'config/constants.php');
+        else
+        {    
+                require_once(APPPATH.'config/constants.php');
+        }
 
 /*
  * ------------------------------------------------------


### PR DESCRIPTION
when I needed to keep all my files in 3 settings folders for my different environments I threw me an error that could not read the " constants.php " file , because they always tried to read from the root "config /".

Hope that helps

Greetings