### PR TITLE
Bugfix: child class in valid drivers

### DIFF
--- a/system/libraries/Driver.php
+++ b/system/libraries/Driver.php
@@ -103,7 +103,7 @@ class CI_Driver_Library {
 		$child_name = $this->lib_name.'_'.$child;
 
 		// See if requested child is a valid driver
-		if ( ! in_array($child, $this->valid_drivers))
+		if ( ! in_array($child_name, $this->valid_drivers))
 		{
 			// The requested driver isn't valid!
 			$msg = 'Invalid driver requested: '.$child_name;

--- a/tests/codeigniter/libraries/Driver_test.php
+++ b/tests/codeigniter/libraries/Driver_test.php
@@ -31,7 +31,7 @@ class Driver_test extends CI_TestCase {
 	public function test_load_driver()
 	{
 		// Create driver file
-		$driver = 'basic';
+		$driver = 'Driver_basic';
 		$file = $this->name.'_'.$driver;
 		$class = 'CI_'.$file;
 		$prop = 'called';


### PR DESCRIPTION
$child will never be in $valid_drivers unless backwards compatibility with CI2 and the docs are wrong.