### PR TITLE
Fix notice in cases where method happens to be empty

### DIFF
--- a/system/core/CodeIgniter.php
+++ b/system/core/CodeIgniter.php
@@ -407,7 +407,7 @@ if ( ! is_php('5.4'))
 	{
 		require_once(APPPATH.'controllers/'.$RTR->directory.$class.'.php');
 
-		if ( ! class_exists($class, FALSE) OR $method[0] === '_' OR method_exists('CI_Controller', $method))
+		if ( ! class_exists($class, FALSE) OR (!empty($method) && $method[0] === '_') OR method_exists('CI_Controller', $method))
 		{
 			$e404 = TRUE;
 		}


### PR DESCRIPTION
In some cases while routing some urls, I'm not too sure exactly what causes this, but it happens that method gets to be empty and a php notice "Uninitialized string offset: 0" is shown on the page or ajax requests.