### PR TITLE
Update core/Security.php to fix strip_image_tags() URL displaying bug

### DIFF
--- a/system/core/Security.php
+++ b/system/core/Security.php
@@ -762,7 +762,7 @@ class CI_Security {
 	 */
 	public function strip_image_tags($str)
 	{
-		return preg_replace(array('#<img[\s/]+.*?src\s*=\s*["\'](.+?)["\'].*?\>#', '#<img[\s/]+.*?src\s*=\s*(.+?).*?\>#'), '\\1', $str);
+		return preg_replace(array('#<img[\s/]+.*?src\s*=\s*["\'](.+?)["\'].*?\>#', '#<img[\s/]+.*?src\s*=\s*(.+?\s+|.+).*?\>#'), '\\1', $str);
 	}
 
 	// ----------------------------------------------------------------


### PR DESCRIPTION
The earlier version of strip_image_tags() displays only the first letter of image URL when neither single quotes or double quotes are used to enclose the image URL.

This is fixed by making the regex greedy again, and it can be non-greedy if URL is followed by at least 1 whitespace.