### PR TITLE
Fix order_by random for pdo(sqlite) driver

### DIFF
--- a/system/database/drivers/pdo/subdrivers/pdo_sqlite_driver.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_sqlite_driver.php
@@ -66,7 +66,7 @@ class CI_DB_pdo_sqlite_driver extends CI_DB_pdo_driver {
 	 *
 	 * @var	array
 	 */
-	protected $_random_keyword = ' RANDOM()';
+	protected $_random_keyword = array('RANDOM()', 'RANDOM()');
 
 	// --------------------------------------------------------------------
 


### PR DESCRIPTION
`order_by('column_name', 'random')` expects the driver's `$_random_keyword` to contain array with minimum two elements https://github.com/bcit-ci/CodeIgniter/blob/develop/system/database/DB_query_builder.php#L1191

Having string content generates invalid query like `SELECT * FROM table ORDER BY;`

Signed-off-by: aquilax <aquilax@gmail.com>