### PR TITLE
Cache_file: use $data['time'] for calculating expired time.

### DIFF
--- a/system/libraries/Cache/drivers/Cache_file.php
+++ b/system/libraries/Cache/drivers/Cache_file.php
@@ -227,7 +227,7 @@ class CI_Cache_file extends CI_Driver {
 		{
 			$mtime = filemtime($this->_cache_path.$id);
 
-			if ( ! isset($data['ttl']) OR ! isset($data['time']))
+			if ( ! isset($data['ttl'], $data['time']))
 			{
 				return FALSE;
 			}

--- a/system/libraries/Cache/drivers/Cache_file.php
+++ b/system/libraries/Cache/drivers/Cache_file.php
@@ -233,7 +233,7 @@ class CI_Cache_file extends CI_Driver {
 			}
 
 			return array(
-				'expire' => $mtime + $data['ttl'],
+				'expire' => $data['time'] + $data['ttl'],
 				'mtime'	 => $mtime
 			);
 		}

--- a/system/libraries/Cache/drivers/Cache_file.php
+++ b/system/libraries/Cache/drivers/Cache_file.php
@@ -227,7 +227,7 @@ class CI_Cache_file extends CI_Driver {
 		{
 			$mtime = filemtime($this->_cache_path.$id);
 
-			if ( ! isset($data['ttl']))
+			if ( ! isset($data['ttl']) OR ! isset($data['time']))
 			{
 				return FALSE;
 			}


### PR DESCRIPTION
In case of mtime changed and also keeping the same way implemented  in `_get()` , see [Cache_file.php](https://github.com/bcit-ci/CodeIgniter/blob/develop/system/libraries/Cache/drivers/Cache_file.php#L277)