### PR TITLE
Standard: filtering "resource" type in hex2bin()

### DIFF
--- a/system/core/compat/standard.php
+++ b/system/core/compat/standard.php
@@ -153,7 +153,7 @@ if ( ! function_exists('hex2bin'))
 	 */
 	function hex2bin($data)
 	{
-		if (in_array($type = gettype($data), array('array', 'double', 'object'), TRUE))
+		if (in_array($type = gettype($data), array('array', 'double', 'object', 'resource'), TRUE))
 		{
 			if ($type === 'object' && method_exists($data, '__toString'))
 			{


### PR DESCRIPTION
Keeping in consist with original `hex2bin()` function.