### PR TITLE
Fix several potential XSS injections in the form_helper

### DIFF
--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -88,7 +88,7 @@ if ( ! function_exists('form_open'))
 			$attributes .= ' accept-charset="'.strtolower(config_item('charset')).'"';
 		}
 
-		$form = '<form action="'.$action.'"'.$attributes.">\n";
+		$form = '<form action="'.html_escape($action).'"'.$attributes.">\n";
 
 		if (is_array($hidden))
 		{

--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -202,7 +202,7 @@ if ( ! function_exists('form_hidden'))
 
 		if ( ! is_array($value))
 		{
-			$form .= '<input type="hidden" name="'.$name.'" value="'.html_escape($value)."\" />\n";
+			$form .= '<input type="hidden" name="'.html_escape($name).'" value="'.html_escape($value)."\" />\n";
 		}
 		else
 		{

--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -583,7 +583,7 @@ if ( ! function_exists('form_button'))
 		}
 
 		return '<button '._parse_form_attributes($data, $defaults)._attributes_to_string($extra).'>'
-			.xss_clean($content)
+			.$content
 			."</button>\n";
 	}
 }
@@ -618,7 +618,7 @@ if ( ! function_exists('form_label'))
 			}
 		}
 
-		return $label.'>'.xss_clean($label_text).'</label>';
+		return $label.'>'.$label_text.'</label>';
 	}
 }
 
@@ -641,7 +641,7 @@ if ( ! function_exists('form_fieldset'))
 		$fieldset = '<fieldset'._attributes_to_string($attributes).">\n";
 		if ($legend_text !== '')
 		{
-			return $fieldset.'<legend>'.xss_clean($legend_text)."</legend>\n";
+			return $fieldset.'<legend>'.$legend_text."</legend>\n";
 		}
 
 		return $fieldset;

--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -234,8 +234,8 @@ if ( ! function_exists('form_input'))
 	{
 		$defaults = array(
 			'type' => 'text',
-			'name' => is_array($data) ? '' : html_escape($data),
-			'value' => html_escape($value)
+			'name' => is_array($data) ? '' : $data,
+			'value' => $value
 		);
 
 		return '<input '._parse_form_attributes($data, $defaults)._attributes_to_string($extra)." />\n";

--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -992,7 +992,7 @@ if ( ! function_exists('_attributes_to_string'))
 
 			foreach ($attributes as $key => $val)
 			{
-				$atts .= ' '.$key.'="'.$val.'"';
+				$atts .= ' '.$key.'="'.html_escape($val).'"';
 			}
 
 			return $atts;

--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -208,8 +208,9 @@ if ( ! function_exists('form_hidden'))
 		{
 			foreach ($value as $k => $v)
 			{
-				$k = is_int($k) ? '' : $k;
-				form_hidden($name.'['.$k.']', html_escape($v), TRUE);
+				$k = is_int($k) ? '' : html_escape($k);
+				$n = html_escape($name).'['.$k.']';
+				form_hidden($n, html_escape($v), TRUE);
 			}
 		}
 

--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -234,8 +234,8 @@ if ( ! function_exists('form_input'))
 	{
 		$defaults = array(
 			'type' => 'text',
-			'name' => is_array($data) ? '' : $data,
-			'value' => $value
+			'name' => is_array($data) ? '' : html_escape($data),
+			'value' => html_escape($value)
 		);
 
 		return '<input '._parse_form_attributes($data, $defaults)._attributes_to_string($extra)." />\n";

--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -420,7 +420,7 @@ if ( ! function_exists('form_dropdown'))
 					continue;
 				}
 
-				$form .= '<optgroup label="'.$key."\">\n";
+				$form .= '<optgroup label="'.html_escape($key)."\">\n";
 
 				foreach ($val as $optgroup_key => $optgroup_val)
 				{
@@ -435,7 +435,7 @@ if ( ! function_exists('form_dropdown'))
 			{
 				$form .= '<option value="'.html_escape($key).'"'
 					.(in_array($key, $selected) ? ' selected="selected"' : '').'>'
-					.(string) $val."</option>\n";
+					.(string) html_escape($val)."</option>\n";
 			}
 		}
 
@@ -583,7 +583,7 @@ if ( ! function_exists('form_button'))
 		}
 
 		return '<button '._parse_form_attributes($data, $defaults)._attributes_to_string($extra).'>'
-			.$content
+			.xss_clean($content)
 			."</button>\n";
 	}
 }
@@ -607,18 +607,18 @@ if ( ! function_exists('form_label'))
 
 		if ($id !== '')
 		{
-			$label .= ' for="'.$id.'"';
+			$label .= ' for="'.html_escape($id).'"';
 		}
 
 		if (is_array($attributes) && count($attributes) > 0)
 		{
 			foreach ($attributes as $key => $val)
 			{
-				$label .= ' '.$key.'="'.$val.'"';
+				$label .= ' '.html_escape($key).'="'.html_escape($val).'"';
 			}
 		}
 
-		return $label.'>'.$label_text.'</label>';
+		return $label.'>'.xss_clean($label_text).'</label>';
 	}
 }
 
@@ -641,7 +641,7 @@ if ( ! function_exists('form_fieldset'))
 		$fieldset = '<fieldset'._attributes_to_string($attributes).">\n";
 		if ($legend_text !== '')
 		{
-			return $fieldset.'<legend>'.$legend_text."</legend>\n";
+			return $fieldset.'<legend>'.xss_clean($legend_text)."</legend>\n";
 		}
 
 		return $fieldset;
@@ -956,7 +956,7 @@ if ( ! function_exists('_parse_form_attributes'))
 				continue;
 			}
 
-			$att .= $key.'="'.$val.'" ';
+			$att .= html_escape($key).'="'.html_escape($val).'" ';
 		}
 
 		return $att;

--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -992,7 +992,7 @@ if ( ! function_exists('_attributes_to_string'))
 
 			foreach ($attributes as $key => $val)
 			{
-				$atts .= ' '.$key.'="'.html_escape($val).'"';
+				$atts .= ' '.html_escape($key).'="'.html_escape($val).'"';
 			}
 
 			return $atts;

--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -94,7 +94,7 @@ if ( ! function_exists('form_open'))
 		{
 			foreach ($hidden as $name => $value)
 			{
-				$form .= '<input type="hidden" name="'.$name.'" value="'.html_escape($value).'" />'."\n";
+				$form .= '<input type="hidden" name="'.html_escape($name).'" value="'.html_escape($value).'" />'."\n";
 			}
 		}
 

--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -94,7 +94,7 @@ if ( ! function_exists('form_open'))
 		{
 			foreach ($hidden as $name => $value)
 			{
-				$form .= '<input type="hidden" name="'.html_escape($name).'" value="'.html_escape($value).'" />'."\n";
+				$form .= '<input type="hidden" name="'.$name.'" value="'.html_escape($value).'" />'."\n";
 			}
 		}
 

--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -209,7 +209,7 @@ if ( ! function_exists('form_hidden'))
 			foreach ($value as $k => $v)
 			{
 				$k = is_int($k) ? '' : $k;
-				form_hidden($name.'['.$k.']', $v, TRUE);
+				form_hidden($name.'['.$k.']', html_escape($v), TRUE);
 			}
 		}
 

--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -210,7 +210,7 @@ if ( ! function_exists('form_hidden'))
 			{
 				$k = is_int($k) ? '' : html_escape($k);
 				$n = html_escape($name).'['.$k.']';
-				form_hidden($n, html_escape($v), TRUE);
+				form_hidden($n, $v, TRUE);
 			}
 		}
 


### PR DESCRIPTION
Fix several potential XSS injections in the form helper mainly consisting on:

Applies html_escape multiple times on HTML attribute (`foo="bar"`).
- HTML attribute values (`bar`)
- HTML attribute names (`foo`)

Applies xss_clean sometimes on use outside HTML attributes like `<button>XX</button>`.