### PR TITLE
[BUGFIX] Codeigniter tries to get composer vendor in APPPATH

### DIFF
--- a/system/core/CodeIgniter.php
+++ b/system/core/CodeIgniter.php
@@ -166,9 +166,9 @@ if ( ! is_php('5.4'))
 	{
 		if ($composer_autoload === TRUE)
 		{
-			file_exists(APPPATH.'vendor/autoload.php')
-				? require_once(APPPATH.'vendor/autoload.php')
-				: log_message('error', '$config[\'composer_autoload\'] is set to TRUE but '.APPPATH.'vendor/autoload.php was not found.');
+			file_exists(FCPATH.'vendor/autoload.php')
+				? require_once(FCPATH.'vendor/autoload.php')
+				: log_message('error', '$config[\'composer_autoload\'] is set to TRUE but '.FCPATH.'vendor/autoload.php was not found.');
 		}
 		elseif (file_exists($composer_autoload))
 		{


### PR DESCRIPTION
When installs codeigniter using this command:

composer create-project bcit-ci/codeigniter CI-Clean --prefer-dist

install the "vendor" directory on codeigniter root (FCPATH) including "mikey179/vfsstream" but $composer_autoload tries to get it on APPPATH.'vendor/autoload.php'