### PR TITLE
Update date_helper.php

### DIFF
--- a/system/helpers/date_helper.php
+++ b/system/helpers/date_helper.php
@@ -346,6 +346,7 @@ if ( ! function_exists('mysql_to_unix'))
 		// YYYY-MM-DD HH:MM:SS
 
 		$time = str_replace(array('-', ':', ' '), '', $time);
+    		$time = str_pad($time, 14, '0');
 
 		// YYYYMMDDHHMMSS
 		return mktime(


### PR DESCRIPTION
substr() in php 7, If string is equal to start characters long, an empty string will be returned. Prior to this version, FALSE was returned in this case.

example: $time = '20170711';

Error display: 
Severity: Warning
Message: mktime() expects parameter 1 to be integer, string given.