### PR TITLE
Fixed show_error() for check $exit_status

### DIFF
--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -409,11 +409,6 @@ if ( ! function_exists('show_error'))
 		if ($status_code < 100)
 		{
 			$exit_status = $status_code + 9; // 9 is EXIT__AUTO_MIN
-			if ($exit_status > 125) // 125 is EXIT__AUTO_MAX
-			{
-				$exit_status = 1; // EXIT_ERROR
-			}
-
 			$status_code = 500;
 		}
 		else


### PR DESCRIPTION
At the beginning of the function it checks whether a parameter $status_code is less than 100. Then the parameter $exit_status is formed by summing the $status_code + 9. In this case, the parameter $exit_status can not be more than 108, but somehow it is checked whether the value of the parameter $exit_status over 125. Such a situation can not occur under any circumstances.