### PR TITLE
Create database if not exists support

### DIFF
--- a/system/database/DB_forge.php
+++ b/system/database/DB_forge.php
@@ -91,6 +91,13 @@ abstract class CI_DB_forge {
 	protected $_create_database	= 'CREATE DATABASE %s';
 
 	/**
+	 * CREATE DATABASE IF statement
+	 *
+	 * @var	string
+	 */
+	protected $_create_database_if	= FALSE;
+
+	/**
 	 * DROP DATABASE statement
 	 *
 	 * @var	string
@@ -176,15 +183,17 @@ abstract class CI_DB_forge {
 	 * Create database
 	 *
 	 * @param	string	$db_name
+	 * @param	bool	$if_not_exists	Whether to add IF NOT EXISTS condition
 	 * @return	bool
 	 */
-	public function create_database($db_name)
+	public function create_database($db_name, $if_not_exists = FALSE)
 	{
-		if ($this->_create_database === FALSE)
+		$statement = ($if_not_exists === FALSE) ? '_create_database' : '_create_database_if';
+		if ($this->$statement === FALSE)
 		{
 			return ($this->db->db_debug) ? $this->db->display_error('db_unsupported_feature') : FALSE;
 		}
-		elseif ( ! $this->db->query(sprintf($this->_create_database, $db_name, $this->db->char_set, $this->db->dbcollat)))
+		elseif ( ! $this->db->query(sprintf($this->$statement, $db_name, $this->db->char_set, $this->db->dbcollat)))
 		{
 			return ($this->db->db_debug) ? $this->db->display_error('db_unable_to_drop') : FALSE;
 		}

--- a/system/database/drivers/mysql/mysql_forge.php
+++ b/system/database/drivers/mysql/mysql_forge.php
@@ -54,6 +54,13 @@ class CI_DB_mysql_forge extends CI_DB_forge {
 	protected $_create_database	= 'CREATE DATABASE %s CHARACTER SET %s COLLATE %s';
 
 	/**
+	 * CREATE DATABASE IF statement
+	 *
+	 * @var	string
+	 */
+	protected $_create_database_if	= 'CREATE DATABASE IF NOT EXISTS %s CHARACTER SET %s COLLATE %s';
+
+	/**
 	 * CREATE TABLE keys flag
 	 *
 	 * Whether table keys are created from within the

--- a/system/database/drivers/mysqli/mysqli_forge.php
+++ b/system/database/drivers/mysqli/mysqli_forge.php
@@ -56,6 +56,13 @@ class CI_DB_mysqli_forge extends CI_DB_forge {
 	protected $_create_database	= 'CREATE DATABASE %s CHARACTER SET %s COLLATE %s';
 
 	/**
+	 * CREATE DATABASE IF statement
+	 *
+	 * @var	string
+	 */
+	protected $_create_database_if	= 'CREATE DATABASE IF NOT EXISTS %s CHARACTER SET %s COLLATE %s';
+
+	/**
 	 * CREATE TABLE keys flag
 	 *
 	 * Whether table keys are created from within the


### PR DESCRIPTION
Adds ability to support `CREATE DATABASE IF` statement in `CI_DB_Forge` classes.
It defaults to false, as I am not sure of the usage in every single DB driver, but in MySQL & MySQLIi set to the correct statement

This of course needs extending from people who know how to work with all DB drivers, and is just a start