### PR TITLE
Do not send secure cookie if not https

### DIFF
--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -318,6 +318,13 @@ class CI_Input {
 			}
 		}
 
+		// Do not send secure cookie if not https
+		$secure_cookie = (bool) config_item('cookie_secure');
+		if ($secure_cookie && ! is_https())
+		{
+			return;
+		}
+		
 		if ($prefix === '' && config_item('cookie_prefix') !== '')
 		{
 			$prefix = config_item('cookie_prefix');

--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -340,7 +340,7 @@ class CI_Input {
 			$path = config_item('cookie_path');
 		}
 
-		if ($secure === FALSE && config_item('cookie_secure') === TRUE)
+		if ($secure === FALSE && $secure_cookie === TRUE)
 		{
 			$secure = config_item('cookie_secure');
 		}


### PR DESCRIPTION
Like in CI_Security::csrf_set_cookie.
Otherwise cookie will be exposed over http and can be used from client side to server over https