### PR TITLE
Fix load config order for packages

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -783,7 +783,7 @@ class CI_Loader {
 
 		// Add config file path
 		$config =& $this->_ci_get_component('config');
-		$config->_config_paths[] = $path;
+		array_unshift($config->_config_paths, $path);
 
 		return $this;
 	}


### PR DESCRIPTION
As libraries, models and helpers from packages, config files needs to be loaded first from package path and could be overloaded from application path and/or environnment specific path.
