### PR TITLE
add is_write_type method for merge query

### DIFF
--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -982,7 +982,7 @@ abstract class CI_DB_driver {
 	 */
 	public function is_write_type($sql)
 	{
-		return (bool) preg_match('/^\s*"?(SET|INSERT|UPDATE|DELETE|REPLACE|CREATE|DROP|TRUNCATE|LOAD|COPY|ALTER|RENAME|GRANT|REVOKE|LOCK|UNLOCK|REINDEX)\s/i', $sql);
+		return (bool) preg_match('/^\s*"?(SET|INSERT|UPDATE|DELETE|REPLACE|CREATE|DROP|TRUNCATE|LOAD|COPY|ALTER|RENAME|GRANT|REVOKE|LOCK|UNLOCK|REINDEX|MERGE)\s/i', $sql);
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
I would like to get `affected_rows` when I run the following code:

```php
<?php
$sql = <<<EOD
MERGE INTO DUAL A
USING DUAL B ON (A.ID = B.ID)
WHEN MATCHED THEN
    UPDATE SET A.FOO = B.BAR
WHEN NOT MATCHED THEN
    INSERT (ID, FOO) VALUES (B.ID, B.BAR)
EOD;

$this->db->query($sql);
var_dump($this->db->affected_rows());
```