### PR TITLE
oci8_forge add column bug fix

### DIFF
--- a/system/database/drivers/oci8/oci8_forge.php
+++ b/system/database/drivers/oci8/oci8_forge.php
@@ -126,7 +126,7 @@ class CI_DB_oci8_forge extends CI_DB_forge {
 					$sqls[] = $sql.' RENAME COLUMN '.$this->db->escape_identifiers($field[$i]['name'])
 						.' '.$this->db->escape_identifiers($field[$i]['new_name']);
 				}
-				$field[$i] = $field[$i]['_literal'];
+				$field[$i] = "\n\t".$field[$i]['_literal'];
 			}
 		}
 

--- a/system/database/drivers/oci8/oci8_forge.php
+++ b/system/database/drivers/oci8/oci8_forge.php
@@ -126,6 +126,7 @@ class CI_DB_oci8_forge extends CI_DB_forge {
 					$sqls[] = $sql.' RENAME COLUMN '.$this->db->escape_identifiers($field[$i]['name'])
 						.' '.$this->db->escape_identifiers($field[$i]['new_name']);
 				}
+				$field[$i] = $field[$i]['_literal'];
 			}
 		}
 
@@ -136,7 +137,7 @@ class CI_DB_oci8_forge extends CI_DB_forge {
 
 		// RENAME COLUMN must be executed after MODIFY
 		array_unshift($sqls, $sql);
-		return $sql;
+		return $sqls;
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
I ran the following code and the following error occurred.

Code:
```php
$this->dbforge->add_column('sample', [
   'column_name1' => [
       'type' => 'char',
       'default' => '0'
   ],
   'column_name2' => [
       'type' => 'char',
       'default' => '0'
   ]
]);
```

Error
```shell
A PHP Error was encountered

Severity:    Notice
Message:     Array to string conversion
Filename:    /codeigniter/system/database/drivers/oci8/oci8_forge.php
Line Number: 136

```