### PR TITLE
 Fix inconsitency in library loader

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -1248,7 +1248,7 @@ class CI_Loader {
 		// Was a custom class name supplied? If so we'll use it
 		if (empty($object_name))
 		{
-			$object_name = strtolower($class);
+			$object_name = $class;
 			if (isset($this->_ci_varmap[$object_name]))
 			{
 				$object_name = $this->_ci_varmap[$object_name];

--- a/user_guide_src/source/database/forge.rst
+++ b/user_guide_src/source/database/forge.rst
@@ -97,6 +97,7 @@ Additionally, the following key/values can be used:
 -  auto_increment/true : generates an auto_increment flag on the
    field. Note that the field type must be a type that supports this,
    such as integer.
+-  unique/true : to generate a unique key for the field definition.
 
 ::
 
@@ -110,6 +111,7 @@ Additionally, the following key/values can be used:
 		'blog_title' => array(
 			'type' => 'VARCHAR',
 			'constraint' => '100',
+			'unique' => TRUE,
 		),
 		'blog_author' => array(
 			'type' =>'VARCHAR',
@@ -175,14 +177,14 @@ below is for MySQL.
 
 	$this->dbforge->add_key('blog_id', TRUE);
 	// gives PRIMARY KEY `blog_id` (`blog_id`)
-	
+
 	$this->dbforge->add_key('blog_id', TRUE);
 	$this->dbforge->add_key('site_id', TRUE);
 	// gives PRIMARY KEY `blog_id_site_id` (`blog_id`, `site_id`)
-	
+
 	$this->dbforge->add_key('blog_name');
 	// gives KEY `blog_name` (`blog_name`)
-	
+
 	$this->dbforge->add_key(array('blog_name', 'blog_label'));
 	// gives KEY `blog_name_blog_label` (`blog_name`, `blog_label`)
 
@@ -261,7 +263,7 @@ number of additional fields.
 	$fields = array(
 		'preferences' => array('type' => 'TEXT')
 	);
-	$this->dbforge->add_column('table_name', $fields); 
+	$this->dbforge->add_column('table_name', $fields);
 	// Executes: ALTER TABLE table_name ADD preferences TEXT
 
 If you are using MySQL or CUBIRD, then you can take advantage of their


### PR DESCRIPTION
When loading a library, CodeIgniter shows inconsistent behaviour when assigning the property  
name. This needs some system wide adaption.


```

class Tests extends CI_Controller {
    
    public function __construct() {
        parent::__construct();
    }
    
    public function index() {
        // Model Test.  Model file: application/models/SomeModel.php. Class name: SomeModel
        $this->load->model("SomeModel");
        $this->SomeModel->doSomething();  // Works fine.
        //$this->somemodel->doSomething(); // Does not work,  Throws an undefined property exception ( = expected behaviour)
        
        // Library test. Library file: application/libraries/SomeLibrary.php. Class name: SomeLibrary
        $this->load->library("SomeLibrary");
        $this->SomeLibrary->doSomething();    //  Throws an undefined property exception. However, does work for model classes.
        //$this->somelibrary->doSomething();   //  Does work, although both file and class name are in camel case.
    }
}

```