### PR TITLE
Call strtolower before comparing $_SERVER['HTTP_X_FORWARDED_PROTO'].

### DIFF
--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -355,7 +355,7 @@ if ( ! function_exists('is_https'))
 		{
 			return TRUE;
 		}
-		elseif (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https')
+		elseif (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) === 'https')
 		{
 			return TRUE;
 		}


### PR DESCRIPTION
In case of upper-case HTTP header field value.

Signed-off-by: tianhe1986 <w1s2j3229@163.com>