### PR TITLE
Fixes #4583 by separating attachments to related and mixed multiparts

### DIFF
--- a/system/libraries/Email.php
+++ b/system/libraries/Email.php
@@ -767,7 +767,7 @@ class CI_Email {
 			'disposition'	=> empty($disposition) ? 'attachment' : $disposition,  // Can also be 'inline'  Not sure if it matters
 			'type'		=> $mime,
 			'content'	=> chunk_split(base64_encode($file_content)),
-			'multipart' => 'mixed'
+			'multipart'	=> 'mixed'
 		);
 
 		return $this;
@@ -1413,6 +1413,7 @@ class CI_Email {
 				$attachments_related = $attachments_indexed_by_multipart['related'];
 				$attachments_mixed = $attachments_indexed_by_multipart['mixed'];
 				$prepared_attachment_parts = array();
+				$last_boundary = NULL;
 
 				if (isset($attachments_mixed) && count($attachments_mixed) > 0)
 				{
@@ -1425,7 +1426,8 @@ class CI_Email {
 				if (isset($attachments_related) && count($attachments_related) > 0)
 				{
 					$target_container =& $hdr;
-					if (isset($last_boundary)) {
+					if (isset($last_boundary))
+					{
 						$target_container =& $body;
 						$target_container .= '--' . $last_boundary . $this->newline;
 					}
@@ -1440,7 +1442,10 @@ class CI_Email {
 					$this->_header_str .= $hdr;
 				}
 
-				if (strlen(body) > 0) $body .= $this->newline.$this->newline;
+				if (strlen(body) > 0)
+				{
+					$body .= $this->newline.$this->newline;
+				}
 				$body .= $this->_get_mime_message().$this->newline.$this->newline
 					.'--'.$last_boundary.$this->newline
 
@@ -1475,7 +1480,7 @@ class CI_Email {
 	/**
 	 * Returns attachments mapped by multipart type
 	 *
-	 * @return array
+	 * @return	array
 	 */
 	protected function _attachments_indexed_by_multipart()
 	{
@@ -1497,13 +1502,16 @@ class CI_Email {
 	/**
 	 * Prepares attachment string
 	 *
-	 * @param   array   $attachments
-	 * @param   string  $boundary	  Multipart boundary string
-	 * @return  string
+	 * @param	array	$attachments
+	 * @param	string	$boundary	Multipart boundary string
+	 * @return	string
 	 */
 	protected function _prep_attachments($attachments, $boundary)
 	{
-		if (!isset($attachments) || count($attachments) === 0) return '';
+		if (!isset($attachments) OR count($attachments) === 0)
+		{
+			return '';
+		}
 
 		$attachment_parts = array();
 		foreach ($attachments as $attachment)

--- a/system/libraries/Email.php
+++ b/system/libraries/Email.php
@@ -1404,20 +1404,17 @@ class CI_Email {
 					.$this->newline
 					.$this->_body.$this->newline.$this->newline;
 
-				$attachment_prepared = $this->_prep_attachments($this->_attachments, $this->_atc_boundary);
+				$body .= $this->_prep_attachments($this->_attachments, $this->_atc_boundary);
 
 				break;
 			case 'html-attach' :
 
 				$attachments_indexed_by_multipart = $this->_attachments_indexed_by_multipart();
-				$prepared_attachment_parts = array();
 				$last_boundary = NULL;
 
 				if ( ! empty($attachments_indexed_by_multipart['mixed']))
 				{
 					$hdr .= 'Content-Type: multipart/mixed; boundary="'.$this->_atc_boundary.'"';
-
-					$prepared_attachment_parts[] = $this->_prep_attachments($attachments_indexed_by_multipart['mixed'], $this->_atc_boundary);
 					$last_boundary = $this->_atc_boundary;
 				}
 
@@ -1426,14 +1423,12 @@ class CI_Email {
 					$rel_boundary_header = 'Content-Type: multipart/related; boundary="'.$this->_rel_boundary.'"';
 					if (isset($last_boundary))
 					{
-						$body .= '--' . $last_boundary . $this->newline . $rel_boundary_header;
+						$body .= '--'.$last_boundary.$this->newline.$rel_boundary_header;
 					}
 					else
 					{
 						$hdr .= $rel_boundary_header;
 					}
-
-					array_unshift($prepared_attachment_parts, $this->_prep_attachments($attachments_indexed_by_multipart['related'], $this->_rel_boundary));
 					$last_boundary = $this->_rel_boundary;
 				}
 
@@ -1459,12 +1454,15 @@ class CI_Email {
 					.$this->_prep_quoted_printable($this->_body).$this->newline.$this->newline
 					.'--'.$this->_alt_boundary.'--'.$this->newline.$this->newline;
 
-				$attachment_prepared = implode($this->newline.$this->newline, $prepared_attachment_parts);
+				( ! empty($attachments_indexed_by_multipart['related'])) && $body .= $this->newline.$this->newline
+					.$this->_prep_attachments($attachments_indexed_by_multipart['related'], $this->_rel_boundary);
+
+				( ! empty($attachments_indexed_by_multipart['mixed'])) && $body .= $this->newline.$this->newline
+					.$this->_prep_attachments($attachments_indexed_by_multipart['mixed'], $this->_atc_boundary);
 
 				break;
 		}
 
-		$body .= $attachment_prepared;
 		$this->_finalbody = ($this->_get_protocol() === 'mail')
 			? $body
 			: $hdr.$this->newline.$this->newline.$body;


### PR DESCRIPTION
The issue has been fixed by separating attachments into 2 different multiparts for html emails

- Embedded attachments are generated into a multipart/related part
- Non-embedded attachments are generated into a multipart/mixed part

Please note that this solution also works for Thunderbird.