### PR TITLE
Fix session crashes with UTF-8 characters

### DIFF
--- a/system/libraries/Session/drivers/Session_files_driver.php
+++ b/system/libraries/Session/drivers/Session_files_driver.php
@@ -189,7 +189,7 @@ class CI_Session_files_driver extends CI_Session_driver implements SessionHandle
 		$session_data = '';
 		for ($read = 0, $length = filesize($this->_file_path.$session_id); $read < $length; $read += strlen($buffer))
 		{
-			if (($buffer = fread($this->_file_handle, $length - $read)) === FALSE)
+			if ((($buffer = fread($this->_file_handle, $length - $read)) === FALSE) || (feof($this->_file_handle)))
 			{
 				break;
 			}


### PR DESCRIPTION
Bug fix: endless for loop when tryinig read session data from file with UTF-8 characters.