### PR TITLE
Removed the second condition for unix sockets (redis)

### DIFF
--- a/system/libraries/Cache/drivers/Cache_redis.php
+++ b/system/libraries/Cache/drivers/Cache_redis.php
@@ -55,7 +55,6 @@ class CI_Cache_redis extends CI_Driver
 	 * @var	array
 	 */
 	protected static $_default_config = array(
-		'socket_type' => 'tcp',
 		'host' => '127.0.0.1',
 		'password' => NULL,
 		'port' => 6379,
@@ -105,16 +104,7 @@ class CI_Cache_redis extends CI_Driver
 
 		try
 		{
-			if ($config['socket_type'] === 'unix')
-			{
-				$success = $this->_redis->connect($config['socket']);
-			}
-			else // tcp socket
-			{
-				$success = $this->_redis->connect($config['host'], $config['port'], $config['timeout']);
-			}
-
-			if ( ! $success)
+			if ( ! $this->_redis->connect($config['host'], $config['port'], $config['timeout']))
 			{
 				log_message('error', 'Cache: Redis connection failed. Check your configuration.');
 			}

--- a/system/libraries/Cache/drivers/Cache_redis.php
+++ b/system/libraries/Cache/drivers/Cache_redis.php
@@ -104,7 +104,7 @@ class CI_Cache_redis extends CI_Driver
 
 		try
 		{
-			if ($config['host']{0} === '/')
+			if ($config['host'][0] === '/')
 			{
 			    $config['port'] = 0; // for unix domain socket
 			}

--- a/system/libraries/Cache/drivers/Cache_redis.php
+++ b/system/libraries/Cache/drivers/Cache_redis.php
@@ -104,7 +104,7 @@ class CI_Cache_redis extends CI_Driver
 
 		try
 		{
-			 // for unix domain socket
+			// for unix domain socket
 			if ($config['host'][0] === '/')
 			{
 			    $config['port'] = 0;

--- a/system/libraries/Cache/drivers/Cache_redis.php
+++ b/system/libraries/Cache/drivers/Cache_redis.php
@@ -104,14 +104,7 @@ class CI_Cache_redis extends CI_Driver
 
 		try
 		{
-			// for unix domain socket
-			if ($config['host'][0] === '/')
-			{
-			    $config['port'] = 0;
-			    $config['timeout'] = 0;
-			}
-
-			if ( ! $this->_redis->connect($config['host'], $config['port'], $config['timeout']))
+			if ( ! $this->_redis->connect($config['host'], ($config['host'][0] === '/' ? 0 : $config['port']), $config['timeout']))
 			{
 				log_message('error', 'Cache: Redis connection failed. Check your configuration.');
 			}

--- a/system/libraries/Cache/drivers/Cache_redis.php
+++ b/system/libraries/Cache/drivers/Cache_redis.php
@@ -104,6 +104,11 @@ class CI_Cache_redis extends CI_Driver
 
 		try
 		{
+			if ($config['host']{0} === '/')
+			{
+			    $config['port'] = 0; // for unix domain socket
+			}
+
 			if ( ! $this->_redis->connect($config['host'], $config['port'], $config['timeout']))
 			{
 				log_message('error', 'Cache: Redis connection failed. Check your configuration.');

--- a/system/libraries/Cache/drivers/Cache_redis.php
+++ b/system/libraries/Cache/drivers/Cache_redis.php
@@ -104,9 +104,11 @@ class CI_Cache_redis extends CI_Driver
 
 		try
 		{
+			 // for unix domain socket
 			if ($config['host'][0] === '/')
 			{
-			    $config['port'] = 0; // for unix domain socket
+			    $config['port'] = 0;
+			    $config['timeout'] = 0;
 			}
 
 			if ( ! $this->_redis->connect($config['host'], $config['port'], $config['timeout']))

--- a/user_guide_src/source/libraries/caching.rst
+++ b/user_guide_src/source/libraries/caching.rst
@@ -255,8 +255,6 @@ To use it, you need `Redis server and phpredis PHP extension <https://github.com
 Config options to connect to redis server must be stored in the application/config/redis.php file.
 Available options are::
 	
-	$config['socket_type'] = 'tcp'; //`tcp` or `unix`
-	$config['socket'] = '/var/run/redis.sock'; // in case of `unix` socket type
 	$config['host'] = '127.0.0.1';
 	$config['password'] = NULL;
 	$config['port'] = 6379;


### PR DESCRIPTION
Removed the second condition of connectivity for unix sockets in `Redis::__construct()` method.
It is unnecessary because we can use `host` and `port` parameters.