### PR TITLE
Captcha filenames should be sha1 of timestamp and word 

### DIFF
--- a/system/helpers/captcha_helper.php
+++ b/system/helpers/captcha_helper.php
@@ -105,12 +105,13 @@ if ( ! function_exists('create_captcha'))
 		// Remove old images
 		// -----------------------------------
 
-		$now = microtime(TRUE);
+		$now = time();
 
 		$current_dir = @opendir($img_path);
 		while ($filename = @readdir($current_dir))
 		{
-			if (substr($filename, -4) === '.jpg' && (str_replace('.jpg', '', $filename) + $expiration) < $now)
+            if (in_array(substr($filename, -4), array('.jpg', '.png'))
+                && (filemtime($img_path.$filename) + $expiration) < $now)
 			{
 				@unlink($img_path.$filename);
 			}
@@ -319,12 +320,12 @@ if ( ! function_exists('create_captcha'))
 
 		if (function_exists('imagejpeg'))
 		{
-			$img_filename = $now.'.jpg';
+			$img_filename = sha1($now.$word).'.jpg';
 			imagejpeg($im, $img_path.$img_filename);
 		}
 		elseif (function_exists('imagepng'))
 		{
-			$img_filename = $now.'.png';
+			$img_filename = sha1($now.$word).'.png';
 			imagepng($im, $img_path.$img_filename);
 		}
 		else


### PR DESCRIPTION
Hi,

Currently, captcha helper uses microtime function output as filename. I think we can find a better approach to this, so there is no logic exposed to users.

One of them, which is this pull request, is to save the captcha filenames as a SHA1 of concatenation between timestamp (and not micro-timestamp - see below) and the word itself. 

Based on that, usage of microtime() is no longer needed here; simple `int`s generated by time() should be enough, as the deletion from this pull request uses [`filemtime`](http://php.net/manual/en/function.filemtime.php) function to generate the file timestamp of creation, and by this way we will know which files are "expired" and can be deleted. Also, let's be honest: microseconds aren't the most realistic approach when talking about captcha files expiration.

This pull request also solves a problem where deletion of old files didn't occur on png files, since there were checked only jpg-ending files, and the captcha can generate png files too, if jpg generation is not available.