### PR TITLE
Update to pdo_driver.php

### DIFF
--- a/system/database/drivers/pdo/pdo_driver.php
+++ b/system/database/drivers/pdo/pdo_driver.php
@@ -79,7 +79,11 @@ class CI_DB_pdo_driver extends CI_DB {
 	public function __construct($params)
 	{
 		parent::__construct($params);
-
+                if (preg_match('/(\w+)/', $this->dsn, $match) && get_cfg_var('pdo.dsn.' . $match[1]) !== false)
+                {
+                        $this->subdriver = $match[1];
+                        return;
+                } 
 		if (preg_match('/([^:]+):/', $this->dsn, $match) && count($match) === 2)
 		{
 			// If there is a minimum valid dsn string pattern found, we're done


### PR DESCRIPTION
This  update adds the ability to specify a pdo dsn that is defined in php.ini
For example in the  php.ini file you can say pdo.dsn.<dsn name> = "<connection string>"
And in your application you just specify the dsn name instead of the connection string.  The patch also verifies that the dsn is defined in the photo.ini and if it isn't it defaults back to regular behavior.