### PR TITLE
Fixed deprecation errors for php >=5.6

### DIFF
--- a/system/core/CodeIgniter.php
+++ b/system/core/CodeIgniter.php
@@ -196,9 +196,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 	if (extension_loaded('mbstring'))
 	{
 		define('MB_ENABLED', TRUE);
-		// mbstring.internal_encoding is deprecated starting with PHP 5.6
-		// and it's usage triggers E_DEPRECATED messages.
-		@ini_set('mbstring.internal_encoding', $charset);
+
 		// This is required for mb_convert_encoding() to strip invalid characters.
 		// That's utilized by CI_Utf8, but it's also done for consistency with iconv.
 		mb_substitute_character('none');
@@ -210,22 +208,24 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 
 	// There's an ICONV_IMPL constant, but the PHP manual says that using
 	// iconv's predefined constants is "strongly discouraged".
-	if (extension_loaded('iconv'))
-	{
-		define('ICONV_ENABLED', TRUE);
-		// iconv.internal_encoding is deprecated starting with PHP 5.6
-		// and it's usage triggers E_DEPRECATED messages.
-		@ini_set('iconv.internal_encoding', $charset);
-	}
-	else
-	{
-		define('ICONV_ENABLED', FALSE);
-	}
+    define('ICONV_ENABLED', extension_loaded('iconv'));
 
-	if (is_php('5.6'))
-	{
-		ini_set('php.internal_encoding', $charset);
-	}
+    if (is_php('5.6'))
+    {
+        ini_set('php.internal_encoding', $charset);
+    }
+    else
+    {
+        if (ICONV_ENABLED)
+        {
+            ini_set('iconv.internal_encoding', $charset);
+        }
+
+        if (MB_ENABLED)
+        {
+            ini_set('mbstring.internal_encoding', $charset);
+        }
+    }
 
 /*
  * ------------------------------------------------------


### PR DESCRIPTION
Guys, it's very bad idea to use error shut up operator if we can do that properly.