### PR TITLE
Fixes an issue with uri_string detection.

### DIFF
--- a/system/core/URI.php
+++ b/system/core/URI.php
@@ -203,7 +203,7 @@ class CI_URI {
 
 		// parse_url() returns false if no host is present, but the path or query string
 		// contains a colon followed by a number
-		$uri = parse_url('http://dummy/'.ltrim($_SERVER['REQUEST_URI'], '/'))
+		$uri = parse_url('http://dummy/'.ltrim($_SERVER['REQUEST_URI'], '/'));
 		$query = isset($uri['query']) ? $uri['query'] : '';
 		$uri = isset($uri['path']) ? $uri['path'] : '';
 

--- a/system/core/URI.php
+++ b/system/core/URI.php
@@ -203,7 +203,7 @@ class CI_URI {
 
 		// parse_url() returns false if no host is present, but the path or query string
 		// contains a colon followed by a number
-		$uri = parse_url('http://dummy'.$_SERVER['REQUEST_URI']);
+		$uri = parse_url('http://dummy/'.ltrim($_SERVER['REQUEST_URI'], '/'))
 		$query = isset($uri['query']) ? $uri['query'] : '';
 		$uri = isset($uri['path']) ? $uri['path'] : '';
 


### PR DESCRIPTION
When `$_SERVER['REQUEST_URI']` doesn't have a leading slash, it leads to the dummy URL being generated as `http://dummytest`, instead of `http://dummy/test` as expected, which breaks uri_string detection. This fix makes sure the leading slash is there at all times.