### PR TITLE
Refactor: logic to get the rule's error message

### DIFF
--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -637,7 +637,7 @@ class CI_Form_validation {
 				// Set the message type
 				$type = in_array('required', $rules) ? 'required' : 'isset';
 
-				$line = $this->_get_error_message($type, $row["field"]);
+				$line = $this->_get_error_message($type, $row['field']);
 
 				// Build the error message
 				$message = $this->_build_error_msg($line, $this->_translate_fieldname($row['label']));
@@ -808,7 +808,7 @@ class CI_Form_validation {
 				}
 				else
 				{
-					$line = $this->_get_error_message($rule, $row["field"]);
+					$line = $this->_get_error_message($rule, $row['field']);
 				}
 
 				// Is the parameter we are inserting into the error message the name
@@ -840,8 +840,7 @@ class CI_Form_validation {
 	 * Get the error message for the rule
 	 *
 	 * @param 	string $rule 	The rule name
-	 * @param 	string $field
-	 *
+	 * @param 	string $field	The field name
 	 * @return 	string
 	 */
 	protected function _get_error_message($rule, $field)
@@ -856,7 +855,7 @@ class CI_Form_validation {
 		{
 			return $this->_error_messages[$rule];
 		}
-		elseif (FALSE !== ($tmp = $this->CI->lang->line('form_validation_' . $rule)))
+		elseif (FALSE !== ($tmp = $this->CI->lang->line('form_validation_'.$rule)))
 		{
 			return $tmp;
 		}
@@ -866,7 +865,7 @@ class CI_Form_validation {
 			return $tmp;
 		}
 
-		return $this->CI->lang->line('form_validation_error_message_not_set'). '(' . $rule . ')';
+		return $this->CI->lang->line('form_validation_error_message_not_set').'('.$rule.')';
 	}
 
 	// --------------------------------------------------------------------

--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -637,7 +637,7 @@ class CI_Form_validation {
 				// Set the message type
 				$type = in_array('required', $rules) ? 'required' : 'isset';
 
-				$line = $this->_get_raw_error_message($type, $row);
+				$line = $this->_get_error_message($type, $row["field"]);
 
 				// Build the error message
 				$message = $this->_build_error_msg($line, $this->_translate_fieldname($row['label']));
@@ -808,7 +808,7 @@ class CI_Form_validation {
 				}
 				else
 				{
-					$line = $this->_get_raw_error_message($rule, $row);
+					$line = $this->_get_error_message($rule, $row["field"]);
 				}
 
 				// Is the parameter we are inserting into the error message the name
@@ -839,40 +839,34 @@ class CI_Form_validation {
 	/**
 	 * Get the error message for the rule
 	 *
-	 * @param 	string the rule name.
-	 * @param 	array
+	 * @param 	string $rule 	The rule name
+	 * @param 	string $field
+	 *
 	 * @return 	string
 	 */
-	private function _get_raw_error_message($rule_name, $row)
+	protected function _get_error_message($rule, $field)
 	{
-		$error_message = '';
 		// check if a custom message is defined through validation config row.
-		if (isset($this->_field_data[$row['field']]['errors'][$rule_name]))
+		if (isset($this->_field_data[$field]['errors'][$rule]))
 		{
-			$error_message = $this->_field_data[$row['field']]['errors'][$rule_name];
+			return $this->_field_data[$field]['errors'][$rule];
 		}
 		// check if a custom message has been set using the set_message() function
-		elseif (isset($this->_error_messages[$rule_name]))
+		elseif (isset($this->_error_messages[$rule]))
 		{
-			$error_message = $this->_error_messages[$rule_name];
+			return $this->_error_messages[$rule];
 		}
-		// check if we have an error message in lang file
-		elseif (FALSE !== ($line_tmp = $this->CI->lang->line('form_validation_'.$rule_name)))
+		elseif (FALSE !== ($tmp = $this->CI->lang->line('form_validation_' . $rule)))
 		{
-			$error_message = $line_tmp;
+			return $tmp;
 		}
 		// DEPRECATED support for non-prefixed keys, lang file again
-		elseif (FALSE !== ($line_tmp = $this->CI->lang->line($rule_name, FALSE)))
+		elseif (FALSE !== ($tmp = $this->CI->lang->line($rule, FALSE)))
 		{
-			$error_message = $line_tmp;
-		}
-		// error message not found
-		else
-		{
-			$error_message = $this->CI->lang->line('form_validation_error_message_not_set').'('.$rule_name.')';
+			return $tmp;
 		}
 
-		return $error_message;
+		return $this->CI->lang->line('form_validation_error_message_not_set'). '(' . $rule . ')';
 	}
 
 	// --------------------------------------------------------------------

--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -843,33 +843,33 @@ class CI_Form_validation {
 	 * @param array
 	 * @return string
 	 */
-	private function _get_raw_error_message($key, $row)
+	private function _get_raw_error_message($rule_name, $row)
 	{
 		$error_message = '';
-		// Check if a custom message is defined through validation config row.
-		if (isset($this->_field_data[$row['field']]['errors'][$key]))
+		// check if a custom message is defined through validation config row.
+		if (isset($this->_field_data[$row['field']]['errors'][$rule_name]))
 		{
-			$error_message = $this->_field_data[$row['field']]['errors'][$key];
+			$error_message = $this->_field_data[$row['field']]['errors'][$rule_name];
 		}
 		// check if a custom message has been set using the set_message() function
-		elseif (isset($this->_error_messages[$key]))
+		elseif (isset($this->_error_messages[$rule_name]))
 		{
-			$error_message = $this->_error_messages[$key];
+			$error_message = $this->_error_messages[$rule_name];
 		}
 		// check if we have an error message in lang file
-		elseif (FALSE !== ($line_tmp = $this->CI->lang->line('form_validation_'.$key)))
+		elseif (FALSE !== ($line_tmp = $this->CI->lang->line('form_validation_'.$rule_name)))
 		{
 			$error_message = $line_tmp;
 		}
 		// DEPRECATED support for non-prefixed keys, lang file again
-		elseif (FALSE !== ($line_tmp = $this->CI->lang->line($key, FALSE)))
+		elseif (FALSE !== ($line_tmp = $this->CI->lang->line($rule_name, FALSE)))
 		{
 			$error_message = $line_tmp;
 		}
-		//error message not found
+		// error message not found
 		else
 		{
-			$error_message = $this->CI->lang->line('form_validation_error_message_not_set').'('.$key.')';
+			$error_message = $this->CI->lang->line('form_validation_error_message_not_set').'('.$rule_name.')';
 		}
 
 		return $error_message;

--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -637,21 +637,7 @@ class CI_Form_validation {
 				// Set the message type
 				$type = in_array('required', $rules) ? 'required' : 'isset';
 
-				// Check if a custom message is defined
-				if (isset($this->_field_data[$row['field']]['errors'][$type]))
-				{
-					$line = $this->_field_data[$row['field']]['errors'][$type];
-				}
-				elseif (isset($this->_error_messages[$type]))
-				{
-					$line = $this->_error_messages[$type];
-				}
-				elseif (FALSE === ($line = $this->CI->lang->line('form_validation_'.$type))
-					// DEPRECATED support for non-prefixed keys
-					&& FALSE === ($line = $this->CI->lang->line($type, FALSE)))
-				{
-					$line = 'The field was not set';
-				}
+				$line = $this->_get_raw_error_message($type, $row);
 
 				// Build the error message
 				$message = $this->_build_error_msg($line, $this->_translate_fieldname($row['label']));
@@ -820,23 +806,9 @@ class CI_Form_validation {
 				{
 					$line = $this->CI->lang->line('form_validation_error_message_not_set').'(Anonymous function)';
 				}
-				// Check if a custom message is defined
-				elseif (isset($this->_field_data[$row['field']]['errors'][$rule]))
-				{
-					$line = $this->_field_data[$row['field']]['errors'][$rule];
-				}
-				elseif ( ! isset($this->_error_messages[$rule]))
-				{
-					if (FALSE === ($line = $this->CI->lang->line('form_validation_'.$rule))
-						// DEPRECATED support for non-prefixed keys
-						&& FALSE === ($line = $this->CI->lang->line($rule, FALSE)))
-					{
-						$line = $this->CI->lang->line('form_validation_error_message_not_set').'('.$rule.')';
-					}
-				}
 				else
 				{
-					$line = $this->_error_messages[$rule];
+					$line = $this->_get_raw_error_message($rule, $row);
 				}
 
 				// Is the parameter we are inserting into the error message the name
@@ -860,6 +832,47 @@ class CI_Form_validation {
 				return;
 			}
 		}
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Get the error message for the rule
+	 *
+	 * @param string the rule name.
+	 * @param array
+	 * @return string
+	 */
+	private function _get_raw_error_message($key, $row)
+	{
+		$error_message = '';
+		// Check if a custom message is defined through validation config row.
+		if (isset($this->_field_data[$row['field']]['errors'][$key]))
+		{
+			$error_message = $this->_field_data[$row['field']]['errors'][$key];
+		}
+		// check if a custom message has been set using the set_message() function
+		elseif (isset($this->_error_messages[$key]))
+		{
+			$error_message = $this->_error_messages[$key];
+		}
+		// check if we have an error message in lang file
+		elseif (FALSE !== ($line_tmp = $this->CI->lang->line('form_validation_'.$key)))
+		{
+			$error_message = $line_tmp;
+		}
+		// DEPRECATED support for non-prefixed keys, lang file again
+		elseif (FALSE !== ($line_tmp = $this->CI->lang->line($key, FALSE)))
+		{
+			$error_message = $line_tmp;
+		}
+		//error message not found
+		else
+		{
+			$error_message = $this->CI->lang->line('form_validation_error_message_not_set').'('.$key.')';
+		}
+
+		return $error_message;
 	}
 
 	// --------------------------------------------------------------------

--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -839,9 +839,9 @@ class CI_Form_validation {
 	/**
 	 * Get the error message for the rule
 	 *
-	 * @param string the rule name.
-	 * @param array
-	 * @return string
+	 * @param 	string the rule name.
+	 * @param 	array
+	 * @return 	string
 	 */
 	private function _get_raw_error_message($rule_name, $row)
 	{


### PR DESCRIPTION
Refactored the logic for getting an error message related to a rule.
Don't want to have the same logic in two places.

priority wise:
1. check if a custom message is defined through validation config row.
2. check if a custom message has been set using the set_message() function
3. check if we have an error message in lang file
4. DEPRECATED support for non-prefixed keys, in lang file again
5. error message not found -> default to `"form_validation_error_message_not_set"`
