### PR TITLE
Add useful debugging info for missing lang lines

### DIFF
--- a/system/core/Lang.php
+++ b/system/core/Lang.php
@@ -194,7 +194,7 @@ class CI_Lang {
 		// Because killer robots like unicorns!
 		if ($value === FALSE && $log_errors === TRUE)
 		{
-			log_message('error', 'Could not find the language line "'.$line.'"');
+			log_message('error', 'Could not find the language line "'.$line.'", used in '.next(debug_backtrace())['file'].', code line '.next(debug_backtrace())['line']);
 		}
 
 		return $value;


### PR DESCRIPTION
This change makes it easy to track down where exactly a missing language line (not found in language files) was used in the code. Without this addition it is much harder to track down the file and code line where a non-existing language string was (mis)used or misspelled.