### PR TITLE
Fixes PDO connect when DSN is provided without username & password

### DIFF
--- a/system/database/drivers/pdo/pdo_driver.php
+++ b/system/database/drivers/pdo/pdo_driver.php
@@ -130,7 +130,14 @@ class CI_DB_pdo_driver extends CI_DB {
 
 		try
 		{
-			return new PDO($this->dsn, $this->username, $this->password, $this->options);
+			if (empty($this->username) OR empty($this->password))
+			{
+				return new PDO($this->dsn, NULL, NULL, $this->options);
+			}
+			else
+			{
+				return new PDO($this->dsn, $this->username, $this->password, $this->options);
+			}
 		}
 		catch (PDOException $e)
 		{


### PR DESCRIPTION
If $db['default']['dsn'] is set (including 'user' and 'password' fields), but $db['default']['username'] == '' or $db['default']['password'] == '', CodeIgniter fails to connect. This commit fixes it.