### PR TITLE
Support for using regex in the $field parameter of Form_validation::set_rules(), issue#1812

### DIFF
--- a/TestReadMe
+++ b/TestReadMe
@@ -1,0 +1,1 @@
+Testing stuff around

--- a/TestReadMe
+++ b/TestReadMe
@@ -1,1 +1,0 @@
-Testing stuff around


### PR DESCRIPTION
Made some changes to have this "Support for using regex in the $field parameter of Form_validation::set_rules() , issue#1812" work, hope it's good to go.

Regards,