### PR TITLE
Adds line feeds to the sql query including 'returning'

### DIFF
--- a/system/database/drivers/odbc/odbc_driver.php
+++ b/system/database/drivers/odbc/odbc_driver.php
@@ -196,7 +196,7 @@ class CI_DB_odbc_driver extends CI_DB {
 	 */
 	public function is_write_type($sql)
 	{
-		if (preg_match('#^(INSERT|UPDATE).*RETURNING\s.+(\,\s?.+)*$#i', $sql))
+		if (preg_match('#^(INSERT|UPDATE).*(\f)*?(\n)*?RETURNING\s.+(\,\s?.+)*$#i', $sql))
 		{
 			return FALSE;
 		}

--- a/system/database/drivers/pdo/subdrivers/pdo_odbc_driver.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_odbc_driver.php
@@ -168,7 +168,7 @@ class CI_DB_pdo_odbc_driver extends CI_DB_pdo_driver {
 	 */
 	public function is_write_type($sql)
 	{
-		if (preg_match('#^(INSERT|UPDATE).*RETURNING\s.+(\,\s?.+)*$#i', $sql))
+		if (preg_match('#^(INSERT|UPDATE).*(\f)*?(\n)*?RETURNING\s.+(\,\s?.+)*$#i', $sql))
 		{
 			return FALSE;
 		}

--- a/system/database/drivers/pdo/subdrivers/pdo_pgsql_driver.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_pgsql_driver.php
@@ -154,7 +154,7 @@ class CI_DB_pdo_pgsql_driver extends CI_DB_pdo_driver {
 	 */
 	public function is_write_type($sql)
 	{
-		if (preg_match('#^(INSERT|UPDATE).*RETURNING\s.+(\,\s?.+)*$#i', $sql))
+		if (preg_match('#^(INSERT|UPDATE).*(\f)*?(\n)*?RETURNING\s.+(\,\s?.+)*$#i', $sql))
 		{
 			return FALSE;
 		}

--- a/system/database/drivers/postgre/postgre_driver.php
+++ b/system/database/drivers/postgre/postgre_driver.php
@@ -282,7 +282,7 @@ class CI_DB_postgre_driver extends CI_DB {
 	 */
 	public function is_write_type($sql)
 	{
-		if (preg_match('#^(INSERT|UPDATE).*RETURNING\s.+(\,\s?.+)*$#i', $sql))
+		if (preg_match('#^(INSERT|UPDATE).*(\f)*?(\n)*?RETURNING\s.+(\,\s?.+)*$#i', $sql))
 		{
 			return FALSE;
 		}


### PR DESCRIPTION
When you use a db_query like this:

"insert into x
 ...
  returning y"

doesn't recognize the returning, because of the RegEx on the preg_match at Query Builder.