### PR TITLE
Use real IP in session driver if you're behind a proxy

### DIFF
--- a/system/libraries/Session/Session_driver.php
+++ b/system/libraries/Session/Session_driver.php
@@ -86,6 +86,15 @@ abstract class CI_Session_driver implements SessionHandlerInterface {
 	 */
 	protected $_success, $_failure;
 
+	/**
+	 * Client IP if sess_match_ip used
+	 *
+	 * Necessary if you're running codeigniter behind proxy
+	 *
+	 * @var string
+	 */
+	protected $_client_ip;
+
 	// ------------------------------------------------------------------------
 
 	/**
@@ -107,6 +116,16 @@ abstract class CI_Session_driver implements SessionHandlerInterface {
 		{
 			$this->_success = 0;
 			$this->_failure = -1;
+		}
+
+		if ($this->_config['match_ip'] === TRUE)
+		{
+			$CI =& get_instance();
+			$this->_client_ip = $CI->input->ip_address();
+		}
+		else
+		{
+			$this->_client_ip = $_SERVER['REMOTE_ADDR'];
 		}
 	}
 

--- a/system/libraries/Session/drivers/Session_database_driver.php
+++ b/system/libraries/Session/drivers/Session_database_driver.php
@@ -160,7 +160,7 @@ class CI_Session_database_driver extends CI_Session_driver implements SessionHan
 
 			if ($this->_config['match_ip'])
 			{
-				$this->_db->where('ip_address', $_SERVER['REMOTE_ADDR']);
+				$this->_db->where('ip_address', $this->_client_ip);
 			}
 
 			if (($result = $this->_db->get()->row()) === NULL)
@@ -225,7 +225,7 @@ class CI_Session_database_driver extends CI_Session_driver implements SessionHan
 		{
 			$insert_data = array(
 				'id' => $session_id,
-				'ip_address' => $_SERVER['REMOTE_ADDR'],
+				'ip_address' => $this->_client_ip,
 				'timestamp' => time(),
 				'data' => ($this->_platform === 'postgre' ? base64_encode($session_data) : $session_data)
 			);
@@ -243,7 +243,7 @@ class CI_Session_database_driver extends CI_Session_driver implements SessionHan
 		$this->_db->where('id', $session_id);
 		if ($this->_config['match_ip'])
 		{
-			$this->_db->where('ip_address', $_SERVER['REMOTE_ADDR']);
+			$this->_db->where('ip_address', $this->_client_ip);
 		}
 
 		$update_data = array('timestamp' => time());
@@ -299,7 +299,7 @@ class CI_Session_database_driver extends CI_Session_driver implements SessionHan
 			$this->_db->where('id', $session_id);
 			if ($this->_config['match_ip'])
 			{
-				$this->_db->where('ip_address', $_SERVER['REMOTE_ADDR']);
+				$this->_db->where('ip_address', $this->_client_ip);
 			}
 
 			if ( ! $this->_db->delete($this->_config['save_path']))
@@ -351,7 +351,7 @@ class CI_Session_database_driver extends CI_Session_driver implements SessionHan
 	{
 		if ($this->_platform === 'mysql')
 		{
-			$arg = $session_id.($this->_config['match_ip'] ? '_'.$_SERVER['REMOTE_ADDR'] : '');
+			$arg = $session_id.($this->_config['match_ip'] ? '_'.$this->_client_ip : '');
 			if ($this->_db->query("SELECT GET_LOCK('".$arg."', 300) AS ci_session_lock")->row()->ci_session_lock)
 			{
 				$this->_lock = $arg;
@@ -362,7 +362,7 @@ class CI_Session_database_driver extends CI_Session_driver implements SessionHan
 		}
 		elseif ($this->_platform === 'postgre')
 		{
-			$arg = "hashtext('".$session_id."')".($this->_config['match_ip'] ? ", hashtext('".$_SERVER['REMOTE_ADDR']."')" : '');
+			$arg = "hashtext('".$session_id."')".($this->_config['match_ip'] ? ", hashtext('".$this->_client_ip."')" : '');
 			if ($this->_db->simple_query('SELECT pg_advisory_lock('.$arg.')'))
 			{
 				$this->_lock = $arg;

--- a/system/libraries/Session/drivers/Session_files_driver.php
+++ b/system/libraries/Session/drivers/Session_files_driver.php
@@ -127,7 +127,7 @@ class CI_Session_files_driver extends CI_Session_driver implements SessionHandle
 		$this->_config['save_path'] = $save_path;
 		$this->_file_path = $this->_config['save_path'].DIRECTORY_SEPARATOR
 			.$name // we'll use the session cookie name as a prefix to avoid collisions
-			.($this->_config['match_ip'] ? md5($_SERVER['REMOTE_ADDR']) : '');
+			.($this->_config['match_ip'] ? md5($this->_client_ip) : '');
 
 		return $this->_success;
 	}

--- a/system/libraries/Session/drivers/Session_memcached_driver.php
+++ b/system/libraries/Session/drivers/Session_memcached_driver.php
@@ -88,7 +88,7 @@ class CI_Session_memcached_driver extends CI_Session_driver implements SessionHa
 
 		if ($this->_config['match_ip'] === TRUE)
 		{
-			$this->_key_prefix .= $_SERVER['REMOTE_ADDR'].':';
+			$this->_key_prefix .= $this->_client_ip.':';
 		}
 	}
 

--- a/system/libraries/Session/drivers/Session_redis_driver.php
+++ b/system/libraries/Session/drivers/Session_redis_driver.php
@@ -123,7 +123,7 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 
 			if ($this->_config['match_ip'] === TRUE)
 			{
-				$this->_key_prefix .= $_SERVER['REMOTE_ADDR'].':';
+				$this->_key_prefix .= $this->_client_ip.':';
 			}
 		}
 	}


### PR DESCRIPTION
Hi, 

I'm working on a login library using memcache with CI, but I've discovered that each session driver use "$_SERVER['REMOTE_ADDR']" to prefix the session key. 
But if you're running Codeigniter behind a proxy, $_SERVER['REMOTE_ADDR'] is always 127.0.0.1, and the driver doesn't use configured proxy_ips to get real client ip and the sess_match_ip option doesn't work. 

So, I submit my little contribution to Codeigniter :)
