### PR TITLE
Download helper added new use case 

### DIFF
--- a/system/helpers/download_helper.php
+++ b/system/helpers/download_helper.php
@@ -70,7 +70,7 @@ if ( ! function_exists('force_download'))
 		elseif ($data === NULL)
 		{
 			// Is $filename an array as ['local source path' => 'destination filename']?
-			if(is_array($filename))
+			if(is_array($filename) && count($filename) === 1)
 			{
 				$filepath = key($filename);
 				$filename = current($filename);

--- a/system/helpers/download_helper.php
+++ b/system/helpers/download_helper.php
@@ -70,12 +70,12 @@ if ( ! function_exists('force_download'))
 		elseif ($data === NULL)
 		{
 			// Is $filename an array as ['local source path' => 'destination filename']?
-			if(is_array($filename) && count($filename) == 1)
+			if (is_array($filename) && count($filename) == 1)
 			{
 				$filepath = key($filename);
 				$filename = current($filename);
 
-				if(is_int($filepath))
+				if (is_int($filepath))
 				{
 					return;
 				}

--- a/system/helpers/download_helper.php
+++ b/system/helpers/download_helper.php
@@ -75,6 +75,11 @@ if ( ! function_exists('force_download'))
 				$filepath = key($filename);
 				$filename = current($filename);
 
+				if(is_int($filepath))
+				{
+					return;
+				}
+
 				if ( ! @is_file($filepath) OR ($filesize = @filesize($filepath)) === FALSE)
 				{
 					return;

--- a/system/helpers/download_helper.php
+++ b/system/helpers/download_helper.php
@@ -72,7 +72,7 @@ if ( ! function_exists('force_download'))
 			// Is $filename an array as ['local source path' => 'destination filename']?
 			if (is_array($filename))
 			{
-				if (count($filename) != 1)
+				if (count($filename) !== 1)
 				{
 					return;
 				}

--- a/system/helpers/download_helper.php
+++ b/system/helpers/download_helper.php
@@ -70,7 +70,7 @@ if ( ! function_exists('force_download'))
 		elseif ($data === NULL)
 		{
 			// Is $filename an array as ['local source path' => 'destination filename']?
-			if(is_array($filename) && count($filename))
+			if(is_array($filename) && count($filename) == 1)
 			{
 				$filepath = key($filename);
 				$filename = current($filename);

--- a/system/helpers/download_helper.php
+++ b/system/helpers/download_helper.php
@@ -70,7 +70,7 @@ if ( ! function_exists('force_download'))
 		elseif ($data === NULL)
 		{
 			// Is $filename an array as ['local source path' => 'destination filename']?
-			if(is_array($filename) && count($filename) === 1)
+			if(is_array($filename) && count($filename))
 			{
 				$filepath = key($filename);
 				$filename = current($filename);

--- a/system/helpers/download_helper.php
+++ b/system/helpers/download_helper.php
@@ -70,8 +70,13 @@ if ( ! function_exists('force_download'))
 		elseif ($data === NULL)
 		{
 			// Is $filename an array as ['local source path' => 'destination filename']?
-			if (is_array($filename) && count($filename) == 1)
+			if (is_array($filename))
 			{
+				if (count($filename) != 1)
+				{
+					return;
+				}
+
 				$filepath = key($filename);
 				$filename = current($filename);
 

--- a/system/helpers/download_helper.php
+++ b/system/helpers/download_helper.php
@@ -56,7 +56,7 @@ if ( ! function_exists('force_download'))
 	 *
 	 * Generates headers that force a download to happen
 	 *
-	 * @param	string	filename
+	 * @param	mixed	filename (or an array of local file path => destination filename)
 	 * @param	mixed	the data to be downloaded
 	 * @param	bool	whether to try and send the actual file MIME type
 	 * @return	void
@@ -69,14 +69,28 @@ if ( ! function_exists('force_download'))
 		}
 		elseif ($data === NULL)
 		{
-			if ( ! @is_file($filename) OR ($filesize = @filesize($filename)) === FALSE)
+			// Is $filename an array as ['local source path' => 'destination filename']?
+			if(is_array($filename))
 			{
-				return;
-			}
+				$filepath = key($filename);
+				$filename = current($filename);
 
-			$filepath = $filename;
-			$filename = explode('/', str_replace(DIRECTORY_SEPARATOR, '/', $filename));
-			$filename = end($filename);
+				if ( ! @is_file($filepath) OR ($filesize = @filesize($filepath)) === FALSE)
+				{
+					return;
+				}
+			}
+			else
+			{
+				if ( ! @is_file($filename) OR ($filesize = @filesize($filename)) === FALSE)
+				{
+					return;
+				}
+
+				$filepath = $filename;
+				$filename = explode('/', str_replace(DIRECTORY_SEPARATOR, '/', $filename));
+				$filename = end($filename);
+			}
 		}
 		else
 		{

--- a/user_guide_src/source/helpers/download_helper.rst
+++ b/user_guide_src/source/helpers/download_helper.rst
@@ -38,9 +38,10 @@ The following functions are available:
 
 	If you set the second parameter to NULL and ``$filename`` is an existing, readable
 	file path, then its content will be read instead. You may also set ``$filename``
-	as an array containing a single entry, the key being the existing, readable file path
-	and the value as the downloading file name.
-
+	as an associative array with a single element, where the key of that element would be 
+	the local file you are trying to read and where the value is the name of the downloadable
+	file that will be sent to browser. An example of this is provided below.
+	
 	If you set the third parameter to boolean TRUE, then the actual file MIME type
 	(based on the filename extension) will be sent, so that if your browser has a
 	handler for that type - it can use it.

--- a/user_guide_src/source/helpers/download_helper.rst
+++ b/user_guide_src/source/helpers/download_helper.rst
@@ -26,7 +26,7 @@ The following functions are available:
 
 .. php:function:: force_download([$filename = ''[, $data = ''[, $set_mime = FALSE]]])
 
-	:param	string	$filename: Filename
+	:param	mixed	$filename: Filename
 	:param	mixed	$data: File contents
 	:param	bool	$set_mime: Whether to try to send the actual MIME type
 	:rtype:	void
@@ -37,7 +37,9 @@ The following functions are available:
 	file data.
 
 	If you set the second parameter to NULL and ``$filename`` is an existing, readable
-	file path, then its content will be read instead.
+	file path, then its content will be read instead. You may also set ``$filename``
+	as an array containing a single entry, the key being the existing, readable file path
+	and the value as the downloading file name.
 
 	If you set the third parameter to boolean TRUE, then the actual file MIME type
 	(based on the filename extension) will be sent, so that if your browser has a
@@ -54,3 +56,9 @@ The following functions are available:
 
 		// Contents of photo.jpg will be automatically read
 		force_download('/path/to/photo.jpg', NULL);
+
+	If you want to download an existing file from your server, but change the name
+	of the actual file sent to browser, you will need this::
+
+		// Contents of photo.jpg will be automatically read and sent as my-photo.jpg
+		force_download(array('/path/to/photo.jpg' => 'my-photo.jpg'), NULL);


### PR DESCRIPTION
When using download helper, I can see 3 use cases:

1. You have the content of the file to be downloaded and you provide the name of file as it should be downloaded;
2. You have to read the content from disk and the downloaded file name will be the same as read file;
3. You have to read the content from disk and you provide the name of file as it should be downloaded.

At this point, the first 2 do exist and work. However, 3rd point can be achieved by dev by renaming the local file and then, most probably, renaming it back to original filename.
This PR adds the 3rd use case by letting you provide an array with one item in first param: [local file full path => browser filename].