### PR TITLE
Create ancillary_classes.rst

### DIFF
--- a/user_guide_src/source/general/ancillary_classes.rst
+++ b/user_guide_src/source/general/ancillary_classes.rst
@@ -19,7 +19,7 @@ access CodeIgniter's native resources** simply by using the
 ``get_instance()`` function. This function returns the main
 CodeIgniter object.
 
-Normally, to call any of the available CodeIgniter methods requires
+Normally, to call any of the available methods, CodeIgniter requires
 you to use the ``$this`` construct::
 
 	$this->load->helper('url');


### PR DESCRIPTION
"Normally, to call any of the available CodeIgniter methods requires you to use the ``$this`` construct::" - Grammatical adjustment. It appears that the author meshed two sentences together by starting with the proper noun that they ended the previous sentence but as it is the sentence reads:
"Normally to call any of the available.
CodeIgniter methods requires..."