### PR TITLE
Common: Adding E_PARSE in error judgment.

### DIFF
--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -598,7 +598,7 @@ if ( ! function_exists('_error_handler'))
 	 */
 	function _error_handler($severity, $message, $filepath, $line)
 	{
-		$is_error = (((E_ERROR | E_COMPILE_ERROR | E_CORE_ERROR | E_USER_ERROR) & $severity) === $severity);
+		$is_error = (((E_ERROR | E_PARSE | E_COMPILE_ERROR | E_CORE_ERROR | E_USER_ERROR) & $severity) === $severity);
 
 		// When an error occurred, set the status header to '500 Internal Server Error'
 		// to indicate to the client something went wrong.


### PR DESCRIPTION
Compile-time parse errors should also be treated in the same way as fatal errors.