### PR TITLE
Image_lib::get_image_properties invalid image handling

### DIFF
--- a/system/language/english/imglib_lang.php
+++ b/system/language/english/imglib_lang.php
@@ -51,6 +51,7 @@ $lang['imglib_libpath_invalid'] = 'The path to your image library is not correct
 $lang['imglib_image_process_failed'] = 'Image processing failed. Please verify that your server supports the chosen protocol and that the path to your image library is correct.';
 $lang['imglib_rotation_angle_required'] = 'An angle of rotation is required to rotate the image.';
 $lang['imglib_invalid_path'] = 'The path to the image is not correct.';
+$lang['imglib_invalid_image'] = 'The provided image is not valid.';
 $lang['imglib_copy_failed'] = 'The image copy routine failed.';
 $lang['imglib_missing_font'] = 'Unable to find a font to use.';
 $lang['imglib_save_failed'] = 'Unable to save the image. Please make sure the image and file directory are writable.';

--- a/system/libraries/Image_lib.php
+++ b/system/libraries/Image_lib.php
@@ -1641,6 +1641,11 @@ class CI_Image_lib {
 		}
 
 		$vals = getimagesize($path);
+		if ($vals === FALSE)
+		{
+			$this->set_error('imglib_invalid_image');
+			return FALSE;
+		}
 		$types = array(1 => 'gif', 2 => 'jpeg', 3 => 'png');
 		$mime = (isset($types[$vals[2]])) ? 'image/'.$types[$vals[2]] : 'image/jpg';
 


### PR DESCRIPTION
The get_image_properties method should return false if the image isn't valid just like if it isn't found.
At the moment the method returns 

```
array (
  'width' => NULL,
  'height' => NULL,
  'image_type' => NULL,
  'size_str' => NULL,
  'mime_type' => 'image/jpg',
)
```

because it interprets the `false` as array which results in `NULL`.
