### PR TITLE
Implemented replace_batch() #1652. Definitely plenty of use cases for this.

### DIFF
--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -1525,6 +1525,76 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 		return 'INSERT INTO '.$table.' ('.implode(', ', $keys).') VALUES '.implode(', ', $values);
 	}
 
+	/**
+	 * Replace_Batch
+	 *
+	 * Compiles batch insert strings replacing any existing rows and runs the queries
+	 *
+	 * @param	string	$table	Table to replace insert into
+	 * @param	array	$set 	An associative array of insert values
+	 * @param	bool	$escape	Whether to escape values and identifiers
+	 * @return	int	Number of rows inserted or FALSE on failure
+	 */
+	public function replace_batch($table, $set = NULL, $escape = NULL, $batch_size = 100)
+	{
+		if ($set === NULL)
+		{
+			if (empty($this->qb_set))
+			{
+				return ($this->db_debug) ? $this->display_error('db_must_use_set') : FALSE;
+			}
+		}
+		else
+		{
+			if (empty($set))
+			{
+				return ($this->db_debug) ? $this->display_error('replace_batch() called with no data') : FALSE;
+			}
+
+			$this->set_insert_batch($set, '', $escape);
+		}
+
+		if (strlen($table) === 0)
+		{
+			if ( ! isset($this->qb_from[0]))
+			{
+				return ($this->db_debug) ? $this->display_error('db_must_set_table') : FALSE;
+			}
+
+			$table = $this->qb_from[0];
+		}
+
+		// Batch this baby
+		$affected_rows = 0;
+		for ($i = 0, $total = count($this->qb_set); $i < $total; $i += $batch_size)
+		{
+			if ($this->query($this->_replace_batch($this->protect_identifiers($table, TRUE, $escape, FALSE), $this->qb_keys, array_slice($this->qb_set, $i, $batch_size))))
+			{
+				$affected_rows += $this->affected_rows();
+			}
+		}
+
+		$this->_reset_write();
+		return $affected_rows;
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Insert batch statement
+	 *
+	 * Generates a platform-specific insert string from the supplied data.
+	 *
+	 * @param	string	$table	Table name
+	 * @param	array	$keys	INSERT keys
+	 * @param	array	$values	INSERT values
+	 * @return	string
+	 */
+	protected function _replace_batch($table, $keys, $values)
+	{
+		return 'INSERT INTO '.$table.' ('.implode(', ', $keys).') VALUES '.implode(', ', $values);
+	}
+
 	// --------------------------------------------------------------------
 
 	/**

--- a/system/database/drivers/mssql/mssql_driver.php
+++ b/system/database/drivers/mssql/mssql_driver.php
@@ -491,6 +491,27 @@ class CI_DB_mssql_driver extends CI_DB {
 		return ($this->db->db_debug) ? $this->db->display_error('db_unsupported_feature') : FALSE;
 	}
 
+	/**
+	 * Replace batch statement
+	 *
+	 * Generates a platform-specific insert string from the supplied data.
+	 *
+	 * @param	string	$table	Table name
+	 * @param	array	$keys	INSERT keys
+	 * @param	array	$values	INSERT values
+	 * @return	string|bool
+	 */
+	protected function _replace_batch($table, $keys, $values)
+	{
+		// Multiple-value inserts are only supported as of SQL Server 2008
+		if (version_compare($this->version(), '10', '>='))
+		{
+			return parent::_insert_batch($table, $keys, $values);
+		}
+
+		return ($this->db->db_debug) ? $this->db->display_error('db_unsupported_feature') : FALSE;
+	}
+
 	// --------------------------------------------------------------------
 
 	/**

--- a/system/database/drivers/oci8/oci8_driver.php
+++ b/system/database/drivers/oci8/oci8_driver.php
@@ -609,6 +609,21 @@ class CI_DB_oci8_driver extends CI_DB {
 		return $sql.'SELECT * FROM dual';
 	}
 
+	/**
+	 * Replace batch statement
+	 *
+	 * Generates a platform-specific insert string from the supplied data
+	 *
+	 * @param	string	$table	Table name
+	 * @param	array	$keys	INSERT keys
+	 * @param 	array	$values	INSERT values
+	 * @return	string
+	 */
+	protected function _replace_batch($table, $keys, $values)
+	{
+		return ($this->db->db_debug) ? $this->db->display_error('db_unsupported_feature') : FALSE;
+	}
+
 	// --------------------------------------------------------------------
 
 	/**

--- a/system/database/drivers/pdo/subdrivers/pdo_dblib_driver.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_dblib_driver.php
@@ -334,4 +334,25 @@ class CI_DB_pdo_dblib_driver extends CI_DB_pdo_driver {
 		return ($this->db->db_debug) ? $this->db->display_error('db_unsupported_feature') : FALSE;
 	}
 
+	/**
+	 * Replace batch statement
+	 *
+	 * Generates a platform-specific insert string from the supplied data.
+	 *
+	 * @param	string	$table	Table name
+	 * @param	array	$keys	INSERT keys
+	 * @param	array	$values	INSERT values
+	 * @return	string|bool
+	 */
+	protected function _replace_batch($table, $keys, $values)
+	{
+		// Multiple-value inserts are only supported as of SQL Server 2008
+		if (version_compare($this->version(), '10', '>='))
+		{
+			return parent::_replace_batch($table, $keys, $values);
+		}
+
+		return ($this->db->db_debug) ? $this->db->display_error('db_unsupported_feature') : FALSE;
+	}
+
 }

--- a/system/database/drivers/pdo/subdrivers/pdo_oci_driver.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_oci_driver.php
@@ -278,6 +278,19 @@ class CI_DB_pdo_oci_driver extends CI_DB_pdo_driver {
 		return $sql.'SELECT * FROM dual';
 	}
 
+	/**
+	 * Insert batch statement
+	 *
+	 * @param	string	$table	Table name
+	 * @param	array	$keys	INSERT keys
+	 * @param	array	$values	INSERT values
+	 * @return 	string
+	 */
+	protected function _replace_batch($table, $keys, $values)
+	{
+		return ($this->db->db_debug) ? $this->db->display_error('db_unsupported_feature') : FALSE;
+	}
+
 	// --------------------------------------------------------------------
 
 	/**

--- a/system/database/drivers/pdo/subdrivers/pdo_sqlsrv_driver.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_sqlsrv_driver.php
@@ -366,4 +366,25 @@ class CI_DB_pdo_sqlsrv_driver extends CI_DB_pdo_driver {
 		return ($this->db->db_debug) ? $this->db->display_error('db_unsupported_feature') : FALSE;
 	}
 
+	/**
+	 * Replace batch statement
+	 *
+	 * Generates a platform-specific insert string from the supplied data.
+	 *
+	 * @param	string	$table	Table name
+	 * @param	array	$keys	INSERT keys
+	 * @param	array	$values	INSERT values
+	 * @return	string|bool
+	 */
+	protected function _replace_batch($table, $keys, $values)
+	{
+		// Multiple-value inserts are only supported as of SQL Server 2008
+		if (version_compare($this->version(), '10', '>='))
+		{
+			return parent::_replace_batch($table, $keys, $values);
+		}
+
+		return ($this->db->db_debug) ? $this->db->display_error('db_unsupported_feature') : FALSE;
+	}
+
 }

--- a/system/database/drivers/sqlsrv/sqlsrv_driver.php
+++ b/system/database/drivers/sqlsrv/sqlsrv_driver.php
@@ -528,6 +528,27 @@ class CI_DB_sqlsrv_driver extends CI_DB {
 		return ($this->db->db_debug) ? $this->db->display_error('db_unsupported_feature') : FALSE;
 	}
 
+	/**
+	 * Replace batch statement
+	 *
+	 * Generates a platform-specific insert string from the supplied data.
+	 *
+	 * @param	string	$table	Table name
+	 * @param	array	$keys	INSERT keys
+	 * @param	array	$values	INSERT values
+	 * @return	string|bool
+	 */
+	protected function _replace_batch($table, $keys, $values)
+	{
+		// Multiple-value inserts are only supported as of SQL Server 2008
+		if (version_compare($this->version(), '10', '>='))
+		{
+			return parent::_replace_batch($table, $keys, $values);
+		}
+
+		return ($this->db->db_debug) ? $this->db->display_error('db_unsupported_feature') : FALSE;
+	}
+
 	// --------------------------------------------------------------------
 
 	/**

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -1448,6 +1448,21 @@ Class Reference
 			``INSERT`` queries will be executed, each trying to insert
 			up to ``$batch_size`` rows.
 
+    .. php:method:: replace_batch($table[, $set = NULL[, $escape = NULL[, $batch_size = 100]]])
+
+            :param	string	$table: Table name
+                :param	array	$set: Data to insert
+                :param	bool	$escape: Whether to escape values and identifiers
+                :param	int	$batch_size: Count of rows to insert at once
+                :returns:	Number of rows inserted or FALSE on failure
+                :rtype:	mixed
+
+                Compiles and executes batch ``REPLACE`` statements.
+
+            .. note:: When more than ``$batch_size`` rows are provided, multiple
+    ``REPLACE`` queries will be executed, each trying to insert
+                up to ``$batch_size`` rows.
+
 	.. php:method:: set_insert_batch($key[, $value = ''[, $escape = NULL]])
 
 		:param	mixed	$key: Field name or an array of field/value pairs


### PR DESCRIPTION
Instead of making people compile the query and then replace the "INSERT" string it's better to have this feature.