### PR TITLE
Fix directory delimiter when load local file.

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -886,11 +886,13 @@ class CI_Loader {
 		// Set the path to the requested file
 		if (is_string($_ci_path) && $_ci_path !== '')
 		{
+			$_ci_path = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $_ci_path);
 			$_ci_x = explode('/', $_ci_path);
 			$_ci_file = end($_ci_x);
 		}
 		else
 		{
+			$_ci_view = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $_ci_view);
 			$_ci_ext = pathinfo($_ci_view, PATHINFO_EXTENSION);
 			$_ci_file = ($_ci_ext === '') ? $_ci_view.'.php' : $_ci_view;
 

--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -887,7 +887,7 @@ class CI_Loader {
 		if (is_string($_ci_path) && $_ci_path !== '')
 		{
 			$_ci_path = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $_ci_path);
-			$_ci_x = explode('/', $_ci_path);
+			$_ci_x = explode(DIRECTORY_SEPARATOR, $_ci_path);
 			$_ci_file = end($_ci_x);
 		}
 		else


### PR DESCRIPTION
We are facing some problem which our product are origional development on Windows, so we can mixed use backword slash and forward slash with no problem. (and this across all over our product).

But one of our developer are have problem to loading resource (view template) because he is using Mac and Mac OS didn't support mixed slash.

So I add those two little line to auto convert to the correct slash