### PR TITLE
Detecting if database connection was not successful

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -361,6 +361,10 @@ class CI_Loader {
 
 		// Load the DB class
 		$CI->db =& DB($params, $query_builder);
+		if (!$CI->db->conn_id) 
+		{
+			return FALSE;
+		}
 		return $this;
 	}
 


### PR DESCRIPTION
Hi All, 
I had a problem when I wanted to connect to the database from my code. I used this line:

    $this->load->database();

Unfortunately this way I cannot check if the database connection was successful because the `database()` method of the CI_Loader class doesn't return FALSE in case of the faulty connection attempt. This is impractical and contradicts to the comment of the method:

     * @return    object|bool    Database object if $return is set to TRUE,
     *                    FALSE on failure, CI_Loader instance in any other case

So, I added the appropriate check before returning from the method. 

After this, I can check the connection in my code this way:

    $res = $this->load->database();
    if (!$res) 
    {
        throw new Exception("Database connection error");
    }

I hope this modification helps other CI users. I know that the migration to throwing exceptions is in progress for the next major CI versions but this modification is a small one and it doesn't require modifying the existing projects relying on the present version of CI. So, I think the next minor version change could contain this bugfix. It would make me really happy. :)