### PR TITLE
Do not strip substrings looking like URL encode sequences

### DIFF
--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -1118,7 +1118,7 @@ abstract class CI_DB_driver {
 	 */
 	protected function _escape_str($str)
 	{
-		return str_replace("'", "''", remove_invisible_characters($str));
+		return str_replace("'", "''", remove_invisible_characters($str, FALSE));
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
Fixes #4815.

Indeed, in SQL context there are no URL encode sequences.