### PR TITLE
Remove needless constructor in model general topics documentation

### DIFF
--- a/user_guide_src/source/general/core_classes.rst
+++ b/user_guide_src/source/general/core_classes.rst
@@ -101,6 +101,7 @@ your new class in your application controller's constructors.
 		public function __construct()
 		{
 			parent::__construct();
+			// Your own constructor code
 		}
 
 		public function index()

--- a/user_guide_src/source/general/models.rst
+++ b/user_guide_src/source/general/models.rst
@@ -70,6 +70,7 @@ The basic prototype for a model class is this::
 		public function __construct()
 		{
 			parent::__construct();
+			// Your own constructor code
 		}
 
 	}
@@ -85,6 +86,7 @@ The file name must match the class name. For example, if this is your class::
 		public function __construct()
 		{
 			parent::__construct();
+			// Your own constructor code
 		}
 
 	}

--- a/user_guide_src/source/general/models.rst
+++ b/user_guide_src/source/general/models.rst
@@ -22,12 +22,6 @@ model class might look like::
 		public $content;
 		public $date;
 
-		public function __construct()
-		{
-			// Call the CI_Model constructor
-			parent::__construct();
-		}
-
 		public function get_last_ten_entries()
 		{
 			$query = $this->db->get('entries', 10);


### PR DESCRIPTION
I consider an empty constructor just calling the parent constructor pointless, and believe they should never exist, and as such should never be "suggested" by the documentation. In this PR I removed one such constructor, and added similar comments to others, where they exist in documentation to prove a point.