### PR TITLE
Ignore LIMIT when using CI_DB_query_builder::count_all_results

### DIFF
--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -1488,15 +1488,6 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 			$this->qb_orderby = NULL;
 		}
 
-		//ignore LIMIT
-		if ($this->qb_limit OR $this->qb_offset)
-		{
-			$limit = $this->qb_limit;
-			$this->qb_limit = NULL;
-			$offset = $this->qb_offset;
-			$this->qb_offset = NULL;
-		}
-
 		$result = ($this->qb_distinct === TRUE OR ! empty($this->qb_groupby) OR ! empty($this->qb_cache_groupby))
 			? $this->query($this->_count_string.$this->protect_identifiers('numrows')."\nFROM (\n".$this->_compile_select()."\n) CI_count_all_results")
 			: $this->query($this->_compile_select($this->_count_string.$this->protect_identifiers('numrows')));
@@ -1505,19 +1496,10 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 		{
 			$this->_reset_select();
 		}
-		// If we've previously reset the qb_orderby,qb_limit or qb_offset values, get them back
-		else
+		// If we've previously reset the qb_orderby values, get them back
+		elseif ( ! isset($this->qb_orderby))
 		{
-			if ( ! isset($this->qb_orderby))
-			{
-				$this->qb_orderby = $orderby;
-			}
-
-			if ( ! isset($this->qb_limit))
-			{
-				$this->qb_limit = $limit;
-				$this->qb_offset = $offset;
-			}
+			$this->qb_orderby = $orderby;
 		}
 
 		if ($result->num_rows() === 0)

--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -1488,7 +1488,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 			$this->qb_orderby = NULL;
 		}
 
-		$result = ($this->qb_distinct === TRUE OR ! empty($this->qb_groupby) OR ! empty($this->qb_cache_groupby))
+		$result = ($this->qb_distinct === TRUE OR ! empty($this->qb_groupby) OR ! empty($this->qb_cache_groupby) OR $this->qb_limit OR $this->qb_offset)
 			? $this->query($this->_count_string.$this->protect_identifiers('numrows')."\nFROM (\n".$this->_compile_select()."\n) CI_count_all_results")
 			: $this->query($this->_compile_select($this->_count_string.$this->protect_identifiers('numrows')));
 

--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -1488,6 +1488,15 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 			$this->qb_orderby = NULL;
 		}
 
+		//ignore LIMIT
+		if ($this->qb_limit OR $this->qb_offset)
+		{
+			$limit = $this->qb_limit;
+			$this->qb_limit = NULL;
+			$offset = $this->qb_offset;
+			$this->qb_offset = NULL;
+		}
+
 		$result = ($this->qb_distinct === TRUE OR ! empty($this->qb_groupby) OR ! empty($this->qb_cache_groupby))
 			? $this->query($this->_count_string.$this->protect_identifiers('numrows')."\nFROM (\n".$this->_compile_select()."\n) CI_count_all_results")
 			: $this->query($this->_compile_select($this->_count_string.$this->protect_identifiers('numrows')));
@@ -1496,10 +1505,19 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 		{
 			$this->_reset_select();
 		}
-		// If we've previously reset the qb_orderby values, get them back
-		elseif ( ! isset($this->qb_orderby))
+		// If we've previously reset the qb_orderby,qb_limit or qb_offset values, get them back
+		else
 		{
-			$this->qb_orderby = $orderby;
+			if ( ! isset($this->qb_orderby))
+			{
+				$this->qb_orderby = $orderby;
+			}
+
+			if ( ! isset($this->qb_limit))
+			{
+				$this->qb_limit = $limit;
+				$this->qb_offset = $offset;
+			}
 		}
 
 		if ($result->num_rows() === 0)

--- a/tests/codeigniter/database/query_builder/count_test.php
+++ b/tests/codeigniter/database/query_builder/count_test.php
@@ -42,7 +42,7 @@ class Count_test extends CI_TestCase {
 	 */
 	public function test_count_all_results_limit()
 	{
-		$this->assertEquals(2, $this->db->like('name', 'ian')->limit(10, 10)->count_all_results('job'));
+		$this->assertEquals(1, $this->db->like('name', 'ian')->limit(1)->count_all_results('job'));
 	}
 
 }

--- a/tests/codeigniter/database/query_builder/count_test.php
+++ b/tests/codeigniter/database/query_builder/count_test.php
@@ -35,4 +35,14 @@ class Count_test extends CI_TestCase {
 		$this->assertEquals(2, $this->db->like('name', 'ian')->count_all_results('job'));
 	}
 
+	// ------------------------------------------------------------------------
+
+	/**
+	 * @see ./mocks/schema/skeleton.php
+	 */
+	public function test_count_all_results_limit()
+	{
+		$this->assertEquals(2, $this->db->like('name', 'ian')->limit(10, 10)->count_all_results('job'));
+	}
+
 }


### PR DESCRIPTION
I used the following code for pagination search
```
                 $this->db->where('num >=', 9);
		$this->db->limit(2,2);
		$num = $this->db->count_all_results('test_user', false);
		$query = $this->db->get();
		$result = $query->result_array();
```
and found `count_all_results` generated
```
SELECT COUNT(*) AS `numrows`
FROM `test_user`
WHERE `num` >= 9
 LIMIT 2, 2
```

but 
```
SELECT COUNT(*) AS `numrows`
FROM `test_user`
WHERE `num` >= 9
```
was expected.

Surely I could use `limit(X,X)` after calling `count_all_results`, however, it would be better if `LIMIT` usage be ignored with `count_all_results`.

I also thought about generating sql like this
```
SELECT COUNT(*) AS `numrows`
FROM (
SELECT *
FROM `test_user`
WHERE `num` >= 9
 LIMIT 2, 2
) CI_count_all_results 
```
But it may be a rare usage.