### PR TITLE
allow adding variables to the language line

### DIFF
--- a/system/core/Lang.php
+++ b/system/core/Lang.php
@@ -200,7 +200,7 @@ class CI_Lang {
 		
 		if(!empty($placeholders))
 		{
-			$value = preg_replace_callback(/\[(.*)\]/', function ($preg) use ($placeholders) { return isset($placeholders[$preg[1]]) ? $placeholders[$preg[1]] : $preg[0]; }, $value);
+			$value = preg_replace_callback('/\[(.*)\]/', function ($preg) use ($placeholders) { return isset($placeholders[$preg[1]]) ? $placeholders[$preg[1]] : $preg[0]; }, $value);
 		}
 
 		return $value;

--- a/system/core/Lang.php
+++ b/system/core/Lang.php
@@ -200,7 +200,7 @@ class CI_Lang {
 		
 		if(!empty($placeholders))
 		{
-			$value = preg_replace_callback('/\[[^\s]+\]/', function ($preg) use ($placeholders) { return isset($placeholders[$preg[1]]) ? $placeholders[$preg[1]] : $preg[0]; }, $value);
+			$value = preg_replace_callback(/\[(.*)\]/', function ($preg) use ($placeholders) { return isset($placeholders[$preg[1]]) ? $placeholders[$preg[1]] : $preg[0]; }, $value);
 		}
 
 		return $value;

--- a/system/core/Lang.php
+++ b/system/core/Lang.php
@@ -200,7 +200,7 @@ class CI_Lang {
 		
 		if(!empty($placeholders))
 		{
-			$value = preg_replace_callback('/\[(.*?)\]/', function ($preg) use ($placeholders) { return isset($placeholders[$preg[1]]) ? $placeholders[$preg[1]] : $preg[0]; }, $value);
+			$value = preg_replace_callback('/\[[^\s]+\]/', function ($preg) use ($placeholders) { return isset($placeholders[$preg[1]]) ? $placeholders[$preg[1]] : $preg[0]; }, $value);
 		}
 
 		return $value;

--- a/system/core/Lang.php
+++ b/system/core/Lang.php
@@ -185,9 +185,10 @@ class CI_Lang {
 	 *
 	 * @param	string	$line		Language line key
 	 * @param	bool	$log_errors	Whether to log an error message if the line is not found
+	 * @param	array	$placeholders	Should we want to pass variables to the language line, we can do it here
 	 * @return	string	Translation
 	 */
-	public function line($line, $log_errors = TRUE)
+	public function line($line, $log_errors = TRUE, $placeholders = array())
 	{
 		$value = isset($this->language[$line]) ? $this->language[$line] : FALSE;
 
@@ -195,6 +196,11 @@ class CI_Lang {
 		if ($value === FALSE && $log_errors === TRUE)
 		{
 			log_message('error', 'Could not find the language line "'.$line.'"');
+		}
+		
+		if(!empty($placeholders))
+		{
+			$value = preg_replace_callback('/\[(.*?)\]/', function ($preg) use ($placeholders) { return isset($placeholders[$preg[1]]) ? $placeholders[$preg[1]] : $preg[0]; }, $value);
 		}
 
 		return $value;


### PR DESCRIPTION
I would like to propose the use of "placeholders" when needing to insert variables inside a translated string. This will be done like in example below:
```php
//inside the language file...
$lang['homepage_hello_known'] = 'Hello, [username]! How are you today? ';
```php

```php
//when calling the language line
$this->lang->line('homepage_hello_known',TRUE,array('username'=>'a username'));
```

If it will be approved, I will work on the documentation