### PR TITLE
Added complete list of of Postgres libpq-connect options to Postgres Driver

### DIFF
--- a/system/database/drivers/postgre/postgre_driver.php
+++ b/system/database/drivers/postgre/postgre_driver.php
@@ -128,11 +128,15 @@ class CI_DB_postgre_driver extends CI_DB {
 		 *
 		 * postgre://username:password@localhost:5432/database?connect_timeout=5&sslmode=1
 		 */
-		foreach (array('connect_timeout', 'options', 'sslmode', 'service') as $key)
+		foreach (array('connect_timeout', 'client_encoding', 'options',
+			'application_name', 'fallback_application_name', 'keepalives',
+			'keepalives_idle', 'keepalives_interval', 'keepalives_count', 'tty',
+			'sslmode', 'requiressl', 'sslcert', 'sslkey', 'sslrootcert', 'sslcrl',
+			'requirepeer', 'krbsrvname', 'gsslib', 'service') as $key)
 		{
-			if (isset($this->$key) && is_string($this->key) && $this->key !== '')
+			if (isset($this->$key) && is_string($this->$key) && $this->$key !== '')
 			{
-				$this->dsn .= $key."='".$this->key."' ";
+				$this->dsn .= $key."='".$this->$key."' ";
 			}
 		}
 


### PR DESCRIPTION
Thanks to all of you who work to keep CodeIgniter running!

In an earlier bug report/issue (https://github.com/bcit-ci/CodeIgniter/issues/5057) there was discussion about the list of options currently supported in the Postgres libpq-connect string. In my own app I'm using the 'sslrootcert' option. I went to the Postgres documentation to see what else is allowed: https://www.postgresql.org/docs/9.1/static/libpq-connect.html

I have updated the list to include all valid options. I'm thinking the purpose of the foreach loop is to prevent programmers/whoever from generating non-valid options to postgres. The way it stands now it prevents valid (and in my case necessary) options.

BTW, it is not a big deal for me to just patch the core with my own option list ... and as far as I can tell, I'm the only person on the planet who uses this section of code! :-) Part of me is not particularly thrilled that I will have to go through such a long list every time I connect to the db. Anyway, let me know your thoughts ... I'm fine with whatever gets decided.

P.S. I wasn't sure what to do about the key/$key issue since that was already accepted.