### PR TITLE
Removed deprecated function valid_email

### DIFF
--- a/system/helpers/email_helper.php
+++ b/system/helpers/email_helper.php
@@ -49,23 +49,6 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 
 // ------------------------------------------------------------------------
 
-if ( ! function_exists('valid_email'))
-{
-	/**
-	 * Validate email address
-	 *
-	 * @deprecated	3.0.0	Use PHP's filter_var() instead
-	 * @param	string	$email
-	 * @return	bool
-	 */
-	function valid_email($email)
-	{
-		return (bool) filter_var($email, FILTER_VALIDATE_EMAIL);
-	}
-}
-
-// ------------------------------------------------------------------------
-
 if ( ! function_exists('send_email'))
 {
 	/**

--- a/tests/codeigniter/helpers/email_helper_test.php
+++ b/tests/codeigniter/helpers/email_helper_test.php
@@ -1,6 +1,7 @@
 <?php
 
-class Email_helper_test extends CI_TestCase {
+class Email_helper_test extends CI_TestCase 
+{
 
 	public function set_up()
 	{

--- a/tests/codeigniter/helpers/email_helper_test.php
+++ b/tests/codeigniter/helpers/email_helper_test.php
@@ -1,7 +1,6 @@
 <?php
 
-class Email_helper_test extends CI_TestCase 
-{
+class Email_helper_test extends CI_TestCase {
 
 	public function set_up()
 	{

--- a/tests/codeigniter/helpers/email_helper_test.php
+++ b/tests/codeigniter/helpers/email_helper_test.php
@@ -7,15 +7,7 @@ class Email_helper_test extends CI_TestCase {
 		$this->helper('email');
 	}
 
-	public function test_valid_email()
-	{
-		$this->assertEquals(FALSE, valid_email('test'));
-		$this->assertEquals(FALSE, valid_email('test@test@test.com'));
-		$this->assertEquals(TRUE, valid_email('test@test.com'));
-		$this->assertEquals(TRUE, valid_email('my.test@test.com'));
-		$this->assertEquals(TRUE, valid_email('my.test@subdomain.test.com'));
-	}
-
+	
 	public function test_send_mail()
 	{
 		$this->markTestSkipped("Can't test");

--- a/tests/codeigniter/helpers/email_helper_test.php
+++ b/tests/codeigniter/helpers/email_helper_test.php
@@ -6,7 +6,6 @@ class Email_helper_test extends CI_TestCase {
 	{
 		$this->helper('email');
 	}
-
 	
 	public function test_send_mail()
 	{


### PR DESCRIPTION
I think that valid_email function is not widely used and it should be removed from latest version. Developer should use filter_var($email, FILTER_VALIDATE_EMAIL) instead of valid_email. I am puling request with removing from test case also.