### PR TITLE
DB_query_builder: Add cache merge flag.

### DIFF
--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -187,6 +187,13 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	protected $qb_caching				= FALSE;
 
 	/**
+	 * QB Cache merge flag
+	 *
+	 * @var	bool
+	 */
+	protected $qb_cache_merged				= FALSE;
+
+	/**
 	 * QB Cache exists list
 	 *
 	 * @var	array
@@ -2735,6 +2742,12 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 */
 	protected function _merge_cache()
 	{
+		if ($this->qb_cache_merged === TRUE)
+		{
+			return;
+		}
+		$this->qb_cache_merged = TRUE;
+
 		if (count($this->qb_cache_exists) === 0)
 		{
 			return;
@@ -2853,7 +2866,8 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 			'qb_no_escape'		=> array(),
 			'qb_distinct'		=> FALSE,
 			'qb_limit'		=> FALSE,
-			'qb_offset'		=> FALSE
+			'qb_offset'		=> FALSE,
+			'qb_cache_merged'	=> FALSE
 		));
 	}
 
@@ -2876,7 +2890,8 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 			'qb_where'	=> array(),
 			'qb_orderby'	=> array(),
 			'qb_keys'	=> array(),
-			'qb_limit'	=> FALSE
+			'qb_limit'	=> FALSE,
+			'qb_cache_merged'	=> FALSE
 		));
 	}
 


### PR DESCRIPTION
I used the following code
```
$this->db->select('id, country');
$this->db->start_cache();
$this->db->where('id >', -9);		
$this->db->stop_cache();
$sql = $this->db->get_compiled_select('user', false);
echo $sql."\n";
$query = $this->db->get('');
```
the last `get()` generated
`SELECT id, country FROM user WHERE id > -9 id > -9`
and then caused a error.

When calling `get_compiled_select()`, each item in `$qb_XXX`(such as `$qb_where`, `$qb_groupby`) would be complied into a string, and they are not reset due to the second param of `get_compiled_select()` set to `TRUE`, then `$qb_cache_XXX` will be merged into `$qb_XXX` again while calling get() later.

So I add a $qb_cache_merged flag to fix it.