### PR TITLE
Respect $config['cur_page'] variable for pagination

### DIFF
--- a/system/libraries/Pagination.php
+++ b/system/libraries/Pagination.php
@@ -497,7 +497,7 @@ class CI_Pagination {
 		{
 			$this->cur_page = $this->CI->input->get($this->query_string_segment);
 		}
-		else
+		elseif (empty($this->cur_page))
 		{
 			// Default to the last segment number if one hasn't been defined.
 			if ($this->uri_segment === 0)
@@ -512,6 +512,10 @@ class CI_Pagination {
 			{
 				$this->cur_page = str_replace(array($this->prefix, $this->suffix), '', $this->cur_page);
 			}
+		} 
+		else
+		{
+			$this->cur_page = (string) $this->cur_page;
 		}
 
 		// If something isn't quite right, back to the default base page.


### PR DESCRIPTION
After upgrading to CI3 I noticed that developers are able to determine the current page counter for pagination based on

* Explicit query string parameters
* URI segment configuration

In earlier versions a developer could still set the current page counter in the pagination lib directly which is useful if you want to use pagination with HTTP POST instead of GET. This could be done by passing

    $config['cur_page']  = '10';

to the pagination function for link generation. Currently this code has changed and will always try to check whether the uri segment is a valid number or not, even if the cur_page variable was passed in the associative array, and fallback to zero if it fails to validate that result.

This can be easily resolved by checking whether the counter was already set with a valid number from the $config array before trying to resolve it from the uri segment.

This fix give a developer more flexibility and stop CI from overwriting the externally set value with an incorrect one.

Signed-off-by: jekkos <jeroen.peelaerts@gmail.com>