### PR TITLE
Accept SQL Functions on SELECT Fields

### DIFF
--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -1210,6 +1210,11 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 		else
 		{
 			$qb_orderby = array();
+			if(is_array($orderby)) 
+			{
+				array_walk($orderby, create_function('&$i,$k','$i=" $k $i";'));
+				$orderby = implode($orderby, ",");
+			}
 			foreach (explode(',', $orderby) as $field)
 			{
 				$qb_orderby[] = ($direction === '' && preg_match('/\s+(ASC|DESC)$/i', rtrim($field), $match, PREG_OFFSET_CAPTURE))


### PR DESCRIPTION
When query builder have SQL Functions on SELECT, the explode return error.  This solves the problem.