### PR TITLE
Create database if not exists

### DIFF
--- a/system/database/DB_forge.php
+++ b/system/database/DB_forge.php
@@ -91,6 +91,13 @@ abstract class CI_DB_forge {
 	protected $_create_database	= 'CREATE DATABASE %s';
 
 	/**
+	 * CREATE DATABASE IF statement
+	 *
+	 * @var	string
+	 */
+	protected $_create_database_if	= FALSE;
+
+	/**
 	 * DROP DATABASE statement
 	 *
 	 * @var	string
@@ -176,15 +183,17 @@ abstract class CI_DB_forge {
 	 * Create database
 	 *
 	 * @param	string	$db_name
+	 * @param	bool	$if_not_exists	Whether to add IF NOT EXISTS condition
 	 * @return	bool
 	 */
-	public function create_database($db_name)
+	public function create_database($db_name, $if_not_exists = FALSE)
 	{
-		if ($this->_create_database === FALSE)
+		$statement = ($if_not_exists === FALSE) ? '_create_database' : '_create_database_if';
+		if ($this->$statement === FALSE)
 		{
 			return ($this->db->db_debug) ? $this->db->display_error('db_unsupported_feature') : FALSE;
 		}
-		elseif ( ! $this->db->query(sprintf($this->_create_database, $db_name, $this->db->char_set, $this->db->dbcollat)))
+		elseif ( ! $this->db->query(sprintf($this->$statement, $db_name, $this->db->char_set, $this->db->dbcollat)))
 		{
 			return ($this->db->db_debug) ? $this->db->display_error('db_unable_to_drop') : FALSE;
 		}

--- a/system/database/drivers/ibase/ibase_forge.php
+++ b/system/database/drivers/ibase/ibase_forge.php
@@ -91,16 +91,17 @@ class CI_DB_ibase_forge extends CI_DB_forge {
 	 * Create database
 	 *
 	 * @param	string	$db_name
-	 * @return	string
+	 * @param	bool	$if_not_exists	Whether to add IF NOT EXISTS condition
+	 * @return	bool
 	 */
-	public function create_database($db_name)
+	public function create_database($db_name, $if_not_exists = FALSE)
 	{
 		// Firebird databases are flat files, so a path is required
 
 		// Hostname is needed for remote access
 		empty($this->db->hostname) OR $db_name = $this->hostname.':'.$db_name;
 
-		return parent::create_database('"'.$db_name.'"');
+		return parent::create_database('"'.$db_name.'"', $if_not_exists);
 	}
 
 	// --------------------------------------------------------------------

--- a/system/database/drivers/mysql/mysql_forge.php
+++ b/system/database/drivers/mysql/mysql_forge.php
@@ -54,6 +54,13 @@ class CI_DB_mysql_forge extends CI_DB_forge {
 	protected $_create_database	= 'CREATE DATABASE %s CHARACTER SET %s COLLATE %s';
 
 	/**
+	 * CREATE DATABASE IF statement
+	 *
+	 * @var	string
+	 */
+	protected $_create_database_if	= 'CREATE DATABASE IF NOT EXISTS %s CHARACTER SET %s COLLATE %s';
+
+	/**
 	 * CREATE TABLE keys flag
 	 *
 	 * Whether table keys are created from within the

--- a/system/database/drivers/mysqli/mysqli_forge.php
+++ b/system/database/drivers/mysqli/mysqli_forge.php
@@ -56,6 +56,13 @@ class CI_DB_mysqli_forge extends CI_DB_forge {
 	protected $_create_database	= 'CREATE DATABASE %s CHARACTER SET %s COLLATE %s';
 
 	/**
+	 * CREATE DATABASE IF statement
+	 *
+	 * @var	string
+	 */
+	protected $_create_database_if	= 'CREATE DATABASE IF NOT EXISTS %s CHARACTER SET %s COLLATE %s';
+
+	/**
 	 * CREATE TABLE keys flag
 	 *
 	 * Whether table keys are created from within the

--- a/system/database/drivers/pdo/subdrivers/pdo_firebird_forge.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_firebird_forge.php
@@ -77,16 +77,17 @@ class CI_DB_pdo_firebird_forge extends CI_DB_pdo_forge {
 	 * Create database
 	 *
 	 * @param	string	$db_name
-	 * @return	string
+	 * @param	bool	$if_not_exists	Whether to add IF NOT EXISTS condition
+	 * @return	bool
 	 */
-	public function create_database($db_name)
+	public function create_database($db_name, $if_not_exists = FALSE)
 	{
 		// Firebird databases are flat files, so a path is required
 
 		// Hostname is needed for remote access
 		empty($this->db->hostname) OR $db_name = $this->hostname.':'.$db_name;
 
-		return parent::create_database('"'.$db_name.'"');
+		return parent::create_database('"'.$db_name.'"', $if_not_exists);
 	}
 
 	// --------------------------------------------------------------------

--- a/system/database/drivers/pdo/subdrivers/pdo_sqlite_forge.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_sqlite_forge.php
@@ -98,10 +98,11 @@ class CI_DB_pdo_sqlite_forge extends CI_DB_pdo_forge {
 	/**
 	 * Create database
 	 *
-	 * @param	string	$db_name	(ignored)
+	 * @param	string	$db_name        (ignored)
+	 * @param	bool	$if_not_exists	Whether to add IF NOT EXISTS condition
 	 * @return	bool
 	 */
-	public function create_database($db_name = '')
+	public function create_database($db_name='', $if_not_exists = FALSE)
 	{
 		// In SQLite, a database is created when you connect to the database.
 		// We'll return TRUE so that an error isn't generated

--- a/system/database/drivers/sqlite/sqlite_forge.php
+++ b/system/database/drivers/sqlite/sqlite_forge.php
@@ -72,10 +72,11 @@ class CI_DB_sqlite_forge extends CI_DB_forge {
 	/**
 	 * Create database
 	 *
-	 * @param	string	$db_name	(ignored)
+	 * @param	string	$db_name        (ignored)
+	 * @param	bool	$if_not_exists	Whether to add IF NOT EXISTS condition
 	 * @return	bool
 	 */
-	public function create_database($db_name = '')
+	public function create_database($db_name='', $if_not_exists = FALSE)
 	{
 		// In SQLite, a database is created when you connect to the database.
 		// We'll return TRUE so that an error isn't generated

--- a/system/database/drivers/sqlite3/sqlite3_forge.php
+++ b/system/database/drivers/sqlite3/sqlite3_forge.php
@@ -84,10 +84,11 @@ class CI_DB_sqlite3_forge extends CI_DB_forge {
 	/**
 	 * Create database
 	 *
-	 * @param	string	$db_name
+	 * @param	string	$db_name        (ignored)
+	 * @param	bool	$if_not_exists	Whether to add IF NOT EXISTS condition
 	 * @return	bool
 	 */
-	public function create_database($db_name = '')
+	public function create_database($db_name='', $if_not_exists = FALSE)
 	{
 		// In SQLite, a database is created when you connect to the database.
 		// We'll return TRUE so that an error isn't generated

--- a/user_guide_src/source/database/forge.rst
+++ b/user_guide_src/source/database/forge.rst
@@ -349,9 +349,10 @@ Class Reference
 
 		Adds a key to the set that will be used to create a table. Usage:  See `Adding Keys`_.
 
-	.. php:method:: create_database($db_name)
+	.. php:method:: create_database($db_name[, $if_not_exists = FALSE])
 
 		:param	string	$db_name: Name of the database to create
+        :param	string	$if_not_exists: Set to TRUE to add an 'IF NOT EXISTS' clause
 		:returns:	TRUE on success, FALSE on failure
 		:rtype:	bool
 


### PR DESCRIPTION
Adds ability to support CREATE DATABASE IF statement in CI_DB_Forge classes.
It defaults to false, as I am not sure of the usage in every single DB driver, but in MySQL & MySQLIi set to the correct statement. Other drivers does not support, but have the new signature, and class method documentation was added

This of course needs extending from people who know how to work with all DB drivers, and is just a start
