### PR TITLE
fix php70w-pdo utf8mb4 bug

### DIFF
--- a/system/database/drivers/pdo/subdrivers/pdo_mysql_driver.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_mysql_driver.php
@@ -106,7 +106,7 @@ class CI_DB_pdo_mysql_driver extends CI_DB_pdo_driver {
 			empty($this->database) OR $this->dsn .= ';dbname='.$this->database;
 			empty($this->char_set) OR $this->dsn .= ';charset='.$this->char_set;
 		}
-		elseif ( ! empty($this->char_set) && strpos($this->dsn, 'charset=', 6) === FALSE && is_php('5.3.6'))
+		elseif ( ! empty($this->char_set) && strpos($this->dsn, 'charset=', 6) === FALSE && is_php('5.3.6') && ! is_php('7.0.0'))
 		{
 			$this->dsn .= ';charset='.$this->char_set;
 		}
@@ -127,7 +127,7 @@ class CI_DB_pdo_mysql_driver extends CI_DB_pdo_driver {
 		 *
 		 * Reference: http://www.php.net/manual/en/ref.pdo-mysql.connection.php
 		 */
-		if ( ! is_php('5.3.6') && ! empty($this->char_set))
+		if ( ! is_php('5.3.6') && ! empty($this->char_set) || is_php('7.0.0'))
 		{
 			$this->options[PDO::MYSQL_ATTR_INIT_COMMAND] = 'SET NAMES '.$this->char_set
 				.(empty($this->dbcollat) ? '' : ' COLLATE '.$this->dbcollat);


### PR DESCRIPTION
php7.0.7 utf8mb4 isn't work

```
$pdo = new PDO('mysql:host=localhost;dbname=my_db;charset=utf8mb4', 'db_user', 'db_password');
```
to: 
```
$pdo = new PDO('mysql:host=localhost;dbname=my_db', 'db_user', 'db_password', array(
    PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4',
));
```