### PR TITLE
[ci skip] recommend PHP >= 5.6

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -29,7 +29,7 @@ guide change log <https://github.com/bcit-ci/CodeIgniter/blob/develop/user_guide
 Server Requirements
 *******************
 
-PHP version 5.5 or newer is recommended.
+PHP version 5.6 or newer is recommended.
 
 It should work on 5.2.4 as well, but we strongly advise you NOT to run
 such old versions of PHP, because of potential security and performance


### PR DESCRIPTION
PHP 5.5 end of life is July 10, 2016