### PR TITLE
update_batch returns -1 when execute update query failed.

### DIFF
--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -1913,7 +1913,11 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 		$affected_rows = 0;
 		for ($i = 0, $total = count($this->qb_set); $i < $total; $i += $batch_size)
 		{
-			$this->query($this->_update_batch($this->protect_identifiers($table, TRUE, NULL, FALSE), array_slice($this->qb_set, $i, $batch_size), $this->protect_identifiers($index)));
+			$ret = $this->query($this->_update_batch($this->protect_identifiers($table, TRUE, NULL, FALSE), array_slice($this->qb_set, $i, $batch_size), $this->protect_identifiers($index)));
+			if ($ret)
+			{
+				return ($this->db_debug) ? $this->display_error('db_invalid_query') : FALSE;
+			}
 			$affected_rows += $this->affected_rows();
 			$this->qb_where = array();
 		}


### PR DESCRIPTION
## Issue
Update batch could cause "Illegal mix of collations (utf8_general_ci,COERCIBLE) and (utf8mb4_general_ci,IMPLICIT) for operation 'case'" failure, when CI's collations and charset was not set correctly. Attach files can show how to make this happens:
[update_batch_return_num_issue.zip](https://github.com/bcit-ci/CodeIgniter/files/370779/update_batch_return_num_issue.zip)

When those kind of error happens, update_batch does not return false as described, but return "-1" instead,  not expected. 

## Patch
Check every return of query call, return FALSE immediately when query call returns FALSE.