### PR TITLE
Ordering by NULLS

### DIFF
--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -1198,7 +1198,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 		}
 		elseif ($direction !== '')
 		{
-			$direction = in_array($direction, array('ASC', 'DESC'), TRUE) ? ' '.$direction : '';
+			$direction = preg_match('/^(ASC|DESC)(|\sNULLS\s(FIRST|LAST))$/', $direction) ? ' '.$direction : '';
 		}
 
 		is_bool($escape) OR $escape = $this->_protect_identifiers;


### PR DESCRIPTION
Looks like after uprading 2 to 3 someone decided to make disappear ordering by NULLS. There were before "$options" variable which can be used to sort NULLS as well. I've made a regex check for this. 
In standard SQL (and most modern DBMS like Oracle, PostgreSQL, DB2, Firebird, Apache Derby, HSQLDB and H2) is possible to specify NULLS LAST or NULLS FIRST.