### PR TITLE
add attribute in form_dropdown in form_helper.php

### DIFF
--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -419,16 +419,49 @@ if ( ! function_exists('form_dropdown'))
 					continue;
 				}
 
-				$form .= '<optgroup label="'.$key."\">\n";
+                                if(array_key_exists('data', $val))
+                                {
+                                        $attributes_ = array();
+                                        
+                                        foreach ($val as $k_=>$v_)
+                                        {
+                                            $k_ = (string) $k_;
+                                            
+                                            if($k_ === 'data')
+                                            {
+                                                continue;
+                                            }
+                                            
+                                            $value__ = '';
+                                            
+                                            if(!array_key_exists('value', $val))
+                                            {
+                                                $value__='value="'.html_escape($key).'"';
+                                            }
+                                            
+                                            $attributes_[$k_] = $v_;
+                                        }
+                                        
+                                        $attributes_ = _attributes_to_string($attributes_);
+                                        
+                                        $form .= '<option '.$value__.$attributes_
+                                            .(in_array($key, $selected) ? ' selected="selected"' : '').'>'
+                                            .(string) $val['data']."</option>\n";
+                                }
+                                else
+                                {
+                                
+                                        $form .= '<optgroup label="'.$key."\">\n";
 
-				foreach ($val as $optgroup_key => $optgroup_val)
-				{
-					$sel = in_array($optgroup_key, $selected) ? ' selected="selected"' : '';
-					$form .= '<option value="'.html_escape($optgroup_key).'"'.$sel.'>'
-						.(string) $optgroup_val."</option>\n";
-				}
+                                        foreach ($val as $optgroup_key => $optgroup_val)
+                                        {
+                                                $sel = in_array($optgroup_key, $selected) ? ' selected="selected"' : '';
+                                                $form .= '<option value="'.html_escape($optgroup_key).'"'.$sel.'>'
+                                                        .(string) $optgroup_val."</option>\n";
+                                        }
 
-				$form .= "</optgroup>\n";
+                                        $form .= "</optgroup>\n";
+                                }
 			}
 			else
 			{


### PR DESCRIPTION
I add some function of form_dropdown in form_helper.
that can add additionally attribute in `<option>`

**here is a sample usage:**

```
echo form_dropdown(
                'child_count',
                array(
                    '1'=>'a',
                    ''=>array('data'=>'test1','class'=>'imclass','id'=>''),
                    array('data'=>'test2','id'=>'imid()','value'=>'imval'),
                 ),
                set_value('child_count'),
                array('class' => 'cs-select cs-skin-elastic')
        );
```

**then the output:**

```
<select name="child_count" class="cs-select cs-skin-elastic">
     <option value="1">a</option>
     <option value="" class="imclass" id="" selected="selected">test1</option>
     <option  id="imid()" value="imval">test2</option>
</select>
```