### PR TITLE
Small fix for HTML Table library

### DIFF
--- a/system/libraries/Table.php
+++ b/system/libraries/Table.php
@@ -277,7 +277,6 @@ class CI_Table {
 	public function set_caption($caption)
 	{
 		$this->caption = $caption;
-		return $this;
 	}
 
 	// --------------------------------------------------------------------

--- a/system/libraries/Table.php
+++ b/system/libraries/Table.php
@@ -277,7 +277,7 @@ class CI_Table {
 	public function set_caption($caption)
 	{
 		$this->caption = $caption;
-        return $this;
+		return $this;
 	}
 
 	// --------------------------------------------------------------------

--- a/system/libraries/Table.php
+++ b/system/libraries/Table.php
@@ -427,7 +427,7 @@ class CI_Table {
 		$this->rows = array();
 		$this->heading = array();
 		$this->auto_heading = TRUE;
-        $this->caption = NULL;
+		$this->caption = NULL;
 		return $this;
 	}
 

--- a/system/libraries/Table.php
+++ b/system/libraries/Table.php
@@ -277,6 +277,7 @@ class CI_Table {
 	public function set_caption($caption)
 	{
 		$this->caption = $caption;
+        return $this;
 	}
 
 	// --------------------------------------------------------------------
@@ -426,6 +427,7 @@ class CI_Table {
 		$this->rows = array();
 		$this->heading = array();
 		$this->auto_heading = TRUE;
+        $this->caption = NULL;
 		return $this;
 	}
 

--- a/user_guide_src/source/libraries/table.rst
+++ b/user_guide_src/source/libraries/table.rst
@@ -275,7 +275,7 @@ Class Reference
 		:returns:	CI_Table instance (method chaining)
 		:rtype:	CI_Table
 
-		Lets you clear the table heading, row data, and the caption. If you need to show multiple tables with different data you should to call this method
+		Lets you clear the table heading, row data and the caption. If you need to show multiple tables with different data you should to call this method
 		after each table has been generated to clear the previous table information. Example::
 
 			$this->load->library('table');

--- a/user_guide_src/source/libraries/table.rst
+++ b/user_guide_src/source/libraries/table.rst
@@ -275,11 +275,12 @@ Class Reference
 		:returns:	CI_Table instance (method chaining)
 		:rtype:	CI_Table
 
-		Lets you clear the table heading and row data. If you need to show multiple tables with different data you should to call this method
+		Lets you clear the table heading, row data, and the caption. If you need to show multiple tables with different data you should to call this method
 		after each table has been generated to clear the previous table information. Example::
 
 			$this->load->library('table');
 
+			$this->table->set_caption('Preferences');
 			$this->table->set_heading('Name', 'Color', 'Size');
 			$this->table->add_row('Fred', 'Blue', 'Small');
 			$this->table->add_row('Mary', 'Red', 'Large');
@@ -289,6 +290,7 @@ Class Reference
 
 			$this->table->clear();
 
+			$this->table->set_caption('Shipping');
 			$this->table->set_heading('Name', 'Day', 'Delivery');
 			$this->table->add_row('Fred', 'Wednesday', 'Express');
 			$this->table->add_row('Mary', 'Monday', 'Air');


### PR DESCRIPTION
- when calling `clear()`, caption should be cleared too;
- method chaining wasn't working when calling `set_caption()` method;
- updated docs for these changes.