### PR TITLE
fix ORA- 00946

### DIFF
--- a/system/database/drivers/oci8/oci8_forge.php
+++ b/system/database/drivers/oci8/oci8_forge.php
@@ -124,7 +124,7 @@ class CI_DB_oci8_forge extends CI_DB_forge {
 				if ($alter_type === 'MODIFY' && ! empty($field[$i]['new_name']))
 				{
 					$sqls[] = $sql.' RENAME COLUMN '.$this->db->escape_identifiers($field[$i]['name'])
-						.' '.$this->db->escape_identifiers($field[$i]['new_name']);
+						.' TO '.$this->db->escape_identifiers($field[$i]['new_name']);
 				}
 
 				$field[$i] = "\n\t".$field[$i]['_literal'];


### PR DESCRIPTION
I got a `ORA- 00946 : missing TO keyword` error when running the following code.

```php
$this->dbforge->modify_column('foo', [
    'bar' => ['name' => 'foobar']
]);
```

Therefore, the `TO` keyword was added.