### PR TITLE
Accept array in query builder -> order_by

### DIFF
--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -1188,9 +1188,9 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	/**
 	 * ORDER BY
 	 *
-	 * @param	string	$orderby
-	 * @param	string	$direction	ASC, DESC or RANDOM
-	 * @param	bool	$escape
+	 * @param	string|array	$orderby
+	 * @param	string			$direction	ASC, DESC or RANDOM
+	 * @param	bool			$escape
 	 * @return	CI_DB_query_builder
 	 */
 	public function order_by($orderby, $direction = '', $escape = NULL)
@@ -1223,8 +1223,12 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 		}
 		else
 		{
+			if (is_string($orderby))
+			{
+				$orderby = explode(',', $orderby);
+			}
 			$qb_orderby = array();
-			foreach (explode(',', $orderby) as $field)
+			foreach ($orderby as $field)
 			{
 				$qb_orderby[] = ($direction === '' && preg_match('/\s+(ASC|DESC)$/i', rtrim($field), $match, PREG_OFFSET_CAPTURE))
 					? array('field' => ltrim(substr($field, 0, $match[0][1])), 'direction' => ' '.$match[1][0], 'escape' => TRUE)


### PR DESCRIPTION
Sometimes it is useful to write `order_by` columns as array. `select` and `group_by` already have the possibility. I can write code like this:

`->order_by(implode(',', [`
`'FIELD(ev.country_iso3,"CAN","USA") ASC',`
`'FIELD(ev.country_iso3,"SWE","GBP","FRA","DEU") DESC',`
`'ev.country_iso3 ASC',`
`'ev.date ASC',`
`'ev.name ASC',`
`]))`

But it is not as performant and it doesn't look so nice.
So hopefully you accept the pull request :) I would be glad to add the feature to CI4 too.
