### PR TITLE
Added a note for helpers alias

### DIFF
--- a/user_guide_src/source/libraries/loader.rst
+++ b/user_guide_src/source/libraries/loader.rst
@@ -358,6 +358,8 @@ Class Reference
 		This method loads helper files, where file_name is the name of the
 		file, without the _helper.php extension.
 
+		.. note:: The ``helpers()`` alias could be used for semantic purposes (especially when loading more than one helper).
+
 	.. php:method:: file($path[, $return = FALSE])
 
 		:param	string	$path: File path


### PR DESCRIPTION
There is an undocumented feature - `helpers()` method.
I simply added a note to expose this feature.