### PR TITLE
Validate date strings in all formats

### DIFF
--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -1132,6 +1132,26 @@ class CI_Form_validation {
 	// --------------------------------------------------------------------
 
 	/**
+	 * Exists
+	 *
+	 * Check if the input value already exists
+	 * in the specified database field
+	 *
+	 * @param	string	$str
+	 * @param	string	$field
+	 * @return	bool
+	 */
+	public function exists($str, $field)
+	{
+		sscanf($field, '%[^.].%[^.]', $table, $field);
+		return isset($this->CI->db)
+			? ($this->CI->db->limit(1)->get_where($table, array($field => $str))->num_rows() === 1)
+				: FALSE;
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
 	 * Minimum Length
 	 *
 	 * @param	string

--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -1263,7 +1263,7 @@ class CI_Form_validation {
 		}
 
 		$date = DateTime::createFromFormat($format, $str);
-		return $date && $date->format($date) == $str;
+		return $date && $date->format($format) == $str;
 	}
 
 	// --------------------------------------------------------------------

--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -1249,6 +1249,26 @@ class CI_Form_validation {
 	// --------------------------------------------------------------------
 
 	/**
+	 * Valid date
+	 *
+	 * @param	string
+	 * @param	format
+	 * @return	bool
+	 */
+	public function valid_date($str, $format)
+	{
+		if( ! $format)
+		{
+			$format = 'Y-m-d'; //default format
+		}
+
+		$date = DateTime::createFromFormat($format, $str);
+		return $date && $date->format($date) == $str;
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
 	 * Valid Emails
 	 *
 	 * @param	string


### PR DESCRIPTION
Checks whether the string is a valid date. The default format is 'Y-m-d'. 

Format should be compatible with php's [DateTime::createFromFormat](http://php.net/manual/en/datetime.createfromformat.php)
