### PR TITLE
Download helper improvement on reading phase

### DIFF
--- a/system/helpers/download_helper.php
+++ b/system/helpers/download_helper.php
@@ -121,11 +121,6 @@ if ( ! function_exists('force_download'))
 			$filename = implode('.', $x);
 		}
 
-		if ($data === NULL && ($fp = @fopen($filepath, 'rb')) === FALSE)
-		{
-			return;
-		}
-
 		// Clean output buffer
 		if (ob_get_level() !== 0 && @ob_end_clean() === FALSE)
 		{
@@ -146,13 +141,12 @@ if ( ! function_exists('force_download'))
 			exit($data);
 		}
 
-		// Flush 1MB chunks of data
-		while ( ! feof($fp) && ($data = fread($fp, 1048576)) !== FALSE)
+		// Flush the file
+		if (@readfile($filepath) === FALSE)
 		{
-			echo $data;
+			return;
 		}
 
-		fclose($fp);
 		exit;
 	}
 }


### PR DESCRIPTION
CodeIgniter uses the classic combination of `fopen` and `fread` functions to achieve the reading of a file, if a path is provided to `force_download` helper function. 

The only problem about this combination is that `fread` uses a hardcoded value for chunk size: 1048576 (1MB). This may be a memory usage problem on high-load applications developed with CodeIgniter (even on a dedicated server), and can be avoided by using PHP's function [`readfile`](php.net/manual/en/function.readfile.php), which is handling the reading according to server status. As you can see from official docs, it shouldn't create any memory problems, even on big files.
