### PR TITLE
Set checkbox default array

### DIFF
--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -768,7 +768,7 @@ if ( ! function_exists('set_checkbox'))
 	 * @param	string
 	 * @param	string
 	 * @param	bool
-	 * @return	string
+	 * @return	bool|array
 	 */
 	function set_checkbox($field, $value = '', $default = FALSE)
 	{
@@ -803,7 +803,8 @@ if ( ! function_exists('set_checkbox'))
 			return ($input === $value) ? ' checked="checked"' : '';
 		}
 
-		return ($default === TRUE) ? ' checked="checked"' : '';
+		$default = (is_array($default)) ? in_array($value, $default, TRUE) : $default;
+		return ($default === TRUE ) ? ' checked="checked"' : '';
 	}
 }
 

--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -1039,11 +1039,12 @@ class CI_Form_validation {
 	 *
 	 * @param	string
 	 * @param	string
-	 * @param	bool
+	 * @param	bool|array
 	 * @return	string
 	 */
 	public function set_checkbox($field = '', $value = '', $default = FALSE)
 	{
+		$default = (is_array($default)) ? in_array($value, $default, TRUE) : $default;
 		// Logic is exactly the same as for radio fields
 		return $this->set_radio($field, $value, $default);
 	}

--- a/tests/codeigniter/libraries/Form_validation_test.php
+++ b/tests/codeigniter/libraries/Form_validation_test.php
@@ -554,7 +554,9 @@ class Form_validation_test extends CI_TestCase {
 		$this->form_validation->run();
 
 		$this->assertEquals('', $this->form_validation->set_checkbox('select', 'foo'));
+		$this->assertEquals('', $this->form_validation->set_checkbox('select', 'foo', ['bar']));
 		$this->assertEquals(' checked="checked"', $this->form_validation->set_checkbox('select', 'bar', TRUE));
+		$this->assertEquals(' checked="checked"', $this->form_validation->set_checkbox('select', 'bar', ['foo','bar']));
 
 		// Test 2: 1 option selected
 		$this->form_validation->reset_validation();
@@ -564,8 +566,10 @@ class Form_validation_test extends CI_TestCase {
 
 		$this->assertEquals(' checked="checked"', $this->form_validation->set_checkbox('select', 'foo'));
 		$this->assertEquals(' checked="checked"', $this->form_validation->set_checkbox('select', 'foo', TRUE));
+		$this->assertEquals(' checked="checked"', $this->form_validation->set_checkbox('select', 'foo', ['bar']));
 		$this->assertEquals('', $this->form_validation->set_checkbox('select', 'bar'));
 		$this->assertEquals('', $this->form_validation->set_checkbox('select', 'bar', TRUE));
+		$this->assertEquals('', $this->form_validation->set_checkbox('select', 'bar', ['bar']));
 
 		// Test 3: Multiple options selected
 		$this->form_validation->reset_validation();
@@ -575,10 +579,13 @@ class Form_validation_test extends CI_TestCase {
 
 		$this->assertEquals(' checked="checked"', $this->form_validation->set_checkbox('select[]', 'foo'));
 		$this->assertEquals(' checked="checked"', $this->form_validation->set_checkbox('select[]', 'foo', TRUE));
+		$this->assertEquals(' checked="checked"', $this->form_validation->set_checkbox('select[]', 'foo', ['bar']));
 		$this->assertEquals(' checked="checked"', $this->form_validation->set_checkbox('select[]', 'bar'));
 		$this->assertEquals(' checked="checked"', $this->form_validation->set_checkbox('select[]', 'bar', TRUE));
+		$this->assertEquals(' checked="checked"', $this->form_validation->set_checkbox('select[]', 'bar', ['foo']));
 		$this->assertEquals('', $this->form_validation->set_checkbox('select[]', 'foobar'));
 		$this->assertEquals('', $this->form_validation->set_checkbox('select[]', 'foobar', TRUE));
+		$this->assertEquals('', $this->form_validation->set_checkbox('select[]', 'foobar', ['foo', 'bar', 'foobar']));
 	}
 
 	public function test_regex_match()


### PR DESCRIPTION
Considering the use case of set_checkbox, I think it is useful to be able to specify an array by default.
Checkbox is often used when Requesting an array.

For example, if you have an array with values that exist in the database in the edit screen, the following format is valid.

```
<?php echo set_checkbox('select[]', 'key1', $row['selected_list']);?>
```