### PR TITLE
Input: sanitizing optimization

### DIFF
--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -674,7 +674,10 @@ class CI_Input {
 			$new_array = array();
 			foreach (array_keys($str) as $key)
 			{
-				$new_array[$this->_clean_input_keys($key)] = $this->_clean_input_data($str[$key]);
+				if(($cleaned_key = $this->_clean_input_keys($key)) !== FALSE)
+				{
+					$new_array[$cleaned_key] = $this->_clean_input_data($str[$key]);
+				}
 			}
 			return $new_array;
 		}

--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -706,11 +706,11 @@ class CI_Input {
 	 *				key is encountered
 	 * @return	string|bool
 	 */
-	protected function _clean_input_keys($str, $fatal = TRUE)
+	protected function _clean_input_keys($str, $fatal = FALSE)
 	{
 		if ( ! preg_match('/^[a-z0-9:_\/|-]+$/i', $str))
 		{
-			if ($fatal === TRUE)
+			if ($fatal === FALSE)
 			{
 				return FALSE;
 			}

--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -706,11 +706,11 @@ class CI_Input {
 	 *				key is encountered
 	 * @return	string|bool
 	 */
-	protected function _clean_input_keys($str, $fatal = FALSE)
+	protected function _clean_input_keys($str, $fatal = TRUE)
 	{
 		if ( ! preg_match('/^[a-z0-9:_\/|-]+$/i', $str))
 		{
-			if ($fatal === FALSE)
+			if ($fatal === TRUE)
 			{
 				return FALSE;
 			}

--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -606,22 +606,13 @@ class CI_Input {
 		{
 			$_GET = array();
 		}
-		elseif (is_array($_GET))
+		else
 		{
-			foreach ($_GET as $key => $val)
-			{
-				$_GET[$this->_clean_input_keys($key)] = $this->_clean_input_data($val);
-			}
+			is_array($_GET) && $_GET = $this->_clean_input_data($_GET);
 		}
 
 		// Clean $_POST Data
-		if (is_array($_POST))
-		{
-			foreach ($_POST as $key => $val)
-			{
-				$_POST[$this->_clean_input_keys($key)] = $this->_clean_input_data($val);
-			}
-		}
+		is_array($_POST) && $_POST = $this->_clean_input_data($_POST);
 
 		// Clean $_COOKIE Data
 		if (is_array($_COOKIE))
@@ -637,17 +628,7 @@ class CI_Input {
 				$_COOKIE['$Domain']
 			);
 
-			foreach ($_COOKIE as $key => $val)
-			{
-				if (($cookie_key = $this->_clean_input_keys($key)) !== FALSE)
-				{
-					$_COOKIE[$cookie_key] = $this->_clean_input_data($val);
-				}
-				else
-				{
-					unset($_COOKIE[$key]);
-				}
-			}
+			$_COOKIE = $this->_clean_input_data($_COOKIE);
 		}
 
 		// Sanitize PHP_SELF

--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -655,7 +655,7 @@ class CI_Input {
 			$new_array = array();
 			foreach (array_keys($str) as $key)
 			{
-				if(($cleaned_key = $this->_clean_input_keys($key)) !== FALSE)
+				if (($cleaned_key = $this->_clean_input_keys($key)) !== FALSE)
 				{
 					$new_array[$cleaned_key] = $this->_clean_input_data($str[$key]);
 				}


### PR DESCRIPTION
I did three things.
1. When `_clean_input_keys()` returns `FALSE`, just discard this key.
   If I use '`0=ok&1=gogogo&<*:887=akb48`' as query string and then call `var_dump($_GET)`, I'll get 

```
`array (size=3)
  0 => string 'akb48' (length=5)
  1 => string 'gogogo' (length=6)
  '<*:887' => string 'akb48' (length=5)`
```

However, `$_GET[0]` is expected to be 'ok'. And, I do not confirm whether or not right, but I prefer that uncleaned key be removed from `$_GET` and `$_POST`.
2. Calling `_clean_input_data()` to sanitize `$_GET` , `$_POST` and `$_COOKIE`, basing on the above modification.
3.  Just a one-liner change, keep consist with the meaning of 'fatal'.
