### PR TITLE
Allow CLI to be excluded from permitted uri rules

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -155,10 +155,13 @@ $config['composer_autoload'] = FALSE;
 | The configured value is actually a regular expression character group
 | and it will be executed as: ! preg_match('/^[<permitted_uri_chars>]+$/i
 |
+| Set permitted_uri_chars_exclude_cli to TRUE to permit all CLI requests
+|
 | DO NOT CHANGE THIS UNLESS YOU FULLY UNDERSTAND THE REPERCUSSIONS!!
 |
 */
 $config['permitted_uri_chars'] = 'a-z 0-9~%.:_\-';
+$config['permitted_uri_chars_exclude_cli'] = FALSE;
 
 /*
 |--------------------------------------------------------------------------

--- a/system/core/URI.php
+++ b/system/core/URI.php
@@ -325,9 +325,15 @@ class CI_URI {
 	 */
 	public function filter_uri(&$str)
 	{
-		if ( ! empty($str) && ! empty($this->_permitted_uri_chars) && ! preg_match('/^['.$this->_permitted_uri_chars.']+$/i'.(UTF8_ENABLED ? 'u' : ''), $str))
+		$exclude_cli = $this->config->item('permitted_uri_chars_exclude_cli');
+
+		// If it's a CLI request, and excluded via config, ignore the configuration
+		if ( ! is_cli() || $exclude_cli !== TRUE)
 		{
-			show_error('The URI you submitted has disallowed characters.', 400);
+			if ( ! empty($str) && ! empty($this->_permitted_uri_chars) && ! preg_match('/^['.$this->_permitted_uri_chars.']+$/i'.(UTF8_ENABLED ? 'u' : ''), $str))
+			{
+				show_error('The URI you submitted has disallowed characters.', 400);
+			}
 		}
 	}
 


### PR DESCRIPTION
RE: Issue #4085

Running CI via CLI still enforces permitted URI chars when perhaps it should not.

This PR creates a new config option to allow the user to exclude CLI from these rules.
The other option would be to just always exclude it, but I'm not convinced that's great for security.