### PR TITLE
Always check a model be a subclass of CI_Model when loaded

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -344,9 +344,10 @@ class CI_Loader {
 				throw new RuntimeException('Unable to locate the model you have specified: '.$model);
 			}
 		}
-		elseif ( ! is_subclass_of($model, 'CI_Model'))
+
+		if ( ! is_subclass_of($model, 'CI_Model'))
 		{
-			throw new RuntimeException("Class ".$model." already exists and doesn't extend CI_Model");
+			throw new RuntimeException("Class ".$model." doesn't extend CI_Model");
 		}
 
 		$this->_ci_models[] = $name;

--- a/tests/codeigniter/core/Loader_test.php
+++ b/tests/codeigniter/core/Loader_test.php
@@ -269,6 +269,25 @@ class Loader_test extends CI_TestCase {
 
 	// --------------------------------------------------------------------
 
+	public function test_invalid_model()
+	{
+		$this->ci_set_core_class('model', 'CI_Model');
+
+		// Create model in VFS
+		$model = 'Unit_test_invalid_model';
+		$content = '<?php class '.$model.' {} ';
+		$this->ci_vfs_create($model, $content, $this->ci_app_root, 'models');
+
+		// Test no extending
+		$this->setExpectedException(
+			'RuntimeException',
+			'Class '.$model.' doesn\'t extend CI_Model'
+		);
+		$this->load->model($model);
+	}
+
+	// --------------------------------------------------------------------
+
 	// public function testDatabase()
 	// {
 	// 	$this->assertInstanceOf('CI_Loader', $this->load->database());
@@ -544,7 +563,7 @@ class Loader_test extends CI_TestCase {
 		$dir = 'testdir';
 		$path = APPPATH.$dir.'/';
 		$model = 'Automod';
-		$this->ci_vfs_create($model, '<?php class '.$model.' { }', $this->ci_app_root, array($dir, 'models'));
+		$this->ci_vfs_create($model, '<?php class '.$model.' extends CI_Model { }', $this->ci_app_root, array($dir, 'models'));
 
 		// Create autoloader config
 		$cfg = array(


### PR DESCRIPTION
If a model does not extend the base Model class, it works fine at the first time loaded.

But when this model is loaded at the second time with a different object name,  it throws `RuntimeException`.

In fact, a exception should be thrown at the first time.