### PR TITLE
Fixed regex used for loading helpers

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -590,7 +590,7 @@ class CI_Loader {
 		{
 			$filename = basename($helper);
 			$filepath = ($filename === $helper) ? '' : substr($helper, 0, strlen($helper) - strlen($filename));
-			$filename = strtolower(preg_replace('#(_helper)?(.php)?$#i', '', $filename)).'_helper';
+			$filename = strtolower(preg_replace('#(_helper)?(\.php)?$#i', '', $filename)).'_helper';
 			$helper   = $filepath.$filename;
 
 			if (isset($this->_ci_helpers[$helper]))


### PR DESCRIPTION
We want to exactly match a dot, so we have to escape it.

I found the bug because in my project I load an helper named `session_php_helper.php`, so the `_php` part gets removed and the `session_helper.php` helper gets loaded instead, this way not even an error was shown.