### PR TITLE
Introduce APCu driver

### DIFF
--- a/system/libraries/Cache/Cache.php
+++ b/system/libraries/Cache/Cache.php
@@ -55,6 +55,7 @@ class CI_Cache extends CI_Driver_Library {
 	 */
 	protected $valid_drivers = array(
 		'apc',
+		'apcu',
 		'dummy',
 		'file',
 		'memcached',

--- a/system/libraries/Cache/drivers/Cache_apcu.php
+++ b/system/libraries/Cache/drivers/Cache_apcu.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * CodeIgniter
+ *
+ * An open source application development framework for PHP
+ *
+ * This content is released under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 - 2017, British Columbia Institute of Technology
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @package	CodeIgniter
+ * @author	EllisLab Dev Team
+ * @copyright	Copyright (c) 2008 - 2014, EllisLab, Inc. (https://ellislab.com/)
+ * @copyright	Copyright (c) 2014 - 2017, British Columbia Institute of Technology (http://bcit.ca/)
+ * @license	http://opensource.org/licenses/MIT	MIT License
+ * @link	https://codeigniter.com
+ * @since	Version 2.0.0
+ * @filesource
+ */
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+/**
+ * CodeIgniter APC Caching Class
+ *
+ * @package		CodeIgniter
+ * @subpackage	Libraries
+ * @category	Core
+ * @author		EllisLab Dev Team
+ * @link
+ */
+class CI_Cache_apc extends CI_Driver {
+
+	/**
+	 * Class constructor
+	 *
+	 * Only present so that an error message is logged
+	 * if APC is not available.
+	 *
+	 * @return	void
+	 */
+	public function __construct()
+	{
+		if ( ! $this->is_supported())
+		{
+			log_message('error', 'Cache: Failed to initialize APC; extension not loaded/enabled?');
+		}
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Get
+	 *
+	 * Look for a value in the cache. If it exists, return the data
+	 * if not, return FALSE
+	 *
+	 * @param	string
+	 * @return	mixed	value that is stored/FALSE on failure
+	 */
+	public function get($id)
+	{
+		$success = FALSE;
+		$data = apc_fetch($id, $success);
+
+		if ($success === TRUE)
+		{
+			return is_array($data)
+				? unserialize($data[0])
+				: $data;
+		}
+
+		return FALSE;
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Cache Save
+	 *
+	 * @param	string	$id	Cache ID
+	 * @param	mixed	$data	Data to store
+	 * @param	int	$ttl	Length of time (in seconds) to cache the data
+	 * @param	bool	$raw	Whether to store the raw value
+	 * @return	bool	TRUE on success, FALSE on failure
+	 */
+	public function save($id, $data, $ttl = 60, $raw = FALSE)
+	{
+		$ttl = (int) $ttl;
+
+		return apc_store(
+			$id,
+			($raw === TRUE ? $data : array(serialize($data), time(), $ttl)),
+			$ttl
+		);
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Delete from Cache
+	 *
+	 * @param	mixed	unique identifier of the item in the cache
+	 * @return	bool	true on success/false on failure
+	 */
+	public function delete($id)
+	{
+		return apc_delete($id);
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Increment a raw value
+	 *
+	 * @param	string	$id	Cache ID
+	 * @param	int	$offset	Step/value to add
+	 * @return	mixed	New value on success or FALSE on failure
+	 */
+	public function increment($id, $offset = 1)
+	{
+		return apc_inc($id, $offset);
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Decrement a raw value
+	 *
+	 * @param	string	$id	Cache ID
+	 * @param	int	$offset	Step/value to reduce by
+	 * @return	mixed	New value on success or FALSE on failure
+	 */
+	public function decrement($id, $offset = 1)
+	{
+		return apc_dec($id, $offset);
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Clean the cache
+	 *
+	 * @return	bool	false on failure/true on success
+	 */
+	public function clean()
+	{
+		return apc_clear_cache('user');
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Cache Info
+	 *
+	 * @param	string	user/filehits
+	 * @return	mixed	array on success, false on failure
+	 */
+	 public function cache_info($type = NULL)
+	 {
+		 return apc_cache_info($type);
+	 }
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Get Cache Metadata
+	 *
+	 * @param	mixed	key to get cache metadata on
+	 * @return	mixed	array on success/false on failure
+	 */
+	public function get_metadata($id)
+	{
+		$success = FALSE;
+		$stored = apc_fetch($id, $success);
+
+		if ($success === FALSE OR count($stored) !== 3)
+		{
+			return FALSE;
+		}
+
+		list($data, $time, $ttl) = $stored;
+
+		return array(
+			'expire'	=> $time + $ttl,
+			'mtime'		=> $time,
+			'data'		=> unserialize($data)
+		);
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * is_supported()
+	 *
+	 * Check to see if APC is available on this system, bail if it isn't.
+	 *
+	 * @return	bool
+	 */
+	public function is_supported()
+	{
+		return (extension_loaded('apc') && ini_get('apc.enabled'));
+	}
+}

--- a/system/libraries/Cache/drivers/Cache_apcu.php
+++ b/system/libraries/Cache/drivers/Cache_apcu.php
@@ -82,7 +82,7 @@ class CI_Cache_apcu extends CI_Driver {
 		if ($success === TRUE)
 		{
 			return is_array($data)
-				? unserialize($data[0])
+				? $data[0]
 				: $data;
 		}
 
@@ -106,7 +106,7 @@ class CI_Cache_apcu extends CI_Driver {
 
 		return apcu_store(
 			$id,
-			($raw === TRUE ? $data : array(serialize($data), time(), $ttl)),
+			($raw === TRUE ? $data : array($data, time(), $ttl)),
 			$ttl
 		);
 	}
@@ -199,7 +199,7 @@ class CI_Cache_apcu extends CI_Driver {
 		return array(
 			'expire'  => $time + $ttl,
 			'mtime'   => $time,
-			'data'    => unserialize($data)
+			'data'    => $data
 		);
 	}
 

--- a/system/libraries/Cache/drivers/Cache_apcu.php
+++ b/system/libraries/Cache/drivers/Cache_apcu.php
@@ -38,7 +38,7 @@
 defined('BASEPATH') OR exit('No direct script access allowed');
 
 /**
- * CodeIgniter APC Caching Class
+ * CodeIgniter APCu Caching Class
  *
  * @package		CodeIgniter
  * @subpackage	Libraries
@@ -46,13 +46,13 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  * @author		EllisLab Dev Team
  * @link
  */
-class CI_Cache_apc extends CI_Driver {
+class CI_Cache_apcu extends CI_Driver {
 
 	/**
 	 * Class constructor
 	 *
 	 * Only present so that an error message is logged
-	 * if APC is not available.
+	 * if APCu is not available.
 	 *
 	 * @return	void
 	 */
@@ -60,7 +60,7 @@ class CI_Cache_apc extends CI_Driver {
 	{
 		if ( ! $this->is_supported())
 		{
-			log_message('error', 'Cache: Failed to initialize APC; extension not loaded/enabled?');
+			log_message('error', 'Cache: Failed to initialize APCu; extension not loaded/enabled?');
 		}
 	}
 
@@ -78,7 +78,7 @@ class CI_Cache_apc extends CI_Driver {
 	public function get($id)
 	{
 		$success = FALSE;
-		$data = apc_fetch($id, $success);
+		$data = apcu_fetch($id, $success);
 
 		if ($success === TRUE)
 		{
@@ -105,7 +105,7 @@ class CI_Cache_apc extends CI_Driver {
 	{
 		$ttl = (int) $ttl;
 
-		return apc_store(
+		return apcu_store(
 			$id,
 			($raw === TRUE ? $data : array(serialize($data), time(), $ttl)),
 			$ttl
@@ -122,7 +122,7 @@ class CI_Cache_apc extends CI_Driver {
 	 */
 	public function delete($id)
 	{
-		return apc_delete($id);
+		return apcu_delete($id);
 	}
 
 	// ------------------------------------------------------------------------
@@ -136,7 +136,7 @@ class CI_Cache_apc extends CI_Driver {
 	 */
 	public function increment($id, $offset = 1)
 	{
-		return apc_inc($id, $offset);
+		return apcu_inc($id, $offset);
 	}
 
 	// ------------------------------------------------------------------------
@@ -150,7 +150,7 @@ class CI_Cache_apc extends CI_Driver {
 	 */
 	public function decrement($id, $offset = 1)
 	{
-		return apc_dec($id, $offset);
+		return apcu_dec($id, $offset);
 	}
 
 	// ------------------------------------------------------------------------
@@ -162,7 +162,7 @@ class CI_Cache_apc extends CI_Driver {
 	 */
 	public function clean()
 	{
-		return apc_clear_cache('user');
+		return apcu_clear_cache();
 	}
 
 	// ------------------------------------------------------------------------
@@ -170,12 +170,12 @@ class CI_Cache_apc extends CI_Driver {
 	/**
 	 * Cache Info
 	 *
-	 * @param	string	user/filehits
+	 * @param	bool	Whether to exclude the individual list of cache entries
 	 * @return	mixed	array on success, false on failure
 	 */
-	 public function cache_info($type = NULL)
+	 public function cache_info($limited = FALSE)
 	 {
-		 return apc_cache_info($type);
+		 return apcu_cache_info($limited);
 	 }
 
 	// ------------------------------------------------------------------------
@@ -189,7 +189,7 @@ class CI_Cache_apc extends CI_Driver {
 	public function get_metadata($id)
 	{
 		$success = FALSE;
-		$stored = apc_fetch($id, $success);
+		$stored = apcu_fetch($id, $success);
 
 		if ($success === FALSE OR count($stored) !== 3)
 		{
@@ -210,12 +210,12 @@ class CI_Cache_apc extends CI_Driver {
 	/**
 	 * is_supported()
 	 *
-	 * Check to see if APC is available on this system, bail if it isn't.
+	 * Check to see if APCu is available on this system, bail if it isn't.
 	 *
 	 * @return	bool
 	 */
 	public function is_supported()
 	{
-		return (extension_loaded('apc') && ini_get('apc.enabled'));
+		return (extension_loaded('apcu') && ini_get('apc.enabled'));
 	}
 }

--- a/system/libraries/Cache/drivers/Cache_apcu.php
+++ b/system/libraries/Cache/drivers/Cache_apcu.php
@@ -169,12 +169,11 @@ class CI_Cache_apcu extends CI_Driver {
 	/**
 	 * Cache Info
 	 *
-	 * @param	bool	Whether to exclude the individual list of cache entries
 	 * @return	mixed	array on success, false on failure
 	 */
-	 public function cache_info($limited = FALSE)
+	 public function cache_info()
 	 {
-		 return apcu_cache_info($limited);
+		 return apcu_cache_info();
 	 }
 
 	// ------------------------------------------------------------------------

--- a/system/libraries/Cache/drivers/Cache_apcu.php
+++ b/system/libraries/Cache/drivers/Cache_apcu.php
@@ -44,7 +44,6 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  * @subpackage	Libraries
  * @category	Core
  * @author		CodeIgniter Dev team
- * @link
  */
 class CI_Cache_apcu extends CI_Driver {
 

--- a/system/libraries/Cache/drivers/Cache_apcu.php
+++ b/system/libraries/Cache/drivers/Cache_apcu.php
@@ -43,7 +43,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  * @package		CodeIgniter
  * @subpackage	Libraries
  * @category	Core
- * @author		EllisLab Dev Team
+ * @author		CodeIgniter Dev team
  * @link
  */
 class CI_Cache_apcu extends CI_Driver {

--- a/system/libraries/Cache/drivers/Cache_apcu.php
+++ b/system/libraries/Cache/drivers/Cache_apcu.php
@@ -32,7 +32,7 @@
  * @copyright	Copyright (c) 2014 - 2017, British Columbia Institute of Technology (http://bcit.ca/)
  * @license	http://opensource.org/licenses/MIT	MIT License
  * @link	https://codeigniter.com
- * @since	Version 2.0.0
+ * @since	Version 3.2.0
  * @filesource
  */
 defined('BASEPATH') OR exit('No direct script access allowed');

--- a/system/libraries/Cache/drivers/Cache_apcu.php
+++ b/system/libraries/Cache/drivers/Cache_apcu.php
@@ -198,9 +198,9 @@ class CI_Cache_apcu extends CI_Driver {
 		list($data, $time, $ttl) = $stored;
 
 		return array(
-			'expire'	=> $time + $ttl,
-			'mtime'		=> $time,
-			'data'		=> unserialize($data)
+			'expire'  => $time + $ttl,
+			'mtime'   => $time,
+			'data'    => unserialize($data)
 		);
 	}
 


### PR DESCRIPTION
I recently work on PHP7 and APCu with CodeIgniter, but there is no built-in APCu driver.
So I create APCu cache driver and [Prefix]_Cache, but I want to use it as a built-in driver.

This is compatible with existing driver usage.

```php
$this->load->driver('cache', 
    array('adapter' => 'apcu')
);
$bar = 'bar'
$this->cache->save('foo', $bar);

$this->cache->get('foo') // output 'bar'
```