### PR TITLE
Zip Compress library improvements

### DIFF
--- a/system/libraries/Zip.php
+++ b/system/libraries/Zip.php
@@ -120,8 +120,9 @@ class CI_Zip {
 	public function __construct()
 	{
 		$this->now = time();
+		$this->zipdata = @tmpfile();
 
-		if ( ! ($this->zipdata = @tmpfile()))
+		if ($this->zipdata === FALSE)
 		{
 			log_message('error', 'Couldn\'t create Zip temp file.');
 			return;
@@ -507,7 +508,9 @@ class CI_Zip {
 			fclose($this->zipdata);
 		}
 
-		if ( ! ($this->zipdata = @tmpfile()))
+		$this->zipdata = @tmpfile();
+
+		if ($this->zipdata === FALSE)
 		{
 			log_message('error', 'Couldn\'t create Zip temp file.');
 


### PR DESCRIPTION
Right now, the Zip Compress library is saving all information of the archive directly into RAM memory (this means if we are creating a 10MB archive (with compression_level = 0), then an additional 10MB will be occupied by Zip library into RAM memory.

This can be easily fixed by using filesystem. In this PR, I'm suggesting to use [`tmpfile`](http://php.net/manual/en/function.tmpfile.php): a temporary file is creating into TEMP folder and there we shall save the `zipdata` property (which contains raw data of the archive). `directory` property will continue to live inside memory RAM.

I ran some tests regarding this change. As a test subject, I used a fresh copy of CodeIgniter folder for `read_dir` function. Compression level used was 0.

With the old ZIP library:

Memory usage before calling `read_dir`: 918,096 bytes
Memory after calling `read_dir`: 12,151,008 bytes
Execution time for `read_dir` call: 0.3140s
Total time for saving file (`archive` call): 0.0599s

With the changed ZIP library:

Memory usage before calling `read_dir`: 918,888 bytes
Memory after calling `read_dir`: 960,688 bytes
Execution time for `read_dir` call: 0.2253s
Total time for saving file (`archive` call): 0.0127s

It's obviously that 1MB RAM-usage request is better than a 12MB RAM-usage request. But as you can see, it's also faster!

**So how is the performance better by using the filesystem?**
1. Every time a write operation is performed to temp file, the result from `fwrite` function is directly added to `offset` property (as it represents the written number of bytes), removing the old `strlen` execution on `zipdata` property, thus using simple, pure math addition.
2. Every time `get_zip` (and as a result, `archive` too) was called (_and_ also every time a file was added to zip), an additional `strlen` was performed on `zipdata` property (_offset to start of central dir_), however, `offset` property already contains the necessary `zipdata` length :) 

I'm open to any suggestions or changes related to this PR, as I think we can make Zip Compress library really efficient on large archives too.
