### PR TITLE
[ci skip] Fix file name in documentation

### DIFF
--- a/user_guide_src/source/libraries/form_validation.rst
+++ b/user_guide_src/source/libraries/form_validation.rst
@@ -116,7 +116,7 @@ this code and save it to your application/views/ folder::
 The Controller
 ==============
 
-Using a text editor, create a controller called form.php. In it, place
+Using a text editor, create a controller called Form.php. In it, place
 this code and save it to your application/controllers/ folder::
 
 	<?php


### PR DESCRIPTION
With case-sensitive filesystem, visiting example.com/index.php/form/ returns a '404 Page Not Found' error