### PR TITLE
Add array identifier for library loader

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -182,7 +182,7 @@ class CI_Loader {
 	 * Loads and instantiates libraries.
 	 * Designed to be called from application controllers.
 	 *
-	 * @param	string	$library	Library name
+	 * @param	mixed	$library	Library name
 	 * @param	array	$params		Optional parameters to pass to the library class constructor
 	 * @param	string	$object_name	An optional object name to assign to
 	 * @return	object


### PR DESCRIPTION
Add array type to $library param at PHPDoc, so the IDE will not show a warning when we passing an array to it.