### PR TITLE
Match both single and double quote in DB_driver

### DIFF
--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -982,7 +982,7 @@ abstract class CI_DB_driver {
 	 */
 	public function is_write_type($sql)
 	{
-		return (bool) preg_match('/^\s*"?(SET|INSERT|UPDATE|DELETE|REPLACE|CREATE|DROP|TRUNCATE|LOAD|COPY|ALTER|RENAME|GRANT|REVOKE|LOCK|UNLOCK|REINDEX)\s/i', $sql);
+		return (bool) preg_match('/^\s*["\']?(SET|INSERT|UPDATE|DELETE|REPLACE|CREATE|DROP|TRUNCATE|LOAD|COPY|ALTER|RENAME|GRANT|REVOKE|LOCK|UNLOCK|REINDEX)\s/i', $sql);
 	}
 
 	// --------------------------------------------------------------------

--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -938,7 +938,7 @@ abstract class CI_DB_driver {
 		$ml = strlen($this->bind_marker);
 
 		// Make sure not to replace a chunk inside a string that happens to match the bind marker
-		if ($c = preg_match_all("/'[^']*'/i", $sql, $matches))
+		if ($c = preg_match_all("/(['\"])[^\\1]*\\1/i", $sql, $matches))
 		{
 			$c = preg_match_all('/'.preg_quote($this->bind_marker, '/').'/i',
 				str_replace($matches[0],

--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -982,7 +982,7 @@ abstract class CI_DB_driver {
 	 */
 	public function is_write_type($sql)
 	{
-		return (bool) preg_match('/^\s*["\']?(SET|INSERT|UPDATE|DELETE|REPLACE|CREATE|DROP|TRUNCATE|LOAD|COPY|ALTER|RENAME|GRANT|REVOKE|LOCK|UNLOCK|REINDEX)\s/i', $sql);
+		return (bool) preg_match('/^\s*"?(SET|INSERT|UPDATE|DELETE|REPLACE|CREATE|DROP|TRUNCATE|LOAD|COPY|ALTER|RENAME|GRANT|REVOKE|LOCK|UNLOCK|REINDEX)\s/i', $sql);
 	}
 
 	// --------------------------------------------------------------------

--- a/system/database/drivers/odbc/odbc_driver.php
+++ b/system/database/drivers/odbc/odbc_driver.php
@@ -172,7 +172,7 @@ class CI_DB_odbc_driver extends CI_DB_driver {
 		$ml = strlen($this->bind_marker);
 
 		// Make sure not to replace a chunk inside a string that happens to match the bind marker
-		if ($c = preg_match_all("/'[^']*'/i", $sql, $matches))
+		if ($c = preg_match_all("/(['\"])[^\\1]*\\1/i", $sql, $matches))
 		{
 			$c = preg_match_all('/'.preg_quote($this->bind_marker, '/').'/i',
 				str_replace($matches[0],


### PR DESCRIPTION
I use the following code in controller.

```
$this->load->database();
$sql = 'select * from reader where reader_id = ? and level = ? and tag = "1?2"';
$binds = ['3456', '888'];
$compiled_sql = $this->db->compile_binds($sql, $binds);
echo $compiled_sql;
```

The expected output should be
`select * from reader where reader_id = '3456' and level = '888' and tag = "1?2"`

However,  get
`select * from reader where reader_id = ? and level = ? and tag = "1?2"`

It is because that double quote does not be matched in `compile_binds()`.

And the same with `is_write_type()`.
