### PR TITLE
Not returning array when there's no DB error

### DIFF
--- a/system/database/drivers/postgre/postgre_driver.php
+++ b/system/database/drivers/postgre/postgre_driver.php
@@ -471,7 +471,25 @@ class CI_DB_postgre_driver extends CI_DB {
 	 */
 	public function error()
 	{
-		return array('code' => '', 'message' => pg_last_error($this->conn_id));
+		//Set postgres' last error to a variable
+		$last_error = pg_last_error($this->conn_id);
+		
+		//Check if there is an error or not (pg_last_error returns FALSE when it's empty)
+		if(!$last_error) 
+		{
+			//If we can't find errors then we'll return false
+			$retval = FALSE;
+		}
+		//If there's an error in pg_last_error
+		else
+		{
+			//Returning array with code and message 
+			//(since pg_last_error do not support error codes we leave it blank as it was)
+			$retval = array('code'=>'', 'message'=>$last_error);
+		}
+		
+		//Finally return the result of the evaluation
+		return $retval;
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
In Oracle Drivers I've noticed that when we call `$this->db->error()` and there's no error, then we get a `false` operator, which allows us to compare in our applications.

When I tested the same result with PostgreSQL I came across a possible bug. Even when there's no error in the query (or even when there's no query executed at all) the function `$this->db->error()` always return a blank array with `code` and `message` keys.

I rewrote the function to check if there's actually an error and return `false` or the array depending on its eval.