### PR TITLE
fixed return FALSE when load database error

### DIFF
--- a/system/database/DB.php
+++ b/system/database/DB.php
@@ -216,6 +216,10 @@ function &DB($params = '', $query_builder_override = NULL)
 		}
 	}
 
-	$DB->initialize();
-	return $DB;
+	if ($DB->initialize() !== FALSE) {
+		return $DB;
+	}
+	else {
+		return FALSE;
+	}
 }

--- a/system/database/DB.php
+++ b/system/database/DB.php
@@ -216,10 +216,5 @@ function &DB($params = '', $query_builder_override = NULL)
 		}
 	}
 
-	if ($DB->initialize() !== FALSE) {
-		return $DB;
-	}
-	else {
-		return FALSE;
-	}
+	return $DB->initialize() ? $DB : FALSE;
 }


### PR DESCRIPTION
In my case:
```
// maybe can't connect database server
if ($db = $this->load->database('db_conf', true)) {
    // some query to get value
    return $row['field'];
}
else {
    return 'default_value';
}
```
But in code always return $DB(new $driver($params);).

In code note, `CI_Loader.database` return `object|bool`.