### PR TITLE
Fix flash data not being cleared when using native sessions

### DIFF
--- a/system/libraries/Session/Session.php
+++ b/system/libraries/Session/Session.php
@@ -77,6 +77,7 @@ class CI_Session {
 		elseif ((bool) ini_get('session.auto_start'))
 		{
 			log_message('error', 'Session: session.auto_start is enabled in php.ini. Aborting.');
+			$this->_ci_init_vars();
 			return;
 		}
 		elseif ( ! empty($params['driver']))


### PR DESCRIPTION
Using the file driver (why that exists at all is a mystery) we got file permission problems we could not resolve, even with `chmod -R 777` to give everyone rights to write in the designated directory, so we switched to native drivers using `session.auto_start` in php.ini, after taking a look at the Session.php implementation to learn that will stop it. This is how we discovered that flash data persisted when using PHP's native sessions.