### PR TITLE
update attributes in the form helper

### DIFF
--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -937,6 +937,8 @@ if ( ! function_exists('_parse_form_attributes'))
 			if ($key === 'value')
 			{
 				$val = html_escape($val);
+				$att .= $key.'="'.$val.'" ';
+				continue;
 			}
 			elseif ($key === 'name' && ! strlen($default['name']))
 			{

--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -208,7 +208,7 @@ if ( ! function_exists('form_input'))
 			'value' => $value
 		);
 
-		return '<input '._parse_form_attributes($data, $defaults)._attributes_to_string($extra)." />\n";
+		return '<input '._parse_form_attributes($data, $defaults)._attributes_to_string($extra)."/>\n";
 	}
 }
 
@@ -254,7 +254,7 @@ if ( ! function_exists('form_upload'))
 		is_array($data) OR $data = array('name' => $data);
 		$data['type'] = 'file';
 
-		return '<input '._parse_form_attributes($data, $defaults)._attributes_to_string($extra)." />\n";
+		return '<input '._parse_form_attributes($data, $defaults)._attributes_to_string($extra)."/>\n";
 	}
 }
 
@@ -454,7 +454,7 @@ if ( ! function_exists('form_checkbox'))
 			unset($defaults['checked']);
 		}
 
-		return '<input '._parse_form_attributes($data, $defaults)._attributes_to_string($extra)." />\n";
+		return '<input '._parse_form_attributes($data, $defaults)._attributes_to_string($extra)."/>\n";
 	}
 }
 
@@ -500,7 +500,7 @@ if ( ! function_exists('form_submit'))
 			'value' => $value
 		);
 
-		return '<input '._parse_form_attributes($data, $defaults)._attributes_to_string($extra)." />\n";
+		return '<input '._parse_form_attributes($data, $defaults)._attributes_to_string($extra)."/>\n";
 	}
 }
 
@@ -524,7 +524,7 @@ if ( ! function_exists('form_reset'))
 			'value' => $value
 		);
 
-		return '<input '._parse_form_attributes($data, $defaults)._attributes_to_string($extra)." />\n";
+		return '<input '._parse_form_attributes($data, $defaults)._attributes_to_string($extra)."/>\n";
 	}
 }
 
@@ -578,15 +578,12 @@ if ( ! function_exists('form_label'))
 
 		if ($id !== '')
 		{
-			$label .= ' for="'.$id.'"';
+			$label .= ' for="'.$id.'" ';
 		}
 
 		if (is_array($attributes) && count($attributes) > 0)
 		{
-			foreach ($attributes as $key => $val)
-			{
-				$label .= ' '.$key.'="'.$val.'"';
-			}
+			$label .= _attributes_to_string($attributes);
 		}
 
 		return $label.'>'.$label_text.'</label>';
@@ -946,7 +943,7 @@ if ( ! function_exists('_parse_form_attributes'))
 				continue;
 			}
 
-			$att .= $key.'="'.$val.'" ';
+			($val) ? $att .= $key.'="'.$val.'" ' :  $att .= $key.' ' ;
 		}
 
 		return $att;
@@ -979,14 +976,14 @@ if ( ! function_exists('_attributes_to_string'))
 
 		if (is_array($attributes))
 		{
-			$atts = '';
+			$att = '';
 
 			foreach ($attributes as $key => $val)
 			{
-				$atts .= ' '.$key.'="'.$val.'"';
+				($val) ? $att .= $key.'="'.$val.'" ' :  $att .= $key.' ' ;
 			}
 
-			return $atts;
+			return $att;
 		}
 
 		if (is_string($attributes))

--- a/tests/codeigniter/helpers/form_helper_test.php
+++ b/tests/codeigniter/helpers/form_helper_test.php
@@ -25,7 +25,7 @@ EOH;
 	public function test_form_input()
 	{
 		$expected = <<<EOH
-<input type="text" name="username" value="johndoe" id="username" maxlength="100" size="50" style="width:50%"  />
+<input type="text" name="username" value="johndoe" id="username" maxlength="100" size="50" style="width:50%" disabled />
 
 EOH;
 
@@ -36,6 +36,7 @@ EOH;
 			'maxlength'   => '100',
 			'size'        => '50',
 			'style'       => 'width:50%',
+			'disabled'    => '',
 		);
 
 		$this->assertEquals($expected, form_input($data));
@@ -46,7 +47,7 @@ EOH;
 	public function test_form_password()
 	{
 		$expected = <<<EOH
-<input type="password" name="password" value=""  />
+<input type="password" name="password" value="" />
 
 EOH;
 
@@ -58,7 +59,7 @@ EOH;
 	public function test_form_upload()
 	{
 		$expected = <<<EOH
-<input type="file" name="attachment"  />
+<input type="file" name="attachment" />
 
 EOH;
 
@@ -195,7 +196,7 @@ EOH;
 	public function test_form_checkbox()
 	{
 		$expected = <<<EOH
-<input type="checkbox" name="newsletter" value="accept" checked="checked"  />
+<input type="checkbox" name="newsletter" value="accept" checked="checked" />
 
 EOH;
 
@@ -207,7 +208,7 @@ EOH;
 	public function test_form_radio()
 	{
 		$expected = <<<EOH
-<input type="radio" name="newsletter" value="accept" checked="checked"  />
+<input type="radio" name="newsletter" value="accept" checked="checked" />
 
 EOH;
 
@@ -219,7 +220,7 @@ EOH;
 	public function test_form_submit()
 	{
 		$expected = <<<EOH
-<input type="submit" name="mysubmit" value="Submit Post!"  />
+<input type="submit" name="mysubmit" value="Submit Post!" />
 
 EOH;
 
@@ -231,7 +232,7 @@ EOH;
 	public function test_form_label()
 	{
 		$expected = <<<EOH
-<label for="username">What is your Name</label>
+<label for="username" >What is your Name</label>
 EOH;
 
 		$this->assertEquals($expected, form_label('What is your Name', 'username'));
@@ -242,7 +243,7 @@ EOH;
 	public function test_form_reset()
 	{
 		$expected = <<<EOH
-<input type="reset" name="myreset" value="Reset"  />
+<input type="reset" name="myreset" value="Reset" />
 
 EOH;
 


### PR DESCRIPTION
if, in one of the key attributes of the array is null form_help returns only the key

example:

```php
$attributes = array(
      'type'     => 'text',
      'disabled' => '',
      'name'     => 'text',
      'id'       => 'text',
      'class'    => 'text',
      'value'    => 'text',
      );
echo form_input($attributes);
```
return 
```html
<input type="text" name="text" value="text" disabled id="text" class="text" />
```