### PR TITLE
add documentation of exceptions for Loader

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -230,6 +230,10 @@ class CI_Loader {
 	 * @param	string	$name		An optional object name to assign to
 	 * @param	bool	$db_conn	An optional database connection configuration to initialize
 	 * @return	object
+	 * @throws	RuntimeException	If the name of model is already being used by another resource
+	 * @throws	RuntimeException	If model file exists but does not declare class
+	 * @throws	RuntimeException	If unable to load specified model
+	 * @throws	RuntimeException	If class already exists but does not extend CI_Model
 	 */
 	public function model($model, $name = '', $db_conn = FALSE)
 	{
@@ -558,6 +562,7 @@ class CI_Loader {
 	 *
 	 * @param	string|string[]	$helpers	Helper name(s)
 	 * @return	object
+	 * @throws	RuntimeException	If unable to load the requested file
 	 */
 	public function helper($helpers = array())
 	{
@@ -835,6 +840,7 @@ class CI_Loader {
 	 * @used-by	CI_Loader::file()
 	 * @param	array	$_ci_data	Data to load
 	 * @return	object
+	 * @throws	RuntimeException	If unable to load the requsted file
 	 */
 	protected function _ci_load($_ci_data)
 	{
@@ -972,6 +978,7 @@ class CI_Loader {
 	 * @param	mixed	$params		Optional parameters to pass to the class constructor
 	 * @param	string	$object_name	Optional object name to assign to
 	 * @return	void
+	 * @throws	RuntimeException	If unable to load the requested class
 	 */
 	protected function _ci_load_library($class, $params = NULL, $object_name = NULL)
 	{
@@ -1155,6 +1162,8 @@ class CI_Loader {
 	 *						NULL to search in config paths;
 	 *						array containing configuration data
 	 * @param	string		$object_name	Optional object name to assign to
+	 * @throws	RuntimeException	If the class name is invalid or non-existent
+	 * @throws	RuntimeException	If resource already exists but is not an instance of the requested class
 	 * @return	void
 	 */
 	protected function _ci_init_library($class, $prefix, $config = FALSE, $object_name = NULL)

--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -230,10 +230,7 @@ class CI_Loader {
 	 * @param	string	$name		An optional object name to assign to
 	 * @param	bool	$db_conn	An optional database connection configuration to initialize
 	 * @return	object
-	 * @throws	RuntimeException	If the name of model is already being used by another resource
-	 * @throws	RuntimeException	If model file exists but does not declare class
-	 * @throws	RuntimeException	If unable to load specified model
-	 * @throws	RuntimeException	If class already exists but does not extend CI_Model
+	 * @throws	RuntimeException	In case of failure
 	 */
 	public function model($model, $name = '', $db_conn = FALSE)
 	{
@@ -1162,8 +1159,7 @@ class CI_Loader {
 	 *						NULL to search in config paths;
 	 *						array containing configuration data
 	 * @param	string		$object_name	Optional object name to assign to
-	 * @throws	RuntimeException	If the class name is invalid or non-existent
-	 * @throws	RuntimeException	If resource already exists but is not an instance of the requested class
+	 * @throws	RuntimeException	In case of failure
 	 * @return	void
 	 */
 	protected function _ci_init_library($class, $prefix, $config = FALSE, $object_name = NULL)

--- a/user_guide_src/source/libraries/loader.rst
+++ b/user_guide_src/source/libraries/loader.rst
@@ -226,7 +226,7 @@ Class Reference
 		:param	bool	$return: Whether to return the loaded view
 		:returns:	View content string if $return is set to TRUE, otherwise CI_Loader instance (method chaining)
 		:rtype:	mixed
-		:throws:	RuntimeException	If unable to load the requsted file
+		:throws:	RuntimeException	In case of failure
 
 		This method is used to load your View files. If you haven't read the
 		:doc:`Views <../general/views>` section of the user guide it is
@@ -358,7 +358,7 @@ Class Reference
 		:param	mixed	$helpers: Helper name as a string or an array containing multiple helpers
 		:returns:	CI_Loader instance (method chaining)
 		:rtype:	CI_Loader
-		:throws:	RuntimeException	If unable to load the requested file
+		:throws:	RuntimeException	In case of failure
 
 		This method loads helper files, where file_name is the name of the
 		file, without the _helper.php extension.
@@ -369,7 +369,7 @@ Class Reference
 		:param	bool	$return: Whether to return the loaded file
 		:returns:	File contents if $return is set to TRUE, otherwise CI_Loader instance (method chaining)
 		:rtype:	mixed
-		:throws:	RuntimeException	If unable to load the requsted file
+		:throws:	RuntimeException	In case of failure
 
 		This is a generic file loading method. Supply the filepath and name in
 		the first parameter and it will open and read the file. By default the

--- a/user_guide_src/source/libraries/loader.rst
+++ b/user_guide_src/source/libraries/loader.rst
@@ -86,9 +86,7 @@ Class Reference
 		:param	string	$object_name: Optional object name to assign the library to
 		:returns:	CI_Loader instance (method chaining)
 		:rtype:	CI_Loader
-		:throws:	RuntimeException	If unable to load the requested class
-		:throws:	RuntimeException	If the class name is invalid or non-existent
-		:throws:	RuntimeException	If resource already exists but is not an instance of the requested class
+		:throws:	RuntimeException	In case of failure
 
 		This method is used to load core classes.
 
@@ -166,9 +164,7 @@ Class Reference
 		:param	string	$object_name: Optional object name to assign the library to
 		:returns:	CI_Loader instance (method chaining)
 		:rtype:	CI_Loader
-		:throws:	RuntimeException	If unable to load the requested class
-		:throws:	RuntimeException	If the class name is invalid or non-existent
-		:throws:	RuntimeException	If resource already exists but is not an instance of the requested class
+		:throws:	RuntimeException	In case of failure
 
 		This method is used to load driver libraries, acts very much like the
 		``library()`` method.
@@ -306,10 +302,7 @@ Class Reference
 		:param	string	$db_conn: Optional database configuration group to load
 		:returns:	CI_Loader instance (method chaining)
 		:rtype:	CI_Loader
-		:throws:	RuntimeException	If the name of model is already being used by another resource
-		:throws:	RuntimeException	If model file exists but does not declare class
-		:throws:	RuntimeException	If unable to load specified model
-		:throws:	RuntimeException	If class already exists but does not extend CI_Model
+		:throws:	RuntimeException	In case of failure
 
 		::
 

--- a/user_guide_src/source/libraries/loader.rst
+++ b/user_guide_src/source/libraries/loader.rst
@@ -86,6 +86,9 @@ Class Reference
 		:param	string	$object_name: Optional object name to assign the library to
 		:returns:	CI_Loader instance (method chaining)
 		:rtype:	CI_Loader
+		:throws:	RuntimeException	If unable to load the requested class
+		:throws:	RuntimeException	If the class name is invalid or non-existent
+		:throws:	RuntimeException	If resource already exists but is not an instance of the requested class
 
 		This method is used to load core classes.
 
@@ -163,6 +166,9 @@ Class Reference
 		:param	string	$object_name: Optional object name to assign the library to
 		:returns:	CI_Loader instance (method chaining)
 		:rtype:	CI_Loader
+		:throws:	RuntimeException	If unable to load the requested class
+		:throws:	RuntimeException	If the class name is invalid or non-existent
+		:throws:	RuntimeException	If resource already exists but is not an instance of the requested class
 
 		This method is used to load driver libraries, acts very much like the
 		``library()`` method.
@@ -224,6 +230,7 @@ Class Reference
 		:param	bool	$return: Whether to return the loaded view
 		:returns:	View content string if $return is set to TRUE, otherwise CI_Loader instance (method chaining)
 		:rtype:	mixed
+		:throws:	RuntimeException	If unable to load the requsted file
 
 		This method is used to load your View files. If you haven't read the
 		:doc:`Views <../general/views>` section of the user guide it is
@@ -299,6 +306,10 @@ Class Reference
 		:param	string	$db_conn: Optional database configuration group to load
 		:returns:	CI_Loader instance (method chaining)
 		:rtype:	CI_Loader
+		:throws:	RuntimeException	If the name of model is already being used by another resource
+		:throws:	RuntimeException	If model file exists but does not declare class
+		:throws:	RuntimeException	If unable to load specified model
+		:throws:	RuntimeException	If class already exists but does not extend CI_Model
 
 		::
 
@@ -354,6 +365,7 @@ Class Reference
 		:param	mixed	$helpers: Helper name as a string or an array containing multiple helpers
 		:returns:	CI_Loader instance (method chaining)
 		:rtype:	CI_Loader
+		:throws:	RuntimeException	If unable to load the requested file
 
 		This method loads helper files, where file_name is the name of the
 		file, without the _helper.php extension.
@@ -364,6 +376,7 @@ Class Reference
 		:param	bool	$return: Whether to return the loaded file
 		:returns:	File contents if $return is set to TRUE, otherwise CI_Loader instance (method chaining)
 		:rtype:	mixed
+		:throws:	RuntimeException	If unable to load the requsted file
 
 		This is a generic file loading method. Supply the filepath and name in
 		the first parameter and it will open and read the file. By default the


### PR DESCRIPTION
add documentation for #4220 
part of #4189 

In Loader.php, documentation is added for every function which directly triggers an exception.

In the user guide, documentation of exceptions is added for every function which is possible to throw an exception during the execution(directly or indirectly through internal functions).
