### PR TITLE
Use negative length for speeding up.

### DIFF
--- a/system/libraries/Upload.php
+++ b/system/libraries/Upload.php
@@ -601,7 +601,7 @@ class CI_Upload {
 				'file_type'		=> $this->file_type,
 				'file_path'		=> $this->upload_path,
 				'full_path'		=> $this->upload_path.$this->file_name,
-				'raw_name'		=> substr($this->file_name, 0, strlen($this->file_name) - strlen($this->file_ext)),
+				'raw_name'		=> substr($this->file_name, 0, -strlen($this->file_ext)),
 				'orig_name'		=> $this->orig_name,
 				'client_name'		=> $this->client_name,
 				'file_ext'		=> $this->file_ext,


### PR DESCRIPTION
I use the following code for benchmark test.

`
                /* just comment */

		$name = "test_benchmark.cpp.cpp";
		$ext = ".cpp";		
		$raw_name = "";
		
		$this->benchmark->mark("positive_start");
		
		$count = 1000000;
		for($i = 0; $i < $count; $i++){			
			$raw_name = substr($name, 0, strlen($name) - strlen($ext));			
		}
		$this->benchmark->mark("positive_end");
		echo "Positive length elapsed ".$this->benchmark->elapsed_time("positive_start", "positive_end")." seconds. "."<br>";
		
		$this->benchmark->mark("negative_start");
		for($i = 0; $i < $count; $i++){
			$raw_name = substr($name, 0, - strlen($ext));
		}
		$this->benchmark->mark("negative_end");
		echo "Negative length elapsed ".$this->benchmark->elapsed_time("negative_start", "negative_end")." seconds. "."<br>";`

The output is as follows:
Positive length elapsed 4.1075 seconds 
Negative length elapsed 2.8315 seconds


Signed-off-by: tianhe1986 <w1s2j3229@163.com>