### PR TITLE
Added the ability to have uploaded images automatically resized

### DIFF
--- a/system/language/english/upload_lang.php
+++ b/system/language/english/upload_lang.php
@@ -53,3 +53,5 @@ $lang['upload_no_filepath'] = 'The upload path does not appear to be valid.';
 $lang['upload_no_file_types'] = 'You have not specified any allowed file types.';
 $lang['upload_bad_filename'] = 'The file name you submitted already exists on the server.';
 $lang['upload_not_writable'] = 'The upload destination folder does not appear to be writable.';
+$lang['upload_unsupported_image_format'] = 'The image you have uploaded is not supported';
+$lang['upload_image_resize_failed'] = 'The image you have uploaded cannot be resized';

--- a/system/libraries/Upload.php
+++ b/system/libraries/Upload.php
@@ -1094,7 +1094,7 @@ class CI_Upload {
         
    	/**
          * If the upload is an image then automatically resize the image to the max_width and max_height variables
-         * should the size not already be equal to that.
+         * should the size be greater than the max_width or the max_height dimensions
          */
         public function do_auto_resize()
         {


### PR DESCRIPTION
Take the following code: 
`    $config['upload_path'] = './uploads/';
        $config['allowed_types'] = 'gif|jpg|png';
        $config['max_size'] = '100';
        $config['max_width'] = '128';
        $config['max_height'] = '128';
        $config['auto_resize'] = 'true';

        $this->upload->initialize($config);
        if (!$this->upload->do_upload('image_file')) {
            $data = array('error' => $this->upload->display_errors());
            $this->load->view('test', $data);
        } else {
            die('Upload Success');
        }`

With auto_resize set to true any image uploaded thats bigger than 128 by 128 will be resized to 128 by 128.