### PR TITLE
Allowing redis cache to search keys and return their values

### DIFF
--- a/system/libraries/Cache/drivers/Cache_redis.php
+++ b/system/libraries/Cache/drivers/Cache_redis.php
@@ -141,17 +141,35 @@ class CI_Cache_redis extends CI_Driver
 	 * @param	string	Cache ID
 	 * @return	mixed
 	 */
-	public function get($key)
-	{
-		$value = $this->_redis->get($key);
+	 public function get($key)
+ 	{
+ 		$values = array();
+ 		if (strpos($key,'*') !== FALSE) //we are searching
+ 		{
+ 			$keys = $this->_redis->keys($key);
+ 		}
+ 		else //single key
+ 		{
+ 			$keys = array($key);
+ 		}
 
-		if ($value !== FALSE && isset($this->_serialized[$key]))
-		{
-			return unserialize($value);
-		}
-
-		return $value;
-	}
+ 		foreach ($keys as $key)
+ 		{
+ 			$values[$key] = $this->_redis->get($key);
+ 			if ($values[$key] !== FALSE && isset($this->_serialized[$key]))
+ 			{
+ 				$values[$key] = unserialize($values[$key]);
+ 			}
+ 		}
+ 		if (count($values) == 1)
+ 		{
+ 			return $values[$key];
+ 		}
+ 		else //single key
+ 		{
+ 			return $values;
+ 		}
+ 	}
 
 	// ------------------------------------------------------------------------
 


### PR DESCRIPTION
This code update allows those who use Redis to search for keys and get their values returned. It helps when you branches in Redis for storing values.

Code Example:
```
$this->load->driver('cache',array('adapter' => 'redis'));
$this->cache->save('user-5:event-1', $event1, 0);
$this->cache->save('user-5:event-2', $event2, 0);
$this->cache->get("user-5:event-*");
//returns values for both 'user-5:event-1' and 'user-5:event-2'
```