### PR TITLE
allow custom mysqli option before invoking $mysqli->real_connect

### DIFF
--- a/system/database/drivers/mysqli/mysqli_driver.php
+++ b/system/database/drivers/mysqli/mysqli_driver.php
@@ -158,6 +158,12 @@ class CI_DB_mysqli_driver extends CI_DB {
 			}
 		}
 
+		if(isset($this->options) && is_array($this->options) && $this->options){
+			foreach($this->options as $mysqli_option => $mysqli_value){
+				$mysqli->options($mysqli_option, $mysqli_value);
+			}
+		}
+
 		if ($mysqli->real_connect($hostname, $this->username, $this->password, $this->database, $port, $socket, $client_flags))
 		{
 			// Prior to version 5.7.3, MySQL silently downgrades to an unencrypted connection if SSL setup fails


### PR DESCRIPTION
In some situations, we may want to disable mysql strict mode without changing the sql_mode value globally.If we add the "options" key in the DATABASE CONNECTIVITY SETTINGS, we may able to inject some custom mysqli option before $mysqli->real_connect.For example:

	$db['default'] = array(
		'dsn'	=> '',
		'hostname' => 'localhost',
		'username' => '',
		'password' => '',
		'database' => '',
		'dbdriver' => 'mysqli',
		'dbprefix' => '',
		'pconnect' => FALSE,
		'db_debug' => (ENVIRONMENT !== 'production'),
		'cache_on' => FALSE,
		'cachedir' => '',
		'char_set' => 'utf8',
		'dbcollat' => 'utf8_general_ci',
		'swap_pre' => '',
		'encrypt' => FALSE,
		'compress' => FALSE,
		'stricton' => FALSE,
		'failover' => array(),
		'save_queries' => TRUE,
		'options' => array(
			MYSQLI_INIT_COMMAND => "SET SESSION sql_mode = 'NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'"
		)
	);