### PR TITLE
hunanize() helper: Escaping the $separator argument.

### DIFF
--- a/system/helpers/inflector_helper.php
+++ b/system/helpers/inflector_helper.php
@@ -219,7 +219,7 @@ if ( ! function_exists('humanize'))
 	 */
 	function humanize($str, $separator = '_')
 	{
-		return ucwords(preg_replace('/['.$separator.']+/', ' ', trim(MB_ENABLED ? mb_strtolower($str) : strtolower($str))));
+		return ucwords(preg_replace('/['.preg_quote($separator).']+/', ' ', trim(MB_ENABLED ? mb_strtolower($str) : strtolower($str))));
 	}
 }
 


### PR DESCRIPTION
Since the separator could be arbitrary, it needs to be preg-escaped.