### PR TITLE
Check to see whether the cache driver(redis/memcache(d)) is supported when it is initialized

### DIFF
--- a/system/libraries/Cache/drivers/Cache_apc.php
+++ b/system/libraries/Cache/drivers/Cache_apc.php
@@ -198,13 +198,13 @@ class CI_Cache_apc extends CI_Driver {
 	 */
 	public function is_supported()
 	{
-        if (extension_loaded('apc') AND ini_get('apc.enabled'))
-        {
-            return TRUE;
-        }
+		if (extension_loaded('apc') AND ini_get('apc.enabled'))
+		{
+			return TRUE;
+		}
 
-        log_message('debug', 'The APC PHP extension must be loaded and enabled to use APC Cache.');
-        return FALSE;
+		log_message('debug', 'The APC PHP extension must be loaded and enabled to use APC Cache.');
+		return FALSE;
 	}
 
 }

--- a/system/libraries/Cache/drivers/Cache_apc.php
+++ b/system/libraries/Cache/drivers/Cache_apc.php
@@ -198,13 +198,13 @@ class CI_Cache_apc extends CI_Driver {
 	 */
 	public function is_supported()
 	{
-		if ( ! extension_loaded('apc') OR ! ini_get('apc.enabled'))
-		{
-			log_message('debug', 'The APC PHP extension must be loaded to use APC Cache.');
-			return FALSE;
-		}
+        if (extension_loaded('apc') AND ini_get('apc.enabled'))
+        {
+            return TRUE;
+        }
 
-		return TRUE;
+        log_message('debug', 'The APC PHP extension must be loaded and enabled to use APC Cache.');
+        return FALSE;
 	}
 
 }

--- a/system/libraries/Cache/drivers/Cache_file.php
+++ b/system/libraries/Cache/drivers/Cache_file.php
@@ -67,10 +67,10 @@ class CI_Cache_file extends CI_Driver {
 		$path = $CI->config->item('cache_path');
 		$this->_cache_path = ($path === '') ? APPPATH.'cache/' : $path;
 
-        if (!$this->is_supported())
-        {
-            log_message('error', 'The cache directory is indeed writable ：' . $this->_cache_path);
-        }
+		if (!$this->is_supported())
+		{
+			log_message('error', 'The cache directory is indeed writable ：' . $this->_cache_path);
+		}
 	}
 
 	// ------------------------------------------------------------------------

--- a/system/libraries/Cache/drivers/Cache_file.php
+++ b/system/libraries/Cache/drivers/Cache_file.php
@@ -66,6 +66,11 @@ class CI_Cache_file extends CI_Driver {
 		$CI->load->helper('file');
 		$path = $CI->config->item('cache_path');
 		$this->_cache_path = ($path === '') ? APPPATH.'cache/' : $path;
+
+        if (!$this->is_supported())
+        {
+            log_message('error', 'The cache directory is indeed writable ：' . $this->_cache_path);
+        }
 	}
 
 	// ------------------------------------------------------------------------

--- a/system/libraries/Cache/drivers/Cache_memcached.php
+++ b/system/libraries/Cache/drivers/Cache_memcached.php
@@ -79,6 +79,12 @@ class CI_Cache_memcached extends CI_Driver {
 	 */
 	public function __construct()
 	{
+		if (!$this->is_supported())
+        {
+            log_message('error', 'Cache: Failed to create Memcache(d) object; extension not loaded?');
+            return;
+        }
+
 		// Try to load memcached server info from the config file.
 		$CI =& get_instance();
 		$defaults = $this->_memcache_conf['default'];
@@ -100,13 +106,9 @@ class CI_Cache_memcached extends CI_Driver {
 		{
 			$this->_memcached = new Memcached();
 		}
-		elseif (class_exists('Memcache', FALSE))
-		{
-			$this->_memcached = new Memcache();
-		}
 		else
 		{
-			log_message('error', 'Cache: Failed to create Memcache(d) object; extension not loaded?');
+			$this->_memcached = new Memcache();
 		}
 
 		foreach ($this->_memcache_conf as $cache_server)

--- a/system/libraries/Cache/drivers/Cache_memcached.php
+++ b/system/libraries/Cache/drivers/Cache_memcached.php
@@ -80,10 +80,10 @@ class CI_Cache_memcached extends CI_Driver {
 	public function __construct()
 	{
 		if (!$this->is_supported())
-        {
-            log_message('error', 'Cache: Failed to create Memcache(d) object; extension not loaded?');
-            return;
-        }
+		{
+			log_message('error', 'Cache: Failed to create Memcache(d) object; extension not loaded?');
+			return;
+		}
 
 		// Try to load memcached server info from the config file.
 		$CI =& get_instance();

--- a/system/libraries/Cache/drivers/Cache_redis.php
+++ b/system/libraries/Cache/drivers/Cache_redis.php
@@ -91,7 +91,13 @@ class CI_Cache_redis extends CI_Driver
 	 */
 	public function __construct()
 	{
-		$config = array();
+        if (!$this->is_supported())
+        {
+            log_message('error', 'Cache: Failed to create Redis object; extension not loaded?');
+            return;
+        }
+
+        $config = array();
 		$CI =& get_instance();
 
 		if ($CI->config->load('redis', TRUE, TRUE))

--- a/system/libraries/Cache/drivers/Cache_redis.php
+++ b/system/libraries/Cache/drivers/Cache_redis.php
@@ -97,7 +97,7 @@ class CI_Cache_redis extends CI_Driver
 			return;
 		}
 
-        $config = array();
+		$config = array();
 		$CI =& get_instance();
 
 		if ($CI->config->load('redis', TRUE, TRUE))

--- a/system/libraries/Cache/drivers/Cache_redis.php
+++ b/system/libraries/Cache/drivers/Cache_redis.php
@@ -91,11 +91,11 @@ class CI_Cache_redis extends CI_Driver
 	 */
 	public function __construct()
 	{
-        if (!$this->is_supported())
-        {
-            log_message('error', 'Cache: Failed to create Redis object; extension not loaded?');
-            return;
-        }
+		if (!$this->is_supported())
+		{
+			log_message('error', 'Cache: Failed to create Redis object; extension not loaded?');
+			return;
+		}
 
         $config = array();
 		$CI =& get_instance();

--- a/system/libraries/Cache/drivers/Cache_wincache.php
+++ b/system/libraries/Cache/drivers/Cache_wincache.php
@@ -194,13 +194,13 @@ class CI_Cache_wincache extends CI_Driver {
 	 */
 	public function is_supported()
 	{
-		if ( ! extension_loaded('wincache') OR ! ini_get('wincache.ucenabled'))
-		{
-			log_message('debug', 'The Wincache PHP extension must be loaded to use Wincache Cache.');
-			return FALSE;
-		}
+		if (extension_loaded('wincache') AND ini_get('wincache.ucenabled'))
+        {
+            return TRUE;
+        }
 
-		return TRUE;
+        log_message('debug', 'The Wincache PHP extension must be loaded and enabled to use Wincache Cache.');
+        return FALSE;
 	}
 
 }

--- a/system/libraries/Cache/drivers/Cache_wincache.php
+++ b/system/libraries/Cache/drivers/Cache_wincache.php
@@ -195,12 +195,12 @@ class CI_Cache_wincache extends CI_Driver {
 	public function is_supported()
 	{
 		if (extension_loaded('wincache') AND ini_get('wincache.ucenabled'))
-        {
-            return TRUE;
-        }
+		{
+			return TRUE;
+		}
 
-        log_message('debug', 'The Wincache PHP extension must be loaded and enabled to use Wincache Cache.');
-        return FALSE;
+		log_message('debug', 'The Wincache PHP extension must be loaded and enabled to use Wincache Cache.');
+		return FALSE;
 	}
 
 }

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -38,7 +38,7 @@ Release Date: Not Released
 
 Bug fixes for 3.0.5
 -------------------
--  Fixed a bug (#4277) - :doc:`Cache Library <libraries/caching>` Check to see if the cache driver(file/redis/memcache(d)) is supported when it is initialized.
+-  Fixed a bug (#4277) - :doc:`Cache Library <libraries/caching>` Check to see whether the cache driver(file/redis/memcache(d)) is supported when it is initialized.
 -  Fixed a bug (#4391) - :doc:`Email Library <libraries/email>` method ``reply_to()`` didn't apply Q-encoding.
 -  Fixed a bug (#4384) - :doc:`Pagination Library <libraries/pagination>` ignored (possible) *cur_page* configuration value.
 -  Fixed a bug (#4395) - :doc:`Query Builder <database/query_builder>` method ``count_all_results()`` still fails if an ``ORDER BY`` condition is used.

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -38,7 +38,7 @@ Release Date: Not Released
 
 Bug fixes for 3.0.5
 -------------------
-
+-  Fixed a bug (#4277) - :doc:`Cache Library <libraries/caching>` Check to see if the cache driver(file/redis/memcache(d)) is supported when it is initialized.
 -  Fixed a bug (#4391) - :doc:`Email Library <libraries/email>` method ``reply_to()`` didn't apply Q-encoding.
 -  Fixed a bug (#4384) - :doc:`Pagination Library <libraries/pagination>` ignored (possible) *cur_page* configuration value.
 -  Fixed a bug (#4395) - :doc:`Query Builder <database/query_builder>` method ``count_all_results()`` still fails if an ``ORDER BY`` condition is used.


### PR DESCRIPTION
When setting a cache driver(redis/memcache(d)) but it isn't supported on the web server, the server will return "fatal error". So we need check whether the cache driver is supported when it is initialized.