### PR TITLE
Decreasing the probability of race condition in session lock

### DIFF
--- a/system/libraries/Session/drivers/Session_memcached_driver.php
+++ b/system/libraries/Session/drivers/Session_memcached_driver.php
@@ -310,7 +310,7 @@ class CI_Session_memcached_driver extends CI_Session_driver implements SessionHa
 			if ( ! $this->_memcached->replace($this->_lock_key, time(), 300))
 			{
 				return ($this->_memcached->getResultCode() === Memcached::RES_NOTFOUND)
-					? $this->_memcached->set($this->_lock_key, time(), 300)
+					? $this->_memcached->add($this->_lock_key, time(), 300)
 					: FALSE;
 			}
 		}
@@ -326,7 +326,11 @@ class CI_Session_memcached_driver extends CI_Session_driver implements SessionHa
 				continue;
 			}
 
-			if ( ! $this->_memcached->set($lock_key, time(), 300))
+			$set_result = ($this->_memcached->getResultCode() === Memcached::RES_NOTFOUND)
+				? $this->_memcached->add($lock_key, time(), 300)
+				: $this->_memcached->set($lock_key, time(), 300);
+
+			if ( ! $set_result)
 			{
 				log_message('error', 'Session: Error while trying to obtain lock for '.$this->_key_prefix.$session_id);
 				return FALSE;

--- a/system/libraries/Session/drivers/Session_memcached_driver.php
+++ b/system/libraries/Session/drivers/Session_memcached_driver.php
@@ -326,11 +326,11 @@ class CI_Session_memcached_driver extends CI_Session_driver implements SessionHa
 				continue;
 			}
 
-			$set_result = ($this->_memcached->getResultCode() === Memcached::RES_NOTFOUND)
+			$result = ($this->_memcached->getResultCode() === Memcached::RES_NOTFOUND)
 				? $this->_memcached->add($lock_key, time(), 300)
 				: $this->_memcached->set($lock_key, time(), 300);
 
-			if ( ! $set_result)
+			if ( ! $result)
 			{
 				log_message('error', 'Session: Error while trying to obtain lock for '.$this->_key_prefix.$session_id);
 				return FALSE;

--- a/system/libraries/Session/drivers/Session_memcached_driver.php
+++ b/system/libraries/Session/drivers/Session_memcached_driver.php
@@ -326,11 +326,8 @@ class CI_Session_memcached_driver extends CI_Session_driver implements SessionHa
 				continue;
 			}
 
-			$result = ($this->_memcached->getResultCode() === Memcached::RES_NOTFOUND)
-				? $this->_memcached->add($lock_key, time(), 300)
-				: $this->_memcached->set($lock_key, time(), 300);
-
-			if ( ! $result)
+			$method = ($this->_memcached->getResultCode() === Memcached::RES_NOTFOUND) ? 'add' : 'set';
+			if ( ! $this->_memcached->$method($lock_key, time(), 300))
 			{
 				log_message('error', 'Session: Error while trying to obtain lock for '.$this->_key_prefix.$session_id);
 				return FALSE;

--- a/system/libraries/Session/drivers/Session_redis_driver.php
+++ b/system/libraries/Session/drivers/Session_redis_driver.php
@@ -368,6 +368,7 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 			$result = ($ttl === -2)
 				? $this->_redis->set($lock_key, time(), array('nx', 'ex' => 300))
 				: $this->_redis->setex($lock_key, 300, time());
+
 			if ( ! $result)
 			{
 				log_message('error', 'Session: Error while trying to obtain lock for '.$this->_key_prefix.$session_id);

--- a/system/libraries/Session/drivers/Session_redis_driver.php
+++ b/system/libraries/Session/drivers/Session_redis_driver.php
@@ -365,7 +365,16 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 				continue;
 			}
 
-			if ( ! $this->_redis->setex($lock_key, 300, time()))
+			if ($ttl === -2)
+			{
+				$set_result = $this->_redis->set($lock_key, time(), array('nx', 'ex' => 300));
+			}
+			else
+			{
+				$set_result = $this->_redis->setex($lock_key, 300, time());
+			}
+
+			if ( ! $set_result)
 			{
 				log_message('error', 'Session: Error while trying to obtain lock for '.$this->_key_prefix.$session_id);
 				return FALSE;

--- a/system/libraries/Session/drivers/Session_redis_driver.php
+++ b/system/libraries/Session/drivers/Session_redis_driver.php
@@ -365,16 +365,10 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 				continue;
 			}
 
-			if ($ttl === -2)
-			{
-				$set_result = $this->_redis->set($lock_key, time(), array('nx', 'ex' => 300));
-			}
-			else
-			{
-				$set_result = $this->_redis->setex($lock_key, 300, time());
-			}
-
-			if ( ! $set_result)
+			$result = ($ttl === -2)
+				? $this->_redis->set($lock_key, time(), array('nx', 'ex' => 300))
+				: $this->_redis->setex($lock_key, 300, time());
+			if ( ! $result)
 			{
 				log_message('error', 'Session: Error while trying to obtain lock for '.$this->_key_prefix.$session_id);
 				return FALSE;


### PR DESCRIPTION
When using `redis` or `memcached` session driver, if a web-client perform multiple requests at the same time, two or more requests may get the session lock, and finally some of them would generate "Session: Error while trying to free lock for" error log.

Using `Redis::setnx` and `Memcached::add ` properly could help to decrease the probability of this race condition.