### PR TITLE
supplied flag to turn off mysqli SSL verification if ssl_verify passed as false

### DIFF
--- a/system/database/drivers/mysqli/mysqli_driver.php
+++ b/system/database/drivers/mysqli/mysqli_driver.php
@@ -174,6 +174,7 @@ class CI_DB_mysqli_driver extends CI_DB {
 					if ($this->encrypt['ssl_verify'])
 					{
 						defined('MYSQLI_OPT_SSL_VERIFY_SERVER_CERT') && $this->_mysqli->options(MYSQLI_OPT_SSL_VERIFY_SERVER_CERT, TRUE);
+						$client_flags |= MYSQLI_CLIENT_SSL;
 					}
 					// Apparently (when it exists), setting MYSQLI_OPT_SSL_VERIFY_SERVER_CERT
 					// to FALSE didn't do anything, so PHP 5.6.16 introduced yet another
@@ -184,10 +185,11 @@ class CI_DB_mysqli_driver extends CI_DB {
 					elseif (defined('MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT'))
 					{
 						$this->_mysqli->options(MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT, TRUE);
+						$client_flags |= MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT;
 					}
 				}
 
-				$client_flags |= MYSQLI_CLIENT_SSL;
+				
 				$this->_mysqli->ssl_set(
 					isset($ssl['key'])    ? $ssl['key']    : NULL,
 					isset($ssl['cert'])   ? $ssl['cert']   : NULL,


### PR DESCRIPTION
As per http://php.net/manual/en/mysqli.real-connect.php its require to pass MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT flag if we don't want to verify SSL.

Current code is failing to connect mysql server securely without verifying the certificate despite of supplying false in database.php [encrypt][ssl_verify] array.