### PR TITLE
add X-Requested-With as potential AJAX Header

### DIFF
--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -835,7 +835,10 @@ class CI_Input {
 	 */
 	public function is_ajax_request()
 	{
-		return ( ! empty($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest');
+		return ( 
+				(! empty($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest') OR
+				(! empty($_SERVER['X-Requested-With']) && strtolower($_SERVER['X-Requested-With']) === 'xmlhttprequest')
+			);
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
X-Requested-With is mainly used to identify Ajax requests. Most JavaScript frameworks send this field with value of XMLHttpRequest