### PR TITLE
Session: use associative array key search instead of array value search in userdata()

### DIFF
--- a/system/libraries/Session/Session.php
+++ b/system/libraries/Session/Session.php
@@ -678,19 +678,16 @@ class CI_Session {
 			return array();
 		}
 
-		$userdata = array();
+		$userdata = $_SESSION;
+		
+		$_filter_keys = isset($_SESSION['__ci_vars']) ? array_keys($_SESSION['__ci_vars']) : array();
 		$_exclude = array_merge(
-			array('__ci_vars'),
-			$this->get_flash_keys(),
-			$this->get_temp_keys()
+			array('__ci_vars'), $_filter_keys
 		);
-
-		foreach (array_keys($_SESSION) as $key)
+		
+		foreach($_exclude as $_exclude_key)
 		{
-			if ( ! in_array($key, $_exclude, TRUE))
-			{
-				$userdata[$key] = $_SESSION[$key];
-			}
+			unset($userdata[$_exclude_key]);
 		}
 
 		return $userdata;


### PR DESCRIPTION
The efficiency would be highly improved in case of calling userdata() with thousands of flashdata/tempdata.

I use the following code for benchmark test.

```
		$count = 20000;
		for($i = 0; $i < $count; $i++){			
			$this->session->set_tempdata('temp_key'.$i, $i);
			$this->session->set_userdata('key'.$i, $i);
		}
		
		$this->benchmark->mark("session_start");
		$userdata = $this->session->userdata();
		$this->benchmark->mark("session_end");
		echo "Session elapsed ".$this->benchmark->elapsed_time("session_start", "session_end")." seconds. ";
```

Signed-off-by: tianhe1986 <w1s2j3229@163.com>