### PR TITLE
Removed double quotes on $cid

### DIFF
--- a/user_guide_src/source/libraries/email.rst
+++ b/user_guide_src/source/libraries/email.rst
@@ -374,7 +374,7 @@ Class Reference
 			{
 				$this->email->to($address);
 				$cid = $this->email->attachment_cid($filename);
-				$this->email->message('<img src='cid:". $cid ."' alt="photo1" />');
+				$this->email->message('<img src="cid:'. $cid .'" alt="photo1" />');
 				$this->email->send();
 			}
 


### PR DESCRIPTION
Today I am creating a sample email with embedded image. I am following example from CodeIgniter user guide:

`$this->email->message('<img src='cid:". $cid ."' alt="photo1" />');`

But apparently the code sample is not working. The embedded image is not showing on the email (I am aware about SPF/DKIM, I am using SPF and the result is `pass`). After couple of retries I am just removing the double quotes from `$cid`:

`$this->email->message('<img src="cid:'. $cid .'" alt="photo1" />');`

And now its working. The embedded image on the email finally showed up.

I am changing the code sample so it will not confuse other developers.