### PR TITLE
Remove unnecessary backslash from user guide

### DIFF
--- a/user_guide_src/source/tutorial/create_news_items.rst
+++ b/user_guide_src/source/tutorial/create_news_items.rst
@@ -76,7 +76,7 @@ validation <../libraries/form_validation>` library to do this.
 
 The code above adds a lot of functionality. The first few lines load the
 form helper and the form validation library. After that, rules for the
-form validation are set. The ``set\_rules()`` method takes three arguments;
+form validation are set. The ``set_rules()`` method takes three arguments;
 the name of the input field, the name to be used in error messages, and
 the rule. In this case the title and text fields are required.
 


### PR DESCRIPTION
I found a unnecessary backslash on a following page.
http://www.codeigniter.com/user_guide/tutorial/create_news_items.html
