### PR TITLE
Form dropdown duplicates

### DIFF
--- a/tests/codeigniter/helpers/form_helper_test.php
+++ b/tests/codeigniter/helpers/form_helper_test.php
@@ -145,6 +145,28 @@ EOH;
 		$this->assertEquals($expected, form_dropdown('cars', $options, array('volvo', 'audi')));
 	}
 
+	public function test_form_dropdown_duplicates()
+	{
+		$options = array(
+			array('key' => 'US', 'value' => 'United States'),
+			array('separator' => TRUE),
+			array('key' => 'US', 'value' => 'United States'),
+			array('key' => '*', 'value' => 'Rest of the world'),
+		);
+
+		$expected = <<<EOH
+<select name="countries">
+<option value="US">United States</option>
+<option disabled>──────────</option>
+<option value="US">United States</option>
+<option value="*">Rest of the world</option>
+</select>
+
+EOH;
+											// $data, $options, $selected, $attr
+		$this->assertEquals($expected, form_dropdown('countries', $options, array('FR')));
+	}
+
 	// ------------------------------------------------------------------------
 
 	public function test_form_multiselect()

--- a/tests/codeigniter/helpers/form_helper_test.php
+++ b/tests/codeigniter/helpers/form_helper_test.php
@@ -113,7 +113,10 @@ EOH;
 		$shirts_on_sale = array('small', 'large');
 
 		$this->assertEquals($expected, form_dropdown('shirts', $options, $shirts_on_sale));
+	}
 
+	public function test_form_dropdown_optgroups()
+	{
 		$options = array(
 			'Swedish Cars' => array(
 				'volvo'	=> 'Volvo',


### PR DESCRIPTION
I'm in the process of upstreaming a bunch of changes made against 2.1, so...
Per acafee9 :

The rationale is that I have a list of country names where the top few items are a few "top-most" countries, but those must still appear in the alphabetical list so users aren't wondering why they can't find their country.

It also adds nice "separators" (even though they're not in the HTML spec).