### PR TITLE
Added the expiration to save() method

### DIFF
--- a/system/libraries/Cache/drivers/Cache_redis.php
+++ b/system/libraries/Cache/drivers/Cache_redis.php
@@ -184,12 +184,19 @@ class CI_Cache_redis extends CI_Driver
 	{
 		if (is_array($data) OR is_object($data))
 		{
-			return $this->_redis->hMSet($id, array('type' => gettype($data), 'data' => serialize($data)));
+			$success = $this->_redis->hMSet($id, array('type' => gettype($data), 'data' => serialize($data)));
 		}
 		else
 		{
-			return $this->_redis->hMSet($id, array('type' => gettype($data), 'data' => $data));
+			$success = $this->_redis->hMSet($id, array('type' => gettype($data), 'data' => $data));
 		}
+        
+		if ($success && $ttl)
+		{
+			$this->_redis->expireAt($id, time() + $ttl);
+		}
+
+		return $success;
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
Added a `expireAt` call in the `save()` method.
Now the `save()` method with passed `ttl` argument works correctly. 
The `get_metadata()` works correctly.