### PR TITLE
Fix PHP session_write_close warning when writing empty session to Redis

### DIFF
--- a/system/libraries/Session/drivers/Session_redis_driver.php
+++ b/system/libraries/Session/drivers/Session_redis_driver.php
@@ -240,15 +240,9 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 				return $this->_failure;
 			}
 
-			if($this->_fingerprint === md5(''))
-			{
-				// A blank session will not be written to redis, so a timeout cannot be set on it
-				return $this->_success;
-			} else {
-				return ($this->_redis->setTimeout($this->_key_prefix.$session_id, $this->_config['expiration']))
-					? $this->_success
-					: $this->_failure;
-			}
+			return ($this->_redis->setTimeout($this->_key_prefix.$session_id, $this->_config['expiration']))
+				? $this->_success
+				: $this->_failure;
 		}
 
 		return $this->_failure;

--- a/system/libraries/Session/drivers/Session_redis_driver.php
+++ b/system/libraries/Session/drivers/Session_redis_driver.php
@@ -240,9 +240,15 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 				return $this->_failure;
 			}
 
-			return ($this->_redis->setTimeout($this->_key_prefix.$session_id, $this->_config['expiration']))
-				? $this->_success
-				: $this->_failure;
+			if($this->_fingerprint === md5(''))
+			{
+				// A blank session will not be written to redis, so a timeout cannot be set on it
+				return $this->_success;
+			} else {
+				return ($this->_redis->setTimeout($this->_key_prefix.$session_id, $this->_config['expiration']))
+					? $this->_success
+					: $this->_failure;
+			}
 		}
 
 		return $this->_failure;

--- a/system/libraries/Session/drivers/Session_redis_driver.php
+++ b/system/libraries/Session/drivers/Session_redis_driver.php
@@ -198,16 +198,7 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 
 			$session_data = $this->_redis->get($this->_key_prefix.$session_id);
 
-			if ($session_data === FALSE)
-			{
-				// The session ID does not exist in redis yet, so set a flag to create it
-				$this->_key_exists = FALSE;
-				$session_data = '';
-			}
-			else
-			{
-				$this->_key_exists = TRUE;
-			}
+			is_string($session_data) && $this->_key_exists = TRUE;
 
 			$this->_fingerprint = md5($session_data);
 			return $session_data;

--- a/system/libraries/Session/drivers/Session_redis_driver.php
+++ b/system/libraries/Session/drivers/Session_redis_driver.php
@@ -198,7 +198,9 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 
 			$session_data = $this->_redis->get($this->_key_prefix.$session_id);
 
-			is_string($session_data) && $this->_key_exists = TRUE;
+			is_string($session_data)
+				? $this->_key_exists = TRUE
+				: $session_data = '';
 
 			$this->_fingerprint = md5($session_data);
 			return $session_data;

--- a/system/libraries/Session/drivers/Session_redis_driver.php
+++ b/system/libraries/Session/drivers/Session_redis_driver.php
@@ -72,7 +72,7 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 	/**
 	 * Key exists flag
 	 *
-	 * @var boolean
+	 * @var bool
 	 */
 	protected $_key_exists = FALSE;
 
@@ -204,6 +204,10 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 				$this->_key_exists = FALSE;
 				$session_data = '';
 			}
+			else
+			{
+				$this->_key_exists = TRUE;
+			}
 
 			$this->_fingerprint = md5($session_data);
 			return $session_data;
@@ -237,7 +241,7 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 				return $this->_failure;
 			}
 
-			$this->_fingerprint = md5('');
+			$this->_key_exists = FALSE;
 			$this->_session_id = $session_id;
 		}
 
@@ -249,6 +253,7 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 				if ($this->_redis->set($this->_key_prefix.$session_id, $session_data, $this->_config['expiration']))
 				{
 					$this->_fingerprint = $fingerprint;
+					$this->_key_exists = TRUE;
 					return $this->_success;
 				}
 


### PR DESCRIPTION
I'm working on an application that will eventually save session data, but doesn't yet (other than for user logins).  Therefore, the session driver is loaded on each pageview but nothing is written to it.  I noticed that I was getting a `PHP warning: session_write_close(): Failed to write session data (user). Please verify that the current setting of session.save_path is correct ()`, and spent some time debugging.

It seems that if writing an empty session (that is, where `$session_data` is a blank string) to redis, the key isn't actually created in the redis store (expected redis behaviour, I guess).  Therefore, when the driver then runs the `setTimeout` function on that key, it returns 0, which triggers a failure in the `session_write_close` handler.

Therefore, my fix is to simply not set a timeout when the session fingerprint is equal to that of a blank session - as soon as some session data is added, the code runs as it originally did.