### PR TITLE
Fix file deletion on captcha helper

### DIFF
--- a/system/helpers/captcha_helper.php
+++ b/system/helpers/captcha_helper.php
@@ -111,7 +111,7 @@ if ( ! function_exists('create_captcha'))
 		while ($filename = @readdir($current_dir))
 		{
 			if (in_array(substr($filename, -4), array('.jpg', '.png'))
-                && (str_replace(array('.jpg', '.png'), '', $filename) + $expiration) < $now)
+				&& (str_replace(array('.jpg', '.png'), '', $filename) + $expiration) < $now)
 			{
 				@unlink($img_path.$filename);
 			}

--- a/system/helpers/captcha_helper.php
+++ b/system/helpers/captcha_helper.php
@@ -105,12 +105,13 @@ if ( ! function_exists('create_captcha'))
 		// Remove old images
 		// -----------------------------------
 
-		$now = microtime(TRUE);
+		$now = time();
 
 		$current_dir = @opendir($img_path);
 		while ($filename = @readdir($current_dir))
 		{
-			if (substr($filename, -4) === '.jpg' && (str_replace('.jpg', '', $filename) + $expiration) < $now)
+            if (in_array(substr($filename, -4), array('.jpg', '.png'))
+                && (filemtime($img_path.$filename) + $expiration) < $now)
 			{
 				@unlink($img_path.$filename);
 			}
@@ -319,12 +320,12 @@ if ( ! function_exists('create_captcha'))
 
 		if (function_exists('imagejpeg'))
 		{
-			$img_filename = $now.'.jpg';
+			$img_filename = sha1($now.$word).'.jpg';
 			imagejpeg($im, $img_path.$img_filename);
 		}
 		elseif (function_exists('imagepng'))
 		{
-			$img_filename = $now.'.png';
+			$img_filename = sha1($now.$word).'.png';
 			imagepng($im, $img_path.$img_filename);
 		}
 		else

--- a/system/helpers/captcha_helper.php
+++ b/system/helpers/captcha_helper.php
@@ -105,13 +105,12 @@ if ( ! function_exists('create_captcha'))
 		// Remove old images
 		// -----------------------------------
 
-		$now = time();
+		$now = microtime(TRUE);
 
 		$current_dir = @opendir($img_path);
 		while ($filename = @readdir($current_dir))
 		{
-            if (in_array(substr($filename, -4), array('.jpg', '.png'))
-                && (filemtime($img_path.$filename) + $expiration) < $now)
+			if (substr($filename, -4) === '.jpg' && (str_replace('.jpg', '', $filename) + $expiration) < $now)
 			{
 				@unlink($img_path.$filename);
 			}
@@ -320,12 +319,12 @@ if ( ! function_exists('create_captcha'))
 
 		if (function_exists('imagejpeg'))
 		{
-			$img_filename = sha1($now.$word).'.jpg';
+			$img_filename = $now.'.jpg';
 			imagejpeg($im, $img_path.$img_filename);
 		}
 		elseif (function_exists('imagepng'))
 		{
-			$img_filename = sha1($now.$word).'.png';
+			$img_filename = $now.'.png';
 			imagepng($im, $img_path.$img_filename);
 		}
 		else

--- a/system/helpers/captcha_helper.php
+++ b/system/helpers/captcha_helper.php
@@ -110,7 +110,8 @@ if ( ! function_exists('create_captcha'))
 		$current_dir = @opendir($img_path);
 		while ($filename = @readdir($current_dir))
 		{
-			if (substr($filename, -4) === '.jpg' && (str_replace('.jpg', '', $filename) + $expiration) < $now)
+			if (in_array(substr($filename, -4), array('.jpg', '.png'))
+                && (str_replace(array('.jpg', '.png'), '', $filename) + $expiration) < $now)
 			{
 				@unlink($img_path.$filename);
 			}

--- a/system/helpers/download_helper.php
+++ b/system/helpers/download_helper.php
@@ -121,11 +121,6 @@ if ( ! function_exists('force_download'))
 			$filename = implode('.', $x);
 		}
 
-		if ($data === NULL && ($fp = @fopen($filepath, 'rb')) === FALSE)
-		{
-			return;
-		}
-
 		// Clean output buffer
 		if (ob_get_level() !== 0 && @ob_end_clean() === FALSE)
 		{
@@ -146,13 +141,12 @@ if ( ! function_exists('force_download'))
 			exit($data);
 		}
 
-		// Flush 1MB chunks of data
-		while ( ! feof($fp) && ($data = fread($fp, 1048576)) !== FALSE)
-		{
-			echo $data;
-		}
+		// Flush the file
+        if (@readfile($filepath) === FALSE)
+        {
+            return;
+        }
 
-		fclose($fp);
 		exit;
 	}
 }

--- a/system/helpers/download_helper.php
+++ b/system/helpers/download_helper.php
@@ -121,6 +121,11 @@ if ( ! function_exists('force_download'))
 			$filename = implode('.', $x);
 		}
 
+		if ($data === NULL && ($fp = @fopen($filepath, 'rb')) === FALSE)
+		{
+			return;
+		}
+
 		// Clean output buffer
 		if (ob_get_level() !== 0 && @ob_end_clean() === FALSE)
 		{
@@ -141,12 +146,13 @@ if ( ! function_exists('force_download'))
 			exit($data);
 		}
 
-		// Flush the file
-        if (@readfile($filepath) === FALSE)
-        {
-            return;
-        }
+		// Flush 1MB chunks of data
+		while ( ! feof($fp) && ($data = fread($fp, 1048576)) !== FALSE)
+		{
+			echo $data;
+		}
 
+		fclose($fp);
 		exit;
 	}
 }


### PR DESCRIPTION
At this point, captcha helper doesn't remove .png files (expired files) if the imagepng was used at captcha creation (and not jpg).

This pull request solves this issue.