### PR TITLE
CI_Unit_test: Fix name of visible test items.

### DIFF
--- a/system/libraries/Unit_test.php
+++ b/system/libraries/Unit_test.php
@@ -291,7 +291,7 @@ class CI_Unit_test {
 				{
 					continue;
 				}
-				elseif (in_array($key, array('test_name', 'test_datatype', 'test_res_datatype', 'result'), TRUE))
+				elseif (in_array($key, array('test_name', 'test_datatype', 'res_datatype', 'result'), TRUE))
 				{
 					if (FALSE !== ($line = $CI->lang->line(strtolower('ut_'.$val), FALSE)))
 					{


### PR DESCRIPTION
It should be "res_datatype" which is listed in $_test_items_visible rather than "test_res_datatype".