### PR TITLE
Fix xmlrpc timeout, #4843

### DIFF
--- a/system/libraries/Xmlrpc.php
+++ b/system/libraries/Xmlrpc.php
@@ -734,6 +734,8 @@ class XML_RPC_Client extends CI_Xmlrpc
 			.'User-Agent: '.$this->xmlrpcName.$r
 			.'Content-Length: '.strlen($msg->payload).$r.$r
 			.$msg->payload;
+		
+		stream_set_timeout($fp,$this->timeout); // set timeout for subsequent operations
 
 		for ($written = $timestamp = 0, $length = strlen($op); $written < $length; $written += $result)
 		{
@@ -753,9 +755,6 @@ class XML_RPC_Client extends CI_Xmlrpc
 					$result = FALSE;
 					break;
 				}
-
-				usleep(250000);
-				continue;
 			}
 			else
 			{

--- a/user_guide_src/source/libraries/xmlrpc.rst
+++ b/user_guide_src/source/libraries/xmlrpc.rst
@@ -490,6 +490,10 @@ Class Reference
 
 			$this->xmlrpc->timeout(6);
 
+		This timeout period will be used both for an initial connection to 
+                the remote server, as well as for getting a response from it.
+                Make sure you set the timeout before calling `send_request`.
+
 	.. php:method:: method($function)
 
 		:param	string	$function: Method name


### PR DESCRIPTION
Set timeout after socket open, for subsequent operations.
Eliminated usleep(...) in response handling loop
Updated user guide page for xmlrpc library

Signed-off-by:Master Yoda <jim_parry@bcit.ca>