### PR TITLE
Setup the data defining for stored data (redis)

### DIFF
--- a/system/libraries/Cache/drivers/Cache_redis.php
+++ b/system/libraries/Cache/drivers/Cache_redis.php
@@ -143,19 +143,20 @@ class CI_Cache_redis extends CI_Driver
 	 */
 	public function get($key)
 	{
-		$value = $this->_redis->hMGet($key, array('serialized', 'data'));
+		$value = $this->_redis->hMGet($key, array('type', 'data'));
 
-		if ( ! is_array($value) OR  ! isset($value['serialized'], $value['data']))
+		if ( ! is_array($value) OR  ! isset($value['type'], $value['data']))
 		{
 			return FALSE;
 		}
 
-		if ($value['serialized'])
+		if ($value['type'] === 'array' OR $value['type'] === 'object')
 		{
 			return unserialize($value['data']);
 		}
 		else
 		{
+			settype($value['data'], $value['type']);
 			return $value['data'];
 		}
 	}
@@ -175,11 +176,11 @@ class CI_Cache_redis extends CI_Driver
 	{
 		if (is_array($data) OR is_object($data))
 		{
-			return $this->_redis->hMSet($id, array('serialized' => TRUE, 'data' => serialize($data)));
+			return $this->_redis->hMSet($id, array('type' => gettype($data), 'data' => serialize($data)));
 		}
 		else
 		{
-			return $this->_redis->hMSet($id, array('serialized' => FALSE, 'data' => $data));
+			return $this->_redis->hMSet($id, array('type' => gettype($data), 'data' => $data));
 		}
 	}
 

--- a/system/libraries/Cache/drivers/Cache_redis.php
+++ b/system/libraries/Cache/drivers/Cache_redis.php
@@ -143,14 +143,21 @@ class CI_Cache_redis extends CI_Driver
 	 */
 	public function get($key)
 	{
-		$value = $this->_redis->get($key);
+		$value = $this->_redis->hMGet($key, array('serialized', 'data'));
 
-		if ($value !== FALSE && isset($this->_serialized[$key]))
+		if ( ! is_array($value))
 		{
-			return unserialize($value);
+			return FALSE;
 		}
 
-		return $value;
+		if ( ! empty($value['serialized']))
+		{
+			return unserialize($value['data']);
+		}
+		else
+		{
+			return $value['data'];
+		}
 	}
 
 	// ------------------------------------------------------------------------
@@ -168,21 +175,12 @@ class CI_Cache_redis extends CI_Driver
 	{
 		if (is_array($data) OR is_object($data))
 		{
-			if ( ! $this->_redis->sIsMember('_ci_redis_serialized', $id) && ! $this->_redis->sAdd('_ci_redis_serialized', $id))
-			{
-				return FALSE;
-			}
-
-			isset($this->_serialized[$id]) OR $this->_serialized[$id] = TRUE;
-			$data = serialize($data);
+			return $this->_redis->hMSet($id, array('serialized' => TRUE, 'data' => serialize($data)));
 		}
-		elseif (isset($this->_serialized[$id]))
+		else
 		{
-			$this->_serialized[$id] = NULL;
-			$this->_redis->sRemove('_ci_redis_serialized', $id);
+			return $this->_redis->hMSet($id, array('serialized' => FALSE, 'data' => $data));
 		}
-
-		return $this->_redis->set($id, $data, $ttl);
 	}
 
 	// ------------------------------------------------------------------------
@@ -195,18 +193,7 @@ class CI_Cache_redis extends CI_Driver
 	 */
 	public function delete($key)
 	{
-		if ($this->_redis->delete($key) !== 1)
-		{
-			return FALSE;
-		}
-
-		if (isset($this->_serialized[$key]))
-		{
-			$this->_serialized[$key] = NULL;
-			$this->_redis->sRemove('_ci_redis_serialized', $key);
-		}
-
-		return TRUE;
+		return ($this->_redis->delete($key) === 1);
 	}
 
 	// ------------------------------------------------------------------------
@@ -220,7 +207,7 @@ class CI_Cache_redis extends CI_Driver
 	 */
 	public function increment($id, $offset = 1)
 	{
-		return $this->_redis->incr($id, $offset);
+		return $this->_redis->hIncrBy($id, 'data', $offset);
 	}
 
 	// ------------------------------------------------------------------------
@@ -234,7 +221,7 @@ class CI_Cache_redis extends CI_Driver
 	 */
 	public function decrement($id, $offset = 1)
 	{
-		return $this->_redis->decr($id, $offset);
+		return $this->_redis->hIncrBy($id, 'data', -$offset);
 	}
 
 	// ------------------------------------------------------------------------

--- a/system/libraries/Cache/drivers/Cache_redis.php
+++ b/system/libraries/Cache/drivers/Cache_redis.php
@@ -145,7 +145,7 @@ class CI_Cache_redis extends CI_Driver
 	{
 		$value = $this->_redis->hMGet($key, array('type', 'data'));
 
-		if ($value === FALSE OR  $value['type'] === FALSE)
+		if ($value === FALSE OR $value['type'] === FALSE)
 		{
 			return FALSE;
 		}

--- a/system/libraries/Cache/drivers/Cache_redis.php
+++ b/system/libraries/Cache/drivers/Cache_redis.php
@@ -145,7 +145,7 @@ class CI_Cache_redis extends CI_Driver
 	{
 		$value = $this->_redis->hMGet($key, array('type', 'data'));
 
-		if ($value === FALSE OR $value['type'] === FALSE)
+		if (empty($value['type']))
 		{
 			return FALSE;
 		}

--- a/system/libraries/Cache/drivers/Cache_redis.php
+++ b/system/libraries/Cache/drivers/Cache_redis.php
@@ -145,12 +145,12 @@ class CI_Cache_redis extends CI_Driver
 	{
 		$value = $this->_redis->hMGet($key, array('serialized', 'data'));
 
-		if ( ! is_array($value))
+		if ( ! is_array($value) OR  ! isset($value['serialized'], $value['data']))
 		{
 			return FALSE;
 		}
 
-		if ( ! empty($value['serialized']))
+		if ($value['serialized'])
 		{
 			return unserialize($value['data']);
 		}

--- a/system/libraries/Cache/drivers/Cache_redis.php
+++ b/system/libraries/Cache/drivers/Cache_redis.php
@@ -145,7 +145,7 @@ class CI_Cache_redis extends CI_Driver
 	{
 		$value = $this->_redis->hMGet($key, array('type', 'data'));
 
-		if ( ! is_array($value) OR  ! isset($value['type'], $value['data']))
+		if ($value === FALSE OR  $value['type'] === FALSE)
 		{
 			return FALSE;
 		}


### PR DESCRIPTION
It is an improved version.
See previous at #4527 .

By the way, @narfbg  **you are wrong!**
> > Ok. What would we get if we set a boolean value like FALSE or a NULL value? We will get the same value "". 
> > Worth mentioning that "" !== FALSE and "" !== NULL.

> Would we? I'm quite certain that Redis stores NULLs as NULLs and booleans as booleans.

Redis stores NULLs as NULLs and booleans as booleans but PHPRedis returns they as `string`. Check it yourself.