### PR TITLE
Create foreign keys with CI_DB_Forge

### DIFF
--- a/system/database/DB_forge.php
+++ b/system/database/DB_forge.php
@@ -324,6 +324,7 @@ abstract class CI_DB_forge {
 	 * @param $reference_column
 	 * @param $on_update
 	 * @param $on_delete
+	 * @author Lukas B. (greensn0w)
 	 * @return bool
 	 */
 	public function add_foreign_key($index_name, $reference_table, $reference_column, $on_update = 'no action', $on_delete = 'no action')
@@ -361,6 +362,7 @@ abstract class CI_DB_forge {
 	 * Add Foreign Key Helper
 	 *
 	 * @param $table_name
+	 * @author Lukas B. (greensn0w)
 	 * @return array
 	 */
 	private function _add_foreign_keys($table_name)


### PR DESCRIPTION
Given we have this table:

```
Table: assignments
+-----------+------+--------+-----------+-------+
|   Field   | Type | Length | Unsigned? | Null? |
+-----------+------+--------+-----------+-------+
| id        | INT  |     11 | Y         | N     |
| parent_id | INT  |     11 | Y         | Y     |
+-----------+------+--------+-----------+-------+
```

Until now you had to add a foreign key like this:
```php
[...]
$this->dbforge->create_table('assignments');
$this->db->query('ALTER TABLE `assignments` ADD FOREIGN KEY (`parent_id`) REFERENCES `assignments` (`id`)');
```

With this PR you can use a convenience function to add a foreign key:
```php
$this->dbforge->add_foreign_key('parent_id', 'assignments', 'id');
$this->dbforge->create_table('assignments');
```
<hr/>

`->add_foreign_key(..)` takes these arguments:
```php
$this->dbforge->add_foreign_key($index_name, $reference_table, $reference_column, $on_update = 'no action', $on_delete = 'no action')
```
The case of `$on_update` and `$on_delete` is ignored and will be converted to upper case.
<hr/>

All key "blueprints" are stored in an array.

No key is created until `->create_table(...)` is executed