### PR TITLE
Check filefino extention is loaded while uploading

### DIFF
--- a/system/language/english/upload_lang.php
+++ b/system/language/english/upload_lang.php
@@ -53,3 +53,4 @@ $lang['upload_no_filepath'] = 'The upload path does not appear to be valid.';
 $lang['upload_no_file_types'] = 'You have not specified any allowed file types.';
 $lang['upload_bad_filename'] = 'The file name you submitted already exists on the server.';
 $lang['upload_not_writable'] = 'The upload destination folder does not appear to be writable.';
+$lang['upload_fileinfo_notfound'] = 'Unable to load fileinfo extension.';

--- a/system/libraries/Upload.php
+++ b/system/libraries/Upload.php
@@ -1218,6 +1218,13 @@ class CI_Upload {
 		// We'll need this to validate the MIME info string (e.g. text/plain; charset=us-ascii)
 		$regexp = '/^([a-z\-]+\/[a-z0-9\-\.\+]+)(;\s.+)?$/';
 
+		//Check fileinfo extention is loaded or not
+		if(!extension_loaded('fileinfo')) 
+		{
+			$this->set_error('upload_fileinfo_notfound', 'error');
+			return;
+		}
+
 		// Fileinfo extension - most reliable method
 		$finfo = @finfo_open(FILEINFO_MIME);
 		if (is_resource($finfo)) // It is possible that a FALSE value is returned, if there is no magic MIME database file found on the system


### PR DESCRIPTION
Added function to check either fileinfo extention is loaded or not.
Before this check, if extention was not loaded, script jsut stop and
there is no log of what happend. Now this will generate an error log and
return.
