### PR TITLE
Fix the bug: DB_query_build does not use cached "group_by"

### DIFF
--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -1402,7 +1402,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 			$this->qb_orderby = NULL;
 		}
 
-		$result = ($this->qb_distinct === TRUE OR ! empty($this->qb_groupby))
+		$result = ($this->qb_distinct === TRUE OR ! empty($this->qb_groupby) OR in_array('groupby', $this->qb_cache_exists))
 			? $this->query($this->_count_string.$this->protect_identifiers('numrows')."\nFROM (\n".$this->_compile_select()."\n) CI_count_all_results")
 			: $this->query($this->_compile_select($this->_count_string.$this->protect_identifiers('numrows')));
 

--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -1402,7 +1402,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 			$this->qb_orderby = NULL;
 		}
 
-		$result = ($this->qb_distinct === TRUE OR ! empty($this->qb_groupby) OR in_array('groupby', $this->qb_cache_exists))
+		$result = ($this->qb_distinct === TRUE OR ! empty($this->qb_groupby) OR ! empty($this->qb_cache_groupby))
 			? $this->query($this->_count_string.$this->protect_identifiers('numrows')."\nFROM (\n".$this->_compile_select()."\n) CI_count_all_results")
 			: $this->query($this->_compile_select($this->_count_string.$this->protect_identifiers('numrows')));
 


### PR DESCRIPTION
Updated from pull request #4955
See PR #4955 