### PR TITLE
Add dump_cache() & restore_cache() to CI_DB_query_builder

### DIFF
--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -2642,7 +2642,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 */
 	public function dump_cache()
     {
-        return [
+        return array(
             'qb_cache_select'    => $this->qb_cache_select,
             'qb_cache_from'      => $this->qb_cache_from,
             'qb_cache_join'      => $this->qb_cache_join,
@@ -2653,7 +2653,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
             'qb_cache_set'       => $this->qb_cache_set,
             'qb_cache_exists'    => $this->qb_cache_exists,
             'qb_cache_no_escape' => $this->qb_cache_no_escape
-        ];
+        );
     }
 
 	// --------------------------------------------------------------------

--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -2632,6 +2632,47 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	}
 
 	// --------------------------------------------------------------------
+	
+	/**
+	 * Dump Cache
+	 *
+	 * Save (Dump) the QB cache
+	 *
+	 * @return	Array
+	 */
+	public function dump_cache()
+    {
+        return [
+            'qb_cache_select'    => $this->qb_cache_select,
+            'qb_cache_from'      => $this->qb_cache_from,
+            'qb_cache_join'      => $this->qb_cache_join,
+            'qb_cache_where'     => $this->qb_cache_where,
+            'qb_cache_groupby'   => $this->qb_cache_groupby,
+            'qb_cache_having'    => $this->qb_cache_having,
+            'qb_cache_orderby'   => $this->qb_cache_orderby,
+            'qb_cache_set'       => $this->qb_cache_set,
+            'qb_cache_exists'    => $this->qb_cache_exists,
+            'qb_cache_no_escape' => $this->qb_cache_no_escape
+        ];
+    }
+
+	// --------------------------------------------------------------------
+
+    /**
+	 * Restore Cache
+	 *
+	 * Restore the QB cache from saved QB cache
+	 *
+	 * @return	CI_DB_query_builder
+	 */
+	public function restore_cache($qb_cache = [])
+    {
+        $this->_reset_run($qb_cache);
+
+        return $this;
+    }
+
+	// --------------------------------------------------------------------
 
 	/**
 	 * Merge Cache


### PR DESCRIPTION
Add dump_cache() & restore_cache() to CI_DB_query_builder to enable temporary QB cache save.
 
Usage:

**Before flush:**
```
    $qb_cache = $this->db->dump_cache();
```

**Then, fell free to flush your cache:**
```
    $this->db->flush_cache();
```
**You do not have to flush the cache, you can also append some other conditions, and then restore with the save cache.**

**And after you make some other get (SELECT) calls then restore from your saved QB cache:**
```
    $this->db->restore_cache($qb_cache);
```

**And then, you can continue with other get (SELECT) calls with previously cached criteria.**

That's all this done.