### PR TITLE
Remove inline style from hidden fields

### DIFF
--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -100,7 +100,7 @@ if ( ! function_exists('form_open'))
 		{
 			foreach ($hidden as $name => $value)
 			{
-				$form .= '<input type="hidden" name="'.$name.'" value="'.html_escape($value).'" style="display:none;" />'."\n";
+				$form .= '<input type="hidden" name="'.$name.'" value="'.html_escape($value).'" />'."\n";
 			}
 		}
 


### PR DESCRIPTION
I propose to remove the inline style "display:none" for hidden form fields.

1. I know of no browser that actually displays hidden form fields, so setting the style is redundant.
2. I can not imagine situations where developers rely on this style being present.
3. It generates an error when inline styles are disabled in a CSP header.

3 is my main reason for removing the style.