### PR TITLE
Allow route callback to return FALSE

### DIFF
--- a/system/core/Router.php
+++ b/system/core/Router.php
@@ -406,6 +406,12 @@ class CI_Router {
 
 					// Execute the callback using the values in matches as its parameters.
 					$val = call_user_func_array($val, $matches);
+					
+					// Try next route if callback returns false
+					if ($val === FALSE)
+					{
+						continue;
+					}
 				}
 				// Are we using the default routing method for back-references?
 				elseif (strpos($val, '$') !== FALSE && strpos($key, '(') !== FALSE)


### PR DESCRIPTION
If route callback returns FALSE, then try next route in routes. This is useful if we have to map the top level path to different controller.