### PR TITLE
Call Hook & Pass Data

### DIFF
--- a/system/core/Hooks.php
+++ b/system/core/Hooks.php
@@ -128,10 +128,17 @@ class CI_Hooks {
 	 * @uses	CI_Hooks::_run_hook()
 	 *
 	 * @param	string	$which	Hook name
+	 * @param	mixed	$data	Hook data
 	 * @return	bool	TRUE on success or FALSE on failure
 	 */
-	public function call_hook($which = '')
+	public function call_hook($which = '', $data = NULL)
 	{
+		if ( ! is_null($data)) $which = array_merge($which, array(
+			'params' => array(
+				'hook_data' => $data
+			)
+		));
+
 		if ( ! $this->enabled OR ! isset($this->hooks[$which]))
 		{
 			return FALSE;

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -26,6 +26,7 @@ Release Date: Not Released
 
    -  Updated :doc:`Security Library <libraries/security>` method ``get_random_bytes()`` to use PHP7's ``random_bytes()`` function when possible.
    -  Updated :doc:`Encryption Library <libraries/security>` method ``create_key()`` to use PHP7's ``random_bytes()`` function when possible.
+   -  Updated :doc:`Hooks Library <libraries/hooks>` method ``call_hook()`` to allow hook data to be passed to the hook functions.
 
 Bug fixes for 3.0.4
 -------------------

--- a/user_guide_src/source/libraries/hooks.rst
+++ b/user_guide_src/source/libraries/hooks.rst
@@ -1,0 +1,20 @@
+###########
+Hooks Class
+###########
+
+.. note:: This class is initialized automatically by the system so there is no
+	need to do it manually.
+
+***************
+Class Reference
+***************
+
+.. php:class:: CI_Hooks
+
+	.. php:method:: call_hook([$which = ''[, $data = NULL]])
+
+		:param	string	$which: hook name
+		:param	mixed	$data: hook data
+		:rtype:	void
+
+		Calls a particular hook.


### PR DESCRIPTION
Issue: #4356

Updated Hooks library method `call_hook()` to allow hook data to be passed to the hook functions.