### PR TITLE
Form validation message retrieval fix

### DIFF
--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -752,7 +752,7 @@ class CI_Form_validation {
 						: $rule($postdata);
 
 					// Is $callable set to a rule name?
-					if ($callable !== FALSE)
+					if (!is_bool($callable))
 					{
 						$rule = $callable;
 					}
@@ -818,7 +818,14 @@ class CI_Form_validation {
 				// Callable rules might not have named error messages
 				if ( ! is_string($rule))
 				{
-					$line = $this->CI->lang->line('form_validation_error_message_not_set').'(Anonymous function)';
+					if(is_array($rule) && (count($rule) >= 2) && isset($this->_error_messages[$rule[1]]))
+					{
+						$line = $this->_error_messages[$rule[1]];
+					}
+					else
+					{
+						$line = $this->CI->lang->line('form_validation_error_message_not_set').'(Anonymous function)';
+					}
 				}
 				// Check if a custom message is defined
 				elseif (isset($this->_field_data[$row['field']]['errors'][$rule]))


### PR DESCRIPTION
##### Form Validation: "Unable to access an error message corresponding to your field name"
# Info:
PHP Version `5.6.13`
CI Version `3.0.3`

# The Issue:
`/system/libraries/Form_validation.php` Line 819-821:
```php
if ( ! is_string($rule))
{
	$line = $this->CI->lang->line('form_validation_error_message_not_set').'(Anonymous function)';
}
```

These lines cause the error message "Unable to access an error message corresponding to your field name" when it should not appear.

When setting a rule in the form:
```php
$this->form_validation->set_rules('input-name', 'Human Friendly Name', array('required', array($this->my_model, 'function_name')));
```

There is no attempt to retrieve the message set by:
```php
$this->form_validation->set_message('function_name', 'Message to the user.');
```

## What goes wrong:
Lines 712-715 of the same file:
```php
elseif (is_callable($rule))
{
	$callable = TRUE;
}
```
sets the variable `$callable` to `TRUE`.

Lines 755-758 of the same file:
```php
if ($callable !== FALSE)
{
	$rule = $callable;
}
```
This then sets `$rule` to `TRUE`.

`$rule` contained the rule information, so now this is overwritten it has been lost (I haven't completely made sure it wasn't copied to another variable).

# Solution:
Lines 755-758 become:
```php
if (!is_bool($callable))
{
	$rule = $callable;
}
```
So that `$rule` isn't overwritten.

Lines 819-821 become:
```php
if ( ! is_string($rule))
{
	if(is_array($rule) && (count($rule) >= 2) && isset($this->_error_messages[$rule[1]]))
	{
		$line = $this->_error_messages[$rule[1]];
	}
	else
	{
		$line = $this->CI->lang->line('form_validation_error_message_not_set').'(Anonymous function)';
	}
}
```
To attempt to retrieve the error message