### PR TITLE
Support array parse in DB_query_builder::where/having

### DIFF
--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -664,14 +664,20 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 
 			if ($v !== NULL)
 			{
+				$is_array_value = is_array($v);
 				if ($escape === TRUE)
 				{
-					$v = ' '.$this->escape($v);
+					$v = $this->escape($v);
+					if ($is_array_value)
+					{
+						$v = '('.implode(',', $v).')';
+					}
+					$v = ' '.$v;
 				}
 
 				if ( ! $this->_has_operator($k))
 				{
-					$k .= ' = ';
+					$k .= $is_array_value ? ' IN ' : ' = ';
 				}
 			}
 			elseif ( ! $this->_has_operator($k))

--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -674,6 +674,10 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 					}
 					$v = ' '.$v;
 				}
+				elseif ($is_array_value)
+				{
+					$v = '('.implode(',', $v).')';
+				}
 
 				if ( ! $this->_has_operator($k))
 				{


### PR DESCRIPTION
Support the following use.

```
$this->db->where('type', array(8, 9, 10));
$this->db->where('account IN', array('account751000872', 'account781000967'));
$this->db->where('phone_num NOT IN', array('13800000000'));
```

AND

```
$this->db->select('channel_id, count(1) as num');
$this->db->group_by('channel_id');
$this->db->having('num IN ', array(88, 888));
```

Indeed, I could use `where_in` and `where_not_in` in the first case. However, sometimes I prefer to use as follows.

```
$where = array('type' => 10, 
			'account IN' => array('account751000872', 'account781000967'), 
                        'login_token NOT IN' => array('13800000000')
                 );
$this->db->where($where);
```

The same with `having`.