### PR TITLE
CI_Unit_test: Do not replace "is_double" with "is_float".

### DIFF
--- a/system/libraries/Unit_test.php
+++ b/system/libraries/Unit_test.php
@@ -154,7 +154,6 @@ class CI_Unit_test {
 
 		if (in_array($expected, array('is_object', 'is_string', 'is_bool', 'is_true', 'is_false', 'is_int', 'is_numeric', 'is_float', 'is_double', 'is_array', 'is_null', 'is_resource'), TRUE))
 		{
-			$expected = str_replace('is_double', 'is_float', $expected);
 			$result = $expected($test);
 			$extype = str_replace(array('true', 'false'), 'bool', str_replace('is_', '', $expected));
 		}


### PR DESCRIPTION
 "is_double" is already an alias of "is_float".