### PR TITLE
Add aliased tables cache in query_builder.

### DIFF
--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -215,7 +215,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	protected $qb_cache_join			= array();
 
 	/**
-	 * QB Cache aliased tables list data
+	 * QB Cache aliased tables list
 	 *
 	 * @var	array
 	 */
@@ -2288,10 +2288,10 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 			$table = trim(strrchr($table, ' '));
 
 			// Store the alias, if it doesn't already exist
-			if ( ! in_array($table, $this->qb_aliased_tables))
+			if ( ! in_array($table, $this->qb_aliased_tables, TRUE))
 			{
 				$this->qb_aliased_tables[] = $table;
-				if ($this->qb_caching === TRUE && ! in_array($table, $this->qb_cache_aliased_tables))
+				if ($this->qb_caching === TRUE && ! in_array($table, $this->qb_cache_aliased_tables, TRUE))
 				{
 					$this->qb_cache_aliased_tables[] = $table;
 					$this->qb_cache_exists[] = 'aliased_tables';
@@ -2628,17 +2628,17 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	public function flush_cache()
 	{
 		$this->_reset_run(array(
-			'qb_cache_select'			=> array(),
-			'qb_cache_from'				=> array(),
-			'qb_cache_join'				=> array(),
+			'qb_cache_select'		=> array(),
+			'qb_cache_from'			=> array(),
+			'qb_cache_join'			=> array(),	
+			'qb_cache_where'		=> array(),
+			'qb_cache_groupby'		=> array(),
+			'qb_cache_having'		=> array(),
+			'qb_cache_orderby'		=> array(),
+			'qb_cache_set'			=> array(),
+			'qb_cache_exists'		=> array(),
+			'qb_cache_no_escape'	=> array(),
 			'qb_cache_aliased_tables'	=> array(),
-			'qb_cache_where'			=> array(),
-			'qb_cache_groupby'			=> array(),
-			'qb_cache_having'			=> array(),
-			'qb_cache_orderby'			=> array(),
-			'qb_cache_set'				=> array(),
-			'qb_cache_exists'			=> array(),
-			'qb_cache_no_escape'		=> array()
 		));
 
 		return $this;

--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -2630,7 +2630,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 		$this->_reset_run(array(
 			'qb_cache_select'		=> array(),
 			'qb_cache_from'			=> array(),
-			'qb_cache_join'			=> array(),	
+			'qb_cache_join'			=> array(),
 			'qb_cache_where'		=> array(),
 			'qb_cache_groupby'		=> array(),
 			'qb_cache_having'		=> array(),
@@ -2638,7 +2638,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 			'qb_cache_set'			=> array(),
 			'qb_cache_exists'		=> array(),
 			'qb_cache_no_escape'	=> array(),
-			'qb_cache_aliased_tables'	=> array(),
+			'qb_cache_aliased_tables'	=> array()
 		));
 
 		return $this;

--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -215,6 +215,13 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	protected $qb_cache_join			= array();
 
 	/**
+	 * QB Cache aliased tables list data
+	 *
+	 * @var	array
+	 */
+	protected $qb_cache_aliased_tables			= array();
+
+	/**
 	 * QB Cache WHERE data
 	 *
 	 * @var	array
@@ -2284,6 +2291,11 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 			if ( ! in_array($table, $this->qb_aliased_tables))
 			{
 				$this->qb_aliased_tables[] = $table;
+				if ($this->qb_caching === TRUE && ! in_array($table, $this->qb_cache_aliased_tables))
+				{
+					$this->qb_cache_aliased_tables[] = $table;
+					$this->qb_cache_exists[] = 'aliased_tables';
+				}
 			}
 		}
 	}
@@ -2616,16 +2628,17 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	public function flush_cache()
 	{
 		$this->_reset_run(array(
-			'qb_cache_select'		=> array(),
-			'qb_cache_from'			=> array(),
-			'qb_cache_join'			=> array(),
-			'qb_cache_where'		=> array(),
-			'qb_cache_groupby'		=> array(),
-			'qb_cache_having'		=> array(),
-			'qb_cache_orderby'		=> array(),
-			'qb_cache_set'			=> array(),
-			'qb_cache_exists'		=> array(),
-			'qb_cache_no_escape'	=> array()
+			'qb_cache_select'			=> array(),
+			'qb_cache_from'				=> array(),
+			'qb_cache_join'				=> array(),
+			'qb_cache_aliased_tables'	=> array(),
+			'qb_cache_where'			=> array(),
+			'qb_cache_groupby'			=> array(),
+			'qb_cache_having'			=> array(),
+			'qb_cache_orderby'			=> array(),
+			'qb_cache_set'				=> array(),
+			'qb_cache_exists'			=> array(),
+			'qb_cache_no_escape'		=> array()
 		));
 
 		return $this;
@@ -2675,13 +2688,6 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 			{
 				$this->qb_no_escape = $qb_no_escape;
 			}
-		}
-
-		// If we are "protecting identifiers" we need to examine the "from"
-		// portion of the query to determine if there are any aliases
-		if ($this->_protect_identifiers === TRUE && count($this->qb_cache_from) > 0)
-		{
-			$this->_track_aliases($this->qb_from);
 		}
 	}
 


### PR DESCRIPTION
Set `$_protect_identifiers` to `TRUE` and also set `dbprefix` to `ok_`.

Then I used the following code:
```
$this->db->start_cache();
$this->db->select('us.name');
$this->db->from('user as us');
$this->db->stop_cache();
$sql = $this->db->get_compiled_select('');
echo $sql."\n";
$sql = $this->db->get_compiled_select('');
echo $sql."\n";
```

and got

```
SELECT `us`.`name` FROM `ok_user` as `us`
SELECT `ok_us`.`name` FROM `ok_user` as `us`
```

The table prefix was not properly processed in `CI_DB_query_builder::_merge_cache()`. 

And the similar situation when using qb cache with alias in JOIN statement.  For example,
```
$this->db->start_cache();
$this->db->select('user.name, jo.description');
$this->db->from('user');
$this->db->join('job as jo', 'user.name = jo.name');
$this->db->stop_cache();
$sql = $this->db->get_compiled_select('');
echo $sql."\n";
$sql = $this->db->get_compiled_select('');
echo $sql."\n";
```
And got
```
SELECT `ok_user`.`name`, `jo`.`description` FROM `ok_user` JOIN `ok_job` as `jo` ON `ok_user`.`name` = `jo`.`name`
SELECT `ok_user`.`name`, `ok_jo`.`description` FROM `ok_user` JOIN `ok_job` as `jo` ON `ok_user`.`name` = `jo`.`name`
```
Because $qb_aliased_tables was reset to empty array and not be reprocessed when merging JOIN cache.

So I add aliased tables cache in this PR to fix them.