### PR TITLE
Make CI_DB_query_builder customisable like any core class

### DIFF
--- a/system/database/DB.php
+++ b/system/database/DB.php
@@ -169,25 +169,35 @@ function &DB($params = '', $query_builder_override = NULL)
 	if ( ! isset($query_builder) OR $query_builder === TRUE)
 	{
 		require_once(BASEPATH.'database/DB_query_builder.php');
-		if ( ! class_exists('CI_DB', FALSE))
+		$app_path = APPPATH.'core/'.DIRECTORY_SEPARATOR;
+		$class = config_item('subclass_prefix').'DB_query_builder';
+		if (file_exists($app_path.$class.'.php'))
 		{
-			/**
-			 * CI_DB
-			 *
-			 * Acts as an alias for both CI_DB_driver and CI_DB_query_builder.
-			 *
-			 * @see	CI_DB_query_builder
-			 * @see	CI_DB_driver
-			 */
-			class CI_DB extends CI_DB_query_builder { }
+			require_once($app_path.$class.'.php');
+			if ( ! class_exists($class, FALSE))
+			{
+				throw new RuntimeException($app_path.$class.".php exists, but doesn't declare class ".$class);
+			}
+		}else {
+			$class = "CI_DB_query_builder";
 		}
 	}
 	elseif ( ! class_exists('CI_DB', FALSE))
 	{
+		$class = "CI_DB_driver";
+	}
+	
+	if ( ! class_exists('CI_DB', FALSE))
+	{
 		/**
-	 	 * @ignore
+		 * CI_DB
+		 *
+		 * Acts as an alias for both CI_DB_driver and CI_DB_query_builder (or its children).
+		 *
+		 * @see	CI_DB_query_builder
+		 * @see	CI_DB_driver
 		 */
-		class CI_DB extends CI_DB_driver { }
+		eval("class CI_DB extends ".$class." { }");
 	}
 
 	// Load the DB driver

--- a/system/database/DB.php
+++ b/system/database/DB.php
@@ -169,7 +169,8 @@ function &DB($params = '', $query_builder_override = NULL)
 	if ( ! isset($query_builder) OR $query_builder === TRUE)
 	{
 		require_once(BASEPATH.'database/DB_query_builder.php');
-		$app_path = APPPATH.'core/'.DIRECTORY_SEPARATOR;
+		
+		$app_path = APPPATH.'core'.DIRECTORY_SEPARATOR;
 		$class = config_item('subclass_prefix').'DB_query_builder';
 		if (file_exists($app_path.$class.'.php'))
 		{


### PR DESCRIPTION
We needed to be able to customize the way DB's update(), insert() and delete() work.

We expected to be able to just create MY_DB_query_builder in application/core and that it would be used, just as easily as extending the Model or Controller.

Turns out it doesn't work, I look around a lot, some people also tried it without any luck, so I decided to fix it myself.
It's heavily inspired by what's happening inside Loader::model() for the checking for the file and class part.

I then use `eval()` to create the CI_DB class extending the correct class. I know a lot of people think that "eval() is evil", but in this case, it's 100% safe and the only way to make this work.

I do realize that the `application/core` folder is design to override only `system/core` files, and not `system/database`, but what I provide is just the base for you to build on. Maybe create an `application/database folder` ?

Also this only works for the CI_DB_query_builder as its the one I needed, but it can be extended to CI_DB_driver or any other DB class really.