### PR TITLE
Removed whitelist from Postgres driver code to allow additional valid options

### DIFF
--- a/system/database/DB.php
+++ b/system/database/DB.php
@@ -136,10 +136,11 @@ function &DB($params = '', $query_builder_override = NULL)
 				if (is_string($val) && in_array(strtoupper($val), array('TRUE', 'FALSE', 'NULL')))
 				{
 					$val = var_export($val, TRUE);
+					$extra[$key] = $val;
 				}
-
-				$params[$key] = $val;
 			}
+
+			$params['extra'] = $extra;
 		}
 	}
 

--- a/system/database/DB.php
+++ b/system/database/DB.php
@@ -138,6 +138,8 @@ function &DB($params = '', $query_builder_override = NULL)
 					$val = var_export($val, TRUE);
 					$extra[$key] = $val;
 				}
+
+				$params[$key] = $val;
 			}
 
 			$params['extra'] = $extra;

--- a/system/database/drivers/postgre/postgre_driver.php
+++ b/system/database/drivers/postgre/postgre_driver.php
@@ -130,7 +130,7 @@ class CI_DB_postgre_driver extends CI_DB {
 		 */
 		if (isset($this->extra))
 		{
-			foreach ($this->extra as $property=>$value)
+			foreach ($this->extra as $property => $value)
 			{
 				$this->dsn .= "$property='$value' ";
 			}

--- a/system/database/drivers/postgre/postgre_driver.php
+++ b/system/database/drivers/postgre/postgre_driver.php
@@ -128,11 +128,11 @@ class CI_DB_postgre_driver extends CI_DB {
 		 *
 		 * postgre://username:password@localhost:5432/database?connect_timeout=5&sslmode=1
 		 */
-		foreach (array('connect_timeout', 'options', 'sslmode', 'service') as $key)
+		if (isset($this->extra))
 		{
-			if (isset($this->$key) && is_string($this->$key) && $this->$key !== '')
+			foreach ($this->extra as $property=>$value)
 			{
-				$this->dsn .= $key."='".$this->$key."' ";
+				$this->dsn .= "$property='$value' ";
 			}
 		}
 

--- a/system/database/drivers/postgre/postgre_driver.php
+++ b/system/database/drivers/postgre/postgre_driver.php
@@ -132,7 +132,10 @@ class CI_DB_postgre_driver extends CI_DB {
 		{
 			foreach ($this->extra as $property => $value)
 			{
-				$this->dsn .= "$property='$value' ";
+				if (is_string($value) && $value !== '')
+				{
+					$this->dsn .= "$property='$value' ";
+				}
 			}
 		}
 


### PR DESCRIPTION
This is a revised approach to an earlier pull request (https://github.com/bcit-ci/CodeIgniter/pull/5063). That discussion ended with the idea of removing a whitelist in system/database/drivers/postgre/postgre_driver.php. In removing the whitelist I encountered on reason why it may have been in place: DB.php added the extra properties to the object itself which has MANY properties. Without the whitelist there was not a convenient way to traverse the extra properties.

To address that I made a modification to DB.php to store the properties in an array so they would be isolated in a field called 'extra'. This allows the driver to traverse the resulting small array to isolate the extra properties.

This is the solution I have currently implemented in my own application and it appears to be okay for my use-case (and a few others I played with).