### PR TITLE
close redis connection on driver destruct if is connected.

### DIFF
--- a/system/libraries/Cache/drivers/Cache_redis.php
+++ b/system/libraries/Cache/drivers/Cache_redis.php
@@ -322,7 +322,9 @@ class CI_Cache_redis extends CI_Driver
 	{
 		if ($this->_redis)
 		{
-			$this->_redis->close();
+			if($this->_redis->isConnected()) {
+				$this->_redis->close();
+			}
 		}
 	}
 }

--- a/system/libraries/Cache/drivers/Cache_redis.php
+++ b/system/libraries/Cache/drivers/Cache_redis.php
@@ -320,11 +320,9 @@ class CI_Cache_redis extends CI_Driver
 	 */
 	public function __destruct()
 	{
-		if ($this->_redis)
+		if ($this->_redis && $this->_redis->isConnected())
 		{
-			if($this->_redis->isConnected()) {
-				$this->_redis->close();
-			}
+			$this->_redis->close();
 		}
 	}
 }


### PR DESCRIPTION
close redis connection on driver destruct if is connected.this may cause fatal error infomation output.