### PR TITLE
Remove unbound PHP constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 		"source": "https://github.com/bcit-ci/CodeIgniter"
 	},
 	"require": {
-		"php": ">=5.2.4"
+		"php": "^5.2.4 || ^7.0"
 	},
 	"suggest": {
 		"paragonie/random_compat": "Provides better randomness in PHP 5.x"


### PR DESCRIPTION
Ref: https://getcomposer.org/doc/faqs/why-are-unbound-version-constraints-a-bad-idea.md

BTW, not related to this PR, but your `composer.json` indent does not follow the convention. It should be 4 spaces, not tabs.