### PR TITLE
Add support for subresource integrity

### DIFF
--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -849,3 +849,26 @@ if ( ! function_exists('function_usable'))
 		return FALSE;
 	}
 }
+
+// ------------------------------------------------------------------------
+
+if ( ! function_exists('base64_file_hash') )
+{
+	/**
+	 * Base64 file hash
+	 *
+	 * Base64 hashes the contents of a file
+	 *
+	 * @param	string	path to file
+	 * @param	string	hash function
+	 * @return	string	base64 encoded hash of file
+	 */
+	function base64_file_hash($path, $hash_function = 'sha256')
+	{
+		$file_contents = file_get_contents($path);
+
+		$hash = hash($hash_function, $file_contents, true);
+
+		return base64_encode($hash);
+	}
+}

--- a/system/helpers/html_helper.php
+++ b/system/helpers/html_helper.php
@@ -280,33 +280,64 @@ if ( ! function_exists('script_tag') )
 		$CI =& get_instance();
 		$script = '<script ';
 
-		if (preg_match('#^([a-z]+:)?//#i', $src))
+		if (is_array($src))
 		{
-			$script .= 'src="'.$src.'" ';
-		}
-		elseif ($index_page === TRUE)
-		{
-			$script .= 'src="'.$CI->config->site_url($src).'" ';
+			foreach ($src as $k => $v)
+			{
+				if ($k === 'src' && ! preg_match('#^([a-z]+:)?//#i', $v))
+				{
+					if ($index_page === TRUE)
+					{
+						$script .= 'src="'.$CI->config->site_url($v).'" ';
+					}
+					else
+					{
+						$script .= 'src="'.$CI->config->slash_item('base_url').$v.'" ';
+					}
+				}
+				else
+				{					
+					if (is_bool($v))
+					{
+						$script .= $k.' ';
+					}
+					else
+					{
+						$script .= $k.'="'.$v.'" ';
+					}
+				}
+			}
 		}
 		else
 		{
-			$script .= 'src="'.$CI->config->slash_item('base_url').$src.'" ';
-		}
+			if (preg_match('#^([a-z]+:)?//#i', $src))
+			{
+				$script .= 'src="'.$src.'" ';
+			}
+			elseif ($index_page === TRUE)
+			{
+				$script .= 'src="'.$CI->config->site_url($src).'" ';
+			}
+			else
+			{
+				$script .= 'src="'.$CI->config->slash_item('base_url').$src.'" ';
+			}
 
-		$script .= 'type="'.$type.'" ';
+			$script .= 'type="'.$type.'" ';
 
-		if ($async !== FALSE)
-		{
-			$script .= 'async ';
-		}
+			if ($async !== FALSE)
+			{
+				$script .= 'async ';
+			}
 
-		if ($local_copy !== '')
-		{
-			$local_copy_path = trim(FCPATH, '/').DIRECTORY_SEPARATOR.trim($local_copy,'/\\');
+			if ($local_copy !== '')
+			{
+				$local_copy_path = trim(FCPATH, '/').DIRECTORY_SEPARATOR.trim($local_copy,'/\\');
 
-			$hash = base64_file_hash($local_copy_path, $hash_function);
+				$hash = base64_file_hash($local_copy_path, $hash_function);
 
-			$script .= 'integrity="'.$hash_function.'-'.$hash.'" ';
+				$script .= 'integrity="'.$hash_function.'-'.$hash.'" ';
+			}
 		}
 
 		return trim($script)."></script>\n";

--- a/system/helpers/html_helper.php
+++ b/system/helpers/html_helper.php
@@ -273,9 +273,11 @@ if ( ! function_exists('link_tag'))
 	 * @param	string	title
 	 * @param	string	media
 	 * @param	bool	should index_page be added to the css path
+	 * @param array	[0] server path to file (relative to FCPATH)
+	 *              [1] hash function
 	 * @return	string
 	 */
-	function link_tag($href = '', $rel = 'stylesheet', $type = 'text/css', $title = '', $media = '', $index_page = FALSE)
+	function link_tag($href = '', $rel = 'stylesheet', $type = 'text/css', $title = '', $media = '', $index_page = FALSE, $use_sri = FALSE)
 	{
 		$CI =& get_instance();
 		$link = '<link ';
@@ -326,6 +328,20 @@ if ( ! function_exists('link_tag'))
 			if ($title !== '')
 			{
 				$link .= 'title="'.$title.'" ';
+			}
+
+			if (is_array($use_sri))
+			{
+				$local_copy_path = trim(FCPATH, '/').DIRECTORY_SEPARATOR.trim($use_sri[0],'/\\');
+				$local_copy_contents = file_get_contents($local_copy_path);
+				$hash_function = $use_sri[1];
+
+				$hash = hash($hash_function, $local_copy_contents, true);
+
+				$hash_base64 = base64_encode($hash);
+
+				$link .= 'integrity="'.$hash_function.'-'.$hash_base64.'" '; 
+
 			}
 		}
 

--- a/system/helpers/html_helper.php
+++ b/system/helpers/html_helper.php
@@ -263,11 +263,11 @@ if ( ! function_exists('doctype'))
 if ( ! function_exists('script_tag') )
 {
 	/**
-	 * Link
+	 * Script
 	 *
 	 * Generates linked script
 	 *
-	 * @param	string	url to script
+	 * @param	mixed	url to script or an array
 	 * @param	string	type
 	 * @param	bool	add async attribute to tag
 	 * @param	bool	should index_page be added to the css path

--- a/system/helpers/html_helper.php
+++ b/system/helpers/html_helper.php
@@ -271,11 +271,11 @@ if ( ! function_exists('script_tag') )
 	 * @param	string	type
 	 * @param	bool	add async attribute to tag
 	 * @param	bool	should index_page be added to the css path
-	 * @param array	[0] server path to file (relative to FCPATH)
-	 *              [1] hash function
+	 * @param string	server path to file (relative to FCPATH)
+	 * @param string	hash function
 	 * @return	string
 	 */
-	function script_tag($src = '', $type = 'text/javascript', $async = FALSE, $index_page = FALSE, $use_sri = FALSE )
+	function script_tag($src = '', $type = 'text/javascript', $async = FALSE, $index_page = FALSE, $local_copy = '', $hash_function = 'sha256' )
 	{
 		$CI =& get_instance();
 		$script = '<script ';
@@ -300,10 +300,9 @@ if ( ! function_exists('script_tag') )
 			$script .= 'async ';
 		}
 
-		if (is_array($use_sri))
+		if ($local_copy !== '')
 		{
-			$local_copy_path = trim(FCPATH, '/').DIRECTORY_SEPARATOR.trim($use_sri[0],'/\\');
-			$hash_function = $use_sri[1];
+			$local_copy_path = trim(FCPATH, '/').DIRECTORY_SEPARATOR.trim($local_copy,'/\\');
 
 			$hash = base64_file_hash($local_copy_path, $hash_function);
 
@@ -330,11 +329,11 @@ if ( ! function_exists('link_tag'))
 	 * @param	string	title
 	 * @param	string	media
 	 * @param	bool	should index_page be added to the css path
-	 * @param array	[0] server path to file (relative to FCPATH)
-	 *              [1] hash function
+	 * @param string	server path to file (relative to FCPATH)
+	 * @param string	hash function
 	 * @return	string
 	 */
-	function link_tag($href = '', $rel = 'stylesheet', $type = 'text/css', $title = '', $media = '', $index_page = FALSE, $use_sri = FALSE)
+	function link_tag($href = '', $rel = 'stylesheet', $type = 'text/css', $title = '', $media = '', $index_page = FALSE, $local_copy = '', $hash_function = 'sha256')
 	{
 		$CI =& get_instance();
 		$link = '<link ';
@@ -387,15 +386,13 @@ if ( ! function_exists('link_tag'))
 				$link .= 'title="'.$title.'" ';
 			}
 
-			if (is_array($use_sri))
+			if ($local_copy !== '')
 			{
-				$local_copy_path = trim(FCPATH, '/').DIRECTORY_SEPARATOR.trim($use_sri[0],'/\\');
-				$hash_function = $use_sri[1];
+				$local_copy_path = trim(FCPATH, '/').DIRECTORY_SEPARATOR.trim($local_copy,'/\\');
 
 				$hash = base64_file_hash($local_copy_path, $hash_function);
 
-				$link .= 'integrity="'.$hash_function.'-'.$hash.'" '; 
-
+				$link .= 'integrity="'.$hash_function.'-'.$hash.'" ';
 			}
 		}
 

--- a/system/helpers/html_helper.php
+++ b/system/helpers/html_helper.php
@@ -260,6 +260,66 @@ if ( ! function_exists('doctype'))
 
 // ------------------------------------------------------------------------
 
+if ( ! function_exists('script_tag') )
+{
+	/**
+	 * Link
+	 *
+	 * Generates linked script
+	 *
+	 * @param	string	url to script
+	 * @param	string	type
+	 * @param	bool	add async attribute to tag
+	 * @param	bool	should index_page be added to the css path
+	 * @param array	[0] server path to file (relative to FCPATH)
+	 *              [1] hash function
+	 * @return	string
+	 */
+	function script_tag($src = '', $type = 'text/javascript', $async = FALSE, $index_page = FALSE, $use_sri = FALSE )
+	{
+		$CI =& get_instance();
+		$script = '<script ';
+
+		if (preg_match('#^([a-z]+:)?//#i', $src))
+		{
+			$script .= 'src="'.$src.'" ';
+		}
+		elseif ($index_page === TRUE)
+		{
+			$script .= 'src="'.$CI->config->site_url($src).'" ';
+		}
+		else
+		{
+			$script .= 'src="'.$CI->config->slash_item('base_url').$src.'" ';
+		}
+
+		$script .= 'type="'.$type.'" ';
+
+		if ($async !== FALSE)
+		{
+			$script .= 'async ';
+		}
+
+		if (is_array($use_sri))
+		{
+			$local_copy_path = trim(FCPATH, '/').DIRECTORY_SEPARATOR.trim($use_sri[0],'/\\');
+			$local_copy_contents = file_get_contents($local_copy_path);
+			$hash_function = $use_sri[1];
+
+			$hash = hash($hash_function, $local_copy_contents, true);
+
+			$hash_base64 = base64_encode($hash);
+
+			$script .= 'integrity="'.$hash_function.'-'.$hash_base64.'" ';
+		}
+
+		return trim($script)."></script>\n";
+
+	}
+}
+
+// ------------------------------------------------------------------------
+
 if ( ! function_exists('link_tag'))
 {
 	/**

--- a/system/helpers/html_helper.php
+++ b/system/helpers/html_helper.php
@@ -303,14 +303,11 @@ if ( ! function_exists('script_tag') )
 		if (is_array($use_sri))
 		{
 			$local_copy_path = trim(FCPATH, '/').DIRECTORY_SEPARATOR.trim($use_sri[0],'/\\');
-			$local_copy_contents = file_get_contents($local_copy_path);
 			$hash_function = $use_sri[1];
 
-			$hash = hash($hash_function, $local_copy_contents, true);
+			$hash = base64_file_hash($local_copy_path, $hash_function);
 
-			$hash_base64 = base64_encode($hash);
-
-			$script .= 'integrity="'.$hash_function.'-'.$hash_base64.'" ';
+			$script .= 'integrity="'.$hash_function.'-'.$hash.'" ';
 		}
 
 		return trim($script)."></script>\n";
@@ -393,14 +390,11 @@ if ( ! function_exists('link_tag'))
 			if (is_array($use_sri))
 			{
 				$local_copy_path = trim(FCPATH, '/').DIRECTORY_SEPARATOR.trim($use_sri[0],'/\\');
-				$local_copy_contents = file_get_contents($local_copy_path);
 				$hash_function = $use_sri[1];
 
-				$hash = hash($hash_function, $local_copy_contents, true);
+				$hash = base64_file_hash($local_copy_path, $hash_function);
 
-				$hash_base64 = base64_encode($hash);
-
-				$link .= 'integrity="'.$hash_function.'-'.$hash_base64.'" '; 
+				$link .= 'integrity="'.$hash_function.'-'.$hash.'" '; 
 
 			}
 		}

--- a/user_guide_src/source/helpers/html_helper.rst
+++ b/user_guide_src/source/helpers/html_helper.rst
@@ -173,6 +173,17 @@ The following functions are available:
 		echo script_tag('js/cookie.js', 'text/javascript', true, false, 'js/cookie.js');
 		// gives <script src="http://site.com/js/cookie.js" type="text/javascript" async integrity="sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU"></script>
 
+	Additionally, an associative array can be passed to the ``link()`` function
+	for complete control over all attributes and values::
+
+		$script = array(
+			'src'	=> 'js/script.js',
+			'async'	=> TRUE,
+		);
+
+		echo script_tag($script);
+		// <script src="http://site.com/js/script.js" async></script>
+
 
 .. php:function:: ul($list[, $attributes = ''])
 

--- a/user_guide_src/source/helpers/html_helper.rst
+++ b/user_guide_src/source/helpers/html_helper.rst
@@ -141,6 +141,38 @@ The following functions are available:
 		echo link_tag($link);
 		// <link href="http://site.com/css/printer.css" rel="stylesheet" type="text/css" media="print" />
 
+.. php:function:: script_tag([$src = ''[, $type = 'text/javascript'[, $async = FALSE[, $index_page = FALSE[, $local_copy = ''[, $hash_function = 'sha256']]]]]])
+
+	:param	string	$src: What script are we linking to
+	:param	string	$type: Type of the linked script
+	:param	string	$asyn: Is the script loaded asyncronously?
+	:param	bool	$index_page: Whether to treat $src as a routed URI string
+	:param	string	$local_copy: Server path to a local copy of the linked script (relative to FCPATH) 
+	:param	string	$hash_function: Integrity hash function
+	:returns:	HTML link tag
+	:rtype:	string
+
+	Lets you create <script /> tags. The parameters are *href*, with optional *rel*,
+	*type*, *title*, *media*, *index_page*, *local_copy*, and *hash_function*.
+
+	*index_page* is a boolean value that specifies if the *href* should have
+	the page specified by ``$config['index_page']`` added to the address it creates.
+
+	*local_copy* and *hash_function* are used to create the subresource *integrity* attribute, which allows a browser to verify that a linked file hasn't been modified in transit
+
+	Example::
+
+		echo script_tag('js/alert.js');
+		// gives <script src="http://site.com/js/alert.js" type="text/javascript"></script>
+
+	Further examples::
+
+		echo script_tag('js/cookie.js', 'text/javascript', true);
+		// gives <script src="http://site.com/js/cookie.js" type="text/javascript" async></script>
+
+		echo script_tag('js/cookie.js', 'text/javascript', true, false, 'js/cookie.js');
+		// gives <script src="http://site.com/js/cookie.js" type="text/javascript" async integrity="sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU"></script>
+
 
 .. php:function:: ul($list[, $attributes = ''])
 

--- a/user_guide_src/source/helpers/html_helper.rst
+++ b/user_guide_src/source/helpers/html_helper.rst
@@ -93,7 +93,7 @@ The following functions are available:
 		img($image_properties);
 		// <img src="http://site.com/index.php/images/picture.jpg" alt="Me, demonstrating how to eat 4 slices of pizza at one time" class="post_images" width="200" height="200" title="That was quite a night" rel="lightbox" />
 
-.. php:function:: link_tag([$href = ''[, $rel = 'stylesheet'[, $type = 'text/css'[, $title = ''[, $media = ''[, $index_page = FALSE]]]]]])
+.. php:function:: link_tag([$href = ''[, $rel = 'stylesheet'[, $type = 'text/css'[, $title = ''[, $media = ''[, $index_page = FALSE[, $local_copy = ''[, $hash_function = 'sha256']]]]]]]])
 
 	:param	string	$href: What are we linking to
 	:param	string	$rel: Relation type
@@ -101,6 +101,8 @@ The following functions are available:
 	:param	string	$title: Link title
 	:param	string	$media: Media type
 	:param	bool	$index_page: Whether to treat $src as a routed URI string
+	:param	string	$local_copy: Server path to a local copy of the linked file (relative to FCPATH) 
+	:param	string	$hash_function: Integrity hash function
 	:returns:	HTML link tag
 	:rtype:	string
 
@@ -110,6 +112,8 @@ The following functions are available:
 
 	*index_page* is a boolean value that specifies if the *href* should have
 	the page specified by ``$config['index_page']`` added to the address it creates.
+
+	*local_copy* and *hash_function* are used to create the subresource *integrity* attribute, which allows a browser to verify that a linked file hasn't been modified in transit
 
 	Example::
 


### PR DESCRIPTION
The idea behind this PR is to implement subresource integrity checks on linked resources (scripts, CSS, etc), as highlighted by [GitHub Engineering](http://githubengineering.com/subresource-integrity/).

The primary use case for this is when an application or website loads a script or a stylesheet hosted by a CDN or some other third-party. The `integrity` attribute contains a hash of a local copy of the linked file, which is used to verify that the linked file is the version that the author expects to have loaded, the idea being as to prevent malicious code from being injected.

The integrity check also works on locally-stored files, though the risk of those files being modified in transit is probably lower.