### PR TITLE
Removed URI_TO_ASSOC "caching"

### DIFF
--- a/system/core/URI.php
+++ b/system/core/URI.php
@@ -450,11 +450,6 @@ class CI_URI {
 			return $default;
 		}
 
-		if (isset($this->keyval[$which], $this->keyval[$which][$n]))
-		{
-			return $this->keyval[$which][$n];
-		}
-
 		$total_segments = "total_{$which}s";
 		$segment_array = "{$which}_array";
 

--- a/system/core/URI.php
+++ b/system/core/URI.php
@@ -450,6 +450,11 @@ class CI_URI {
 			return $default;
 		}
 
+		if (isset($this->keyval[$which], $this->keyval[$which][$n]))
+		{
+			return $this->keyval[$which][$n];
+		}
+
 		$total_segments = "total_{$which}s";
 		$segment_array = "{$which}_array";
 
@@ -489,10 +494,13 @@ class CI_URI {
 				}
 			}
 		}
-
-		// Cache the array for reuse
-		isset($this->keyval[$which]) OR $this->keyval[$which] = array();
-		$this->keyval[$which][$n] = $retval;
+		else
+		{
+			// Cache the array for reuse
+			isset($this->keyval[$which]) OR $this->keyval[$which] = array();
+			$this->keyval[$which][$n] = $retval;
+		}
+		
 		return $retval;
 	}
 


### PR DESCRIPTION
When using the uri_to_assoc call multiple times within 1 request, with multiple default values for each call, only the default values of the first call are used. All subsequent calls will have used the cached values.

It might be useful to call this multiple times. For example, when you want to do a general check in your __construct for a param that always has to be set, but the controller methods might expect different parameters.

Removing this IF statement, will solve that issue.

Example:

```
public function __construct()
{
    $default = ['type'];
    $uri_params = $this->uri->uri_to_assoc(3, $default);
}

public function view()
{
    $default = ['type', 'sort_order'];  // Sort_order can be optional 
    $uri_params = $this->uri->uri_to_assoc(3, $default);
    $items = $some_object->get($uri_params['type'], $uri_params['sort_order']);
}
```
This will fail if sort_order isn't passed in the URI, as the default settings will be ignored in the uri_to_assoc call, because of the first call in the constructor.

This PR, will fix that.