### PR TITLE
Fix bug: DB_query_builder do not add parenthesis for cached group_by

### DIFF
--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -1402,7 +1402,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 			$this->qb_orderby = NULL;
 		}
 
-		$result = ($this->qb_distinct === TRUE OR ! empty($this->qb_groupby))
+		$result = ($this->qb_distinct === TRUE OR ! empty($this->qb_groupby) OR in_array('groupby', $this->qb_cache_exists))
 			? $this->query($this->_count_string.$this->protect_identifiers('numrows')."\nFROM (\n".$this->_compile_select()."\n) CI_count_all_results")
 			: $this->query($this->_compile_select($this->_count_string.$this->protect_identifiers('numrows')));
 


### PR DESCRIPTION
Every time executing a SQL sentence, the query builder will be emptied except the cached parts.

However, when using count_all_results method, the function does not test the cached "group_by" clause, in the case where group_by is emptied but cached group_by is there. This flaw results in mistaken count for results.

In this pull request, this is fixed.