### PR TITLE
read() in DB_cache fails when catching E_WARNING with custom error handler

### DIFF
--- a/system/database/DB_cache.php
+++ b/system/database/DB_cache.php
@@ -143,7 +143,7 @@ class CI_DB_Cache {
 		$segment_two = ($this->CI->uri->segment(2) == FALSE) ? 'index' : $this->CI->uri->segment(2);
 		$filepath = $this->db->cachedir.$segment_one.'+'.$segment_two.'/'.md5($sql);
 
-		if (FALSE === ($cachedata = @file_get_contents($filepath)))
+		if ( ! is_file($filepath) OR FALSE === ($cachedata = @file_get_contents($filepath)))
 		{
 			return FALSE;
 		}

--- a/system/database/DB_cache.php
+++ b/system/database/DB_cache.php
@@ -143,7 +143,7 @@ class CI_DB_Cache {
 		$segment_two = ($this->CI->uri->segment(2) == FALSE) ? 'index' : $this->CI->uri->segment(2);
 		$filepath = $this->db->cachedir.$segment_one.'+'.$segment_two.'/'.md5($sql);
 
-		if ( ! is_file($filepath) OR FALSE === ($cachedata = @file_get_contents($filepath)))
+		if ( ! is_file($filepath) OR FALSE === ($cachedata = file_get_contents($filepath)))
 		{
 			return FALSE;
 		}

--- a/system/database/DB_result.php
+++ b/system/database/DB_result.php
@@ -183,7 +183,7 @@ class CI_DB_result {
 		{
 			return $this->custom_result_object[$class_name];
 		}
-		elseif ($this->result_id === FALSE OR $this->num_rows === 0)
+		elseif ( ! $this->result_id OR $this->num_rows === 0)
 		{
 			return array();
 		}

--- a/system/database/DB_result.php
+++ b/system/database/DB_result.php
@@ -183,7 +183,7 @@ class CI_DB_result {
 		{
 			return $this->custom_result_object[$class_name];
 		}
-		elseif ( ! $this->result_id OR $this->num_rows === 0)
+		elseif ($this->result_id === FALSE OR $this->num_rows === 0)
 		{
 			return array();
 		}


### PR DESCRIPTION
Hi,

when using `set_error_handler()` and matching E_WARNING, the read() method in CI_DB_Cache fails at [L146](https://github.com/bcit-ci/CodeIgniter/blob/develop/system/database/DB_cache.php#L146), this because [`file_get_contents()`](http://php.net/file_get_contents) emits an E_WARNING when it does not find the file.

This should fix it:

````
if ( ! is_file($filepath) OR FALSE === ($cachedata = @file_get_contents($filepath)))
````