### PR TITLE
clean current lock key in redis session driver

### DIFF
--- a/system/libraries/Session/drivers/Session_redis_driver.php
+++ b/system/libraries/Session/drivers/Session_redis_driver.php
@@ -277,7 +277,7 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 			try {
 				if ($this->_redis->ping() === '+PONG')
 				{
-					$this->_release_lock($this->_lock_key);
+					$this->_release_lock();
 					if ($this->_redis->close() === $this->_failure)
 					{
 						return $this->_failure;

--- a/system/libraries/Session/drivers/Session_redis_driver.php
+++ b/system/libraries/Session/drivers/Session_redis_driver.php
@@ -277,8 +277,7 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 			try {
 				if ($this->_redis->ping() === '+PONG')
 				{
-					isset($this->_lock_key) && $this->_redis->delete($this->_lock_key);
-					$this->_lock_key = NULL;
+					$this->_release_lock($this->_lock_key);
 					if ($this->_redis->close() === $this->_failure)
 					{
 						return $this->_failure;

--- a/system/libraries/Session/drivers/Session_redis_driver.php
+++ b/system/libraries/Session/drivers/Session_redis_driver.php
@@ -278,6 +278,7 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 				if ($this->_redis->ping() === '+PONG')
 				{
 					isset($this->_lock_key) && $this->_redis->delete($this->_lock_key);
+					$this->_lock_key = NULL;
 					if ($this->_redis->close() === $this->_failure)
 					{
 						return $this->_failure;


### PR DESCRIPTION
set $this->_lock_key to NULL after close

When calling session_start() again to re-use session after calling session_write_close(), the driver will call _get_lock(). Inside _get_lock, it will check whether the lock has been already gained by checking _lock_key variable. But before this commit, when calling session_write_close(), the close() method did not clear the _lock_key. Next, when calling _get_lock(), it found _lock_key already exist but the lock had been released, so _get_lock failed.

Signed-off-by: roastduck <beantang.tang@gmail.com>