### PR TITLE
Avoid warnings on IDE

### DIFF
--- a/system/core/Hooks.php
+++ b/system/core/Hooks.php
@@ -255,8 +255,14 @@ class CI_Hooks {
 			{
 				return $this->_in_progress = FALSE;
 			}
-
-			$function($params);
+			if(is_callable($function))
+			{
+				$function($params);
+			}
+			else
+			{
+				return $this->_in_progress = FALSE;
+			}
 		}
 
 		$this->_in_progress = FALSE;


### PR DESCRIPTION
This is not a bug itself. but i was getting warnings on PHPstorm. if it
happens to be non callable, returns in_progress false