### PR TITLE
fix bad attribute handling of form_label

### DIFF
--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -609,13 +609,7 @@ if ( ! function_exists('form_label'))
 			$label .= ' for="'.$id.'"';
 		}
 
-		if (is_array($attributes) && count($attributes) > 0)
-		{
-			foreach ($attributes as $key => $val)
-			{
-				$label .= ' '.$key.'="'.$val.'"';
-			}
-		}
+		$label .= _attributes_to_string($attributes);
 
 		return $label.'>'.$label_text.'</label>';
 	}


### PR DESCRIPTION
When passing a string for extra attributes in form_label helper function, these attributes were skipped.