### PR TITLE
Add function level to Class URI core class

### DIFF
--- a/system/core/URI.php
+++ b/system/core/URI.php
@@ -657,5 +657,20 @@ class CI_URI {
 	{
 		return ltrim(load_class('Router', 'core')->directory, '/').implode('/', $this->rsegments);
 	}
-
+	/**
+	 * Fetch uri_string with level
+	 *
+	 * @return	string
+	 */
+	public function level($n)
+	{
+		if($n <= 0) return '';
+		$arr = array();
+		for($i=1; $i<=$n; $i++)
+		{
+			$sg = $this->segment($i);
+			if($sg != "") $arr[] = $sg;
+		}
+		return implode("/", $arr);
+	}
 }


### PR DESCRIPTION
This method very helpful to dev

For example:
I stay at http://example.com/poduct/detail/iphone
I need create a link on view: http://example.com/poduct/detail/ipad
site_url('/poduct/detail/ipad');
But, with level method:
site_url($this->uri->level(2).'/ipad');

Ok, by one reason i need change controller **product** to **shop**. I must edit all link made by site_url function.

With $this->uri->level I didn't must make any changes