### PR TITLE
Fix for #4503

### DIFF
--- a/system/database/drivers/pdo/pdo_driver.php
+++ b/system/database/drivers/pdo/pdo_driver.php
@@ -194,11 +194,7 @@ class CI_DB_pdo_driver extends CI_DB {
 
 		if (is_object($result_id) && $result_id->execute())
 		{
-			if (is_numeric(stripos($sql, 'SELECT')))
-			{
-				$this->affect_rows = count($result_id->fetchAll());
-			}
-			else
+			if (!is_numeric(stripos($sql, 'SELECT')))
 			{
 				$this->affect_rows = $result_id->rowCount();
 			}


### PR DESCRIPTION
#4503 notes that results are coming back empty because fetchAll() is being used on SELECT statements and the resource pointer isn't being reset later.

This change simply makes it so SELECT statements aren't counted as affected rows.