### PR TITLE
(Documentation) Consistent formatting of file paths and inline code

### DIFF
--- a/user_guide_src/source/installation/index.rst
+++ b/user_guide_src/source/installation/index.rst
@@ -6,37 +6,37 @@ CodeIgniter is installed in four steps:
 
 #. Unzip the package.
 #. Upload the CodeIgniter folders and files to your server. Normally the
-   index.php file will be at your root.
-#. Open the application/config/config.php file with a text editor and
+   *index.php* file will be at your root.
+#. Open the *application/config/config.php* file with a text editor and
    set your base URL. If you intend to use encryption or sessions, set
    your encryption key.
 #. If you intend to use a database, open the
-   application/config/database.php file with a text editor and set your
+   *application/config/database.php* file with a text editor and set your
    database settings.
 
 If you wish to increase security by hiding the location of your
 CodeIgniter files you can rename the system and application folders to
 something more private. If you do rename them, you must open your main
-index.php file and set the $system_path and $application_folder
+*index.php* file and set the ``$system_path`` and ``$application_folder``
 variables at the top of the file with the new name you've chosen.
 
 For the best security, both the system and any application folders
 should be placed above web root so that they are not directly accessible
-via a browser. By default, .htaccess files are included in each folder
+via a browser. By default, *.htaccess* files are included in each folder
 to help prevent direct access, but it is best to remove them from public
 access entirely in case the web server configuration changes or doesn't
-abide by the .htaccess.
+abide by the *.htaccess*.
 
 If you would like to keep your views public it is also possible to move
 the views folder out of your application folder.
 
 After moving them, open your main index.php file and set the
-$system_path, $application_folder and $view_folder variables,
-preferably with a full path, e.g. '/www/MyUser/system'.
+``$system_path``, ``$application_folder`` and ``$view_folder`` variables,
+preferably with a full path, e.g. '*/www/MyUser/system*'.
 
 One additional measure to take in production environments is to disable
 PHP error reporting and any other development-only functionality. In
-CodeIgniter, this can be done by setting the ENVIRONMENT constant, which
+CodeIgniter, this can be done by setting the ``ENVIRONMENT`` constant, which
 is more fully described on the :doc:`security
 page <../general/security>`.
 

--- a/user_guide_src/source/installation/troubleshooting.rst
+++ b/user_guide_src/source/installation/troubleshooting.rst
@@ -4,12 +4,12 @@ Troubleshooting
 
 If you find that no matter what you put in your URL only your default
 page is loading, it might be that your server does not support the
-REQUEST_URI variable needed to serve search-engine friendly URLs. As a
-first step, open your application/config/config.php file and look for
+``REQUEST_URI`` variable needed to serve search-engine friendly URLs. As a
+first step, open your *application/config/config.php* file and look for
 the URI Protocol information. It will recommend that you try a couple
 alternate settings. If it still doesn't work after you've tried this
 you'll need to force CodeIgniter to add a question mark to your URLs. To
-do this open your **application/config/config.php** file and change this::
+do this open your *application/config/config.php* file and change this::
 
 	$config['index_page'] = "index.php";
 

--- a/user_guide_src/source/installation/troubleshooting.rst
+++ b/user_guide_src/source/installation/troubleshooting.rst
@@ -4,7 +4,7 @@ Troubleshooting
 
 If you find that no matter what you put in your URL only your default
 page is loading, it might be that your server does not support the
-``REQUEST_URI`` variable needed to serve search-engine friendly URLs. As a
+REQUEST_URI variable needed to serve search-engine friendly URLs. As a
 first step, open your *application/config/config.php* file and look for
 the URI Protocol information. It will recommend that you try a couple
 alternate settings. If it still doesn't work after you've tried this

--- a/user_guide_src/source/overview/at_a_glance.rst
+++ b/user_guide_src/source/overview/at_a_glance.rst
@@ -54,8 +54,8 @@ approach::
 
 	example.com/news/article/345
 
-Note: By default the index.php file is included in the URL but it can be
-removed using a simple .htaccess file.
+Note: By default the *index.php* file is included in the URL but it can be
+removed using a simple *.htaccess* file.
 
 CodeIgniter Packs a Punch
 =========================

--- a/user_guide_src/source/tutorial/create_news_items.rst
+++ b/user_guide_src/source/tutorial/create_news_items.rst
@@ -14,7 +14,7 @@ To input data into the database you need to create a form where you can
 input the information to be stored. This means you'll be needing a form
 with two fields, one for the title and one for the text. You'll derive
 the slug from our title in the model. Create the new view at
-application/views/news/create.php.
+*application/views/news/create.php*.
 
 ::
 
@@ -35,7 +35,7 @@ application/views/news/create.php.
     </form>
 
 There are only two things here that probably look unfamiliar to you: the
-form_open() function and the validation_errors() function.
+``form_open()`` function and the ``validation_errors()`` function.
 
 The first function is provided by the :doc:`form
 helper <../helpers/form_helper>` and renders the form element and
@@ -76,7 +76,7 @@ validation <../libraries/form_validation>` library to do this.
 
 The code above adds a lot of functionality. The first few lines load the
 form helper and the form validation library. After that, rules for the
-form validation are set. The set\_rules() method takes three arguments;
+form validation are set. The ``set\_rules()`` method takes three arguments;
 the name of the input field, the name to be used in error messages, and
 the rule. In this case the title and text fields are required.
 
@@ -88,7 +88,7 @@ Continuing down, you can see a condition that checks whether the form
 validation ran successfully. If it did not, the form is displayed, if it
 was submitted **and** passed all the rules, the model is called. After
 this, a view is loaded to display a success message. Create a view at
-application/views/news/success.php and write a success message.
+*application/views/news/success.php* and write a success message.
 
 Model
 -----
@@ -123,19 +123,19 @@ sure everything is in lowercase characters. This leaves you with a nice
 slug, perfect for creating URIs.
 
 Let's continue with preparing the record that is going to be inserted
-later, inside the $data array. Each element corresponds with a column in
+later, inside the ``$data`` array. Each element corresponds with a column in
 the database table created earlier. You might notice a new method here,
-namely the post() method from the :doc:`input
+namely the ``post()`` method from the :doc:`input
 library <../libraries/input>`. This method makes sure the data is
 sanitized, protecting you from nasty attacks from others. The input
-library is loaded by default. At last, you insert our $data array into
+library is loaded by default. At last, you insert our ``$data`` array into
 our database.
 
 Routing
 -------
 
 Before you can start adding news items into your CodeIgniter application
-you have to add an extra rule to config/routes.php file. Make sure your
+you have to add an extra rule to *config/routes.php* file. Make sure your
 file contains the following. This makes sure CodeIgniter sees 'create'
 as a method instead of a news item's slug.
 

--- a/user_guide_src/source/tutorial/static_pages.rst
+++ b/user_guide_src/source/tutorial/static_pages.rst
@@ -24,7 +24,7 @@ you'll see URL patterns that match:
 As URL schemes become more complex, this may change. But for now, this
 is all we will need to know.
 
-Create a file at application/controllers/Pages.php with the following
+Create a file at *application/controllers/Pages.php* with the following
 code.
 
 ::


### PR DESCRIPTION
Consistent formatting for first 4 sections of documentation

- File paths are made _italicised_
- Method names and variables are formatted with `inline code`