### PR TITLE
Default doctype is now HTML 5

### DIFF
--- a/system/helpers/html_helper.php
+++ b/system/helpers/html_helper.php
@@ -229,7 +229,7 @@ if ( ! function_exists('doctype'))
 	 * @param	string	type	The doctype to be generated
 	 * @return	string
 	 */
-	function doctype($type = 'xhtml1-strict')
+	function doctype($type = 'html5')
 	{
 		static $doctypes;
 

--- a/user_guide_src/source/helpers/html_helper.rst
+++ b/user_guide_src/source/helpers/html_helper.rst
@@ -330,18 +330,18 @@ The following functions are available:
 		// <meta charset="UTF-8" />
 
 
-.. php:function:: doctype([$type = 'xhtml1-strict'])
+.. php:function:: doctype([$type = 'html5'])
 
 	:param	string	$type: Doctype name
 	:returns:	HTML DocType tag
 	:rtype:	string
 
-	Helps you generate document type declarations, or DTD's. XHTML 1.0
+	Helps you generate document type declarations, or DTD's. HTML 5
 	is used by default, but many doctypes are available.
 
 	Example::
 
-		echo doctype(); // <!DOCTYPE PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+		echo doctype(); // <!DOCTYPE html>
 
 		echo doctype('html4-trans'); // <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 


### PR DESCRIPTION
HTML Helper changed to generate HTML 5 declaration as default in place of XHTML 1.0 Strict when using `doctype()` function.