### PR TITLE
Allow to omit trailing slash in config paths

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -221,7 +221,7 @@ $config['log_threshold'] = 0;
 |--------------------------------------------------------------------------
 |
 | Leave this BLANK unless you would like to set something other than the default
-| application/logs/ directory. Use a full server path with trailing slash.
+| application/logs/ directory. Use a full server path.
 |
 */
 $config['log_path'] = '';
@@ -269,7 +269,7 @@ $config['log_date_format'] = 'Y-m-d H:i:s';
 |--------------------------------------------------------------------------
 |
 | Leave this BLANK unless you would like to set something other than the default
-| application/views/errors/ directory.  Use a full server path with trailing slash.
+| application/views/errors/ directory.  Use a full server path.
 |
 */
 $config['error_views_path'] = '';
@@ -280,7 +280,7 @@ $config['error_views_path'] = '';
 |--------------------------------------------------------------------------
 |
 | Leave this BLANK unless you would like to set something other than the default
-| application/cache/ directory.  Use a full server path with trailing slash.
+| application/cache/ directory.  Use a full server path.
 |
 */
 $config['cache_path'] = '';

--- a/system/core/Exceptions.php
+++ b/system/core/Exceptions.php
@@ -161,6 +161,10 @@ class CI_Exceptions {
 		{
 			$templates_path = VIEWPATH.'errors'.DIRECTORY_SEPARATOR;
 		}
+		else
+		{
+			$templates_path = rtrim($templates_path, '/\\').DIRECTORY_SEPARATOR;
+		}
 
 		if (is_cli())
 		{
@@ -193,6 +197,10 @@ class CI_Exceptions {
 		if (empty($templates_path))
 		{
 			$templates_path = VIEWPATH.'errors'.DIRECTORY_SEPARATOR;
+		}
+		else
+		{
+			$templates_path = rtrim($templates_path, '/\\').DIRECTORY_SEPARATOR;
 		}
 
 		$message = $exception->getMessage();
@@ -239,6 +247,10 @@ class CI_Exceptions {
 		if (empty($templates_path))
 		{
 			$templates_path = VIEWPATH.'errors'.DIRECTORY_SEPARATOR;
+		}
+		else
+		{
+			$templates_path = rtrim($templates_path, '/\\').DIRECTORY_SEPARATOR;
 		}
 
 		$severity = isset($this->levels[$severity]) ? $this->levels[$severity] : $severity;

--- a/system/core/Log.php
+++ b/system/core/Log.php
@@ -124,7 +124,9 @@ class CI_Log {
 
 		isset(self::$func_override) OR self::$func_override = (extension_loaded('mbstring') && ini_get('mbstring.func_override'));
 
-		$this->_log_path = ($config['log_path'] !== '') ? $config['log_path'] : APPPATH.'logs/';
+		$this->_log_path = ($config['log_path'] !== '')
+			? rtrim($config['log_path'], '/\\').DIRECTORY_SEPARATOR : APPPATH.'logs'.DIRECTORY_SEPARATOR;
+
 		$this->_file_ext = (isset($config['log_file_extension']) && $config['log_file_extension'] !== '')
 			? ltrim($config['log_file_extension'], '.') : 'php';
 

--- a/system/core/Output.php
+++ b/system/core/Output.php
@@ -554,7 +554,7 @@ class CI_Output {
 	{
 		$CI =& get_instance();
 		$path = $CI->config->item('cache_path');
-		$cache_path = ($path === '') ? APPPATH.'cache/' : $path;
+		$cache_path = ($path === '') ? APPPATH.'cache'.DIRECTORY_SEPARATOR : rtrim($path, '/\\').DIRECTORY_SEPARATOR;
 
 		if ( ! is_dir($cache_path) OR ! is_really_writable($cache_path))
 		{


### PR DESCRIPTION
This always has bugged me :)

Let's be kind to the developer, don't break everything if he provided a path without trailing slash.