### PR TITLE
Fix mismatched brackets in documentation

### DIFF
--- a/user_guide_src/source/database/db_driver_reference.rst
+++ b/user_guide_src/source/database/db_driver_reference.rst
@@ -83,7 +83,7 @@ This article is intended to be a reference for them.
 
 		Database version number.
 
-	.. php:method:: query($sql[, $binds = FALSE[, $return_object = NULL]]])
+	.. php:method:: query($sql[, $binds = FALSE[, $return_object = NULL]])
 
 		:param	string	$sql: The SQL statement to execute
 		:param	array	$binds: An array of binding data

--- a/user_guide_src/source/helpers/cookie_helper.rst
+++ b/user_guide_src/source/helpers/cookie_helper.rst
@@ -25,7 +25,7 @@ Available Functions
 The following functions are available:
 
 
-.. php:function:: set_cookie($name[, $value = ''[, $expire = ''[, $domain = ''[, $path = '/'[, $prefix = ''[, $secure = FALSE[, $httponly = FALSE]]]]]]]])
+.. php:function:: set_cookie($name[, $value = ''[, $expire = ''[, $domain = ''[, $path = '/'[, $prefix = ''[, $secure = FALSE[, $httponly = FALSE]]]]]]])
 
 	:param	mixed	$name: Cookie name *or* associative array of all of the parameters available to this function
 	:param	string	$value: Cookie value
@@ -42,7 +42,7 @@ The following functions are available:
 	a description of its use, as this function is an alias for
 	``CI_Input::set_cookie()``.
 
-.. php:function:: get_cookie($index[, $xss_clean = NULL]])
+.. php:function:: get_cookie($index[, $xss_clean = NULL])
 
 	:param	string	$index: Cookie name
 	:param	bool	$xss_clean: Whether to apply XSS filtering to the returned value
@@ -56,7 +56,7 @@ The following functions are available:
 	the ``$config['cookie_prefix']`` that you might've set in your
 	*application/config/config.php* file.
 
-.. php:function:: delete_cookie($name[, $domain = ''[, $path = '/'[, $prefix = '']]]])
+.. php:function:: delete_cookie($name[, $domain = ''[, $path = '/'[, $prefix = '']]])
 
 	:param	string	$name: Cookie name
 	:param	string	$domain: Cookie domain (usually: .yourdomain.com)

--- a/user_guide_src/source/helpers/form_helper.rst
+++ b/user_guide_src/source/helpers/form_helper.rst
@@ -108,7 +108,7 @@ The following functions are available:
 				<input type="hidden" name="member_id" value="234" />
 
 
-.. php:function:: form_open_multipart([$action = ''[, $attributes = array()[, $hidden = array()]])
+.. php:function:: form_open_multipart([$action = ''[, $attributes = array()[, $hidden = array()]]])
 
 	:param	string	$action: Form action/target URI string
 	:param	array	$attributes: HTML attributes
@@ -187,7 +187,7 @@ The following functions are available:
 			<input type="hidden" name="email" value="john@example.com" id="hiddenemail" class="hiddenemail" />
 		*/
 
-.. php:function:: form_input([$data = ''[, $value = ''[, $extra = '']])
+.. php:function:: form_input([$data = ''[, $value = ''[, $extra = '']]])
 
 	:param	array	$data: Field attributes data
 	:param	string	$value: Field value

--- a/user_guide_src/source/libraries/sessions.rst
+++ b/user_guide_src/source/libraries/sessions.rst
@@ -842,7 +842,7 @@ Class Reference
 		.. note:: This method is DEPRECATED. Use ``userdata()``
 			with no parameters instead.
 
-	.. php:method:: get_userdata()
+	.. php:method:: &get_userdata()
 
 		:returns:	A reference to ``$_SESSION``
 		:rtype:	array

--- a/user_guide_src/source/libraries/sessions.rst
+++ b/user_guide_src/source/libraries/sessions.rst
@@ -842,7 +842,7 @@ Class Reference
 		.. note:: This method is DEPRECATED. Use ``userdata()``
 			with no parameters instead.
 
-	.. php:method:: &get_userdata()
+	.. php:method:: get_userdata()
 
 		:returns:	A reference to ``$_SESSION``
 		:rtype:	array

--- a/user_guide_src/source/libraries/trackback.rst
+++ b/user_guide_src/source/libraries/trackback.rst
@@ -239,7 +239,7 @@ Class Reference
 		This method simply validates the incoming TB data, returning TRUE on success and FALSE on failure.
 		If the data is valid it is set to the ``$this->data`` array so that it can be inserted into a database.
 
-	.. php:method:: send_error([$message = 'Incomplete information')
+	.. php:method:: send_error([$message = 'Incomplete information'])
 
 		:param	string	$message: Error message
 		:rtype: void


### PR DESCRIPTION
Sphinx generates incomplete/incorrect HTML output because there are
mismatched brackets in the documentation.

Signed-off-by: Phil Scherer <pscher1@umbc.edu>