### PR TITLE
Do not fail if the array pointer is after the element

### DIFF
--- a/system/helpers/download_helper.php
+++ b/system/helpers/download_helper.php
@@ -77,6 +77,7 @@ if ( ! function_exists('force_download'))
 					return;
 				}
 
+				reset($filename);
 				$filepath = key($filename);
 				$filename = current($filename);
 


### PR DESCRIPTION
We should not assume the passed array has its pointer set to the first element.