### PR TITLE
DB_Forge "_process_fields" can now handle "TEXT" fields

### DIFF
--- a/system/database/DB_forge.php
+++ b/system/database/DB_forge.php
@@ -777,6 +777,8 @@ abstract class CI_DB_forge {
 			{
 				switch (strtoupper($attributes['TYPE']))
 				{
+					case 'TEXT': // TEXT columns can not have a length
+						break;
 					case 'ENUM':
 					case 'SET':
 						$attributes['CONSTRAINT'] = $this->db->escape($attributes['CONSTRAINT']);


### PR DESCRIPTION
Before, If trying to add a new field, with type="text", and "length"=65535 which is the length taken from the database "information" tables, it would add a "mediumtext" field with size "16777215" on MySQL

Addressing issue [#4854](https://github.com/bcit-ci/CodeIgniter/issues/4854)
