### PR TITLE
Common: Use case-insensitive comparing/replacing

### DIFF
--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -716,8 +716,8 @@ if ( ! function_exists('remove_invisible_characters'))
 		// carriage return (dec 13) and horizontal tab (dec 09)
 		if ($url_encoded)
 		{
-			$non_displayables[] = '/%0[0-8bcef]/';	// url encoded 00-08, 11, 12, 14, 15
-			$non_displayables[] = '/%1[0-9a-f]/';	// url encoded 16-31
+			$non_displayables[] = '/%0[0-8bcef]/i';	// url encoded 00-08, 11, 12, 14, 15
+			$non_displayables[] = '/%1[0-9a-f]/i';	// url encoded 16-31
 		}
 
 		$non_displayables[] = '/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]+/S';	// 00-08, 11, 12, 14-31, 127

--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -355,7 +355,7 @@ if ( ! function_exists('is_https'))
 		{
 			return TRUE;
 		}
-		elseif (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https')
+		elseif (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) === 'https')
 		{
 			return TRUE;
 		}

--- a/tests/codeigniter/core/Common_test.php
+++ b/tests/codeigniter/core/Common_test.php
@@ -54,4 +54,18 @@ class Common_test extends CI_TestCase {
 		);
 	}
 
+	// ------------------------------------------------------------------------
+
+	public function test_remove_invisible_characters()
+	{
+		$this->assertEquals(
+				remove_invisible_characters('Here is a string containing invisible'.chr(0x08).' text %0e.', FALSE),
+			'Here is a string containing invisible text %0e.'
+		);
+
+		$this->assertEquals(
+				remove_invisible_characters('Here is a string %0econtaining url_encoded invisible%1F text.'),
+			'Here is a string containing url_encoded invisible text.'
+		);
+	}
 }


### PR DESCRIPTION
1 Call strtolower before comparing $_SERVER['HTTP_X_FORWARDED_PROTO']  since it is also treated case insensitively in Apache Tomcat([see here](http://tomcat.apache.org/tomcat-8.0-doc/config/filter.html#Basic_configuration_to_handle_'x-forwarded-for'_and_'x-forwarded-proto'))

2 Replace url_encoded invisible characters case-insensitively. For example, both '%0c' and '%0C' should be removed after calling remove_invisible_characters with url_encoded param enabled.