### PR TITLE
Redis Lock sleep time to 0.1s from 1s.

### DIFF
--- a/system/libraries/Session/drivers/Session_redis_driver.php
+++ b/system/libraries/Session/drivers/Session_redis_driver.php
@@ -366,7 +366,7 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 		{
 			if (($ttl = $this->_redis->ttl($lock_key)) > 0)
 			{
-				sleep(1);
+				usleep(100000);
 				continue;
 			}
 


### PR DESCRIPTION
Performance of the CPU could not use in sleep.

$ h2load -n2000 -c80 --header="Accept-Encoding: gzip" https://localhost/

```
1s: finished in 45.89s, 43.58 req/s, 169.77KB/s
0.1s: finished in 16.47s, 303.51 req/s, 1.15MB/s
```
