### PR TITLE
Fix some mistakes in the user guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ user_guide_src/cilexer/pycilexer.egg-info/*
 *.sublime-workspace
 *.sublime-project
 /tests/tests/
+/tests/results/

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -119,7 +119,7 @@ escaping of fields may break them.
 
 ::
 
-	$this->db->select('(SELECT SUM(payments.amount) FROM payments WHERE payments.invoice_id=4') AS amount_paid', FALSE);
+	$this->db->select('(SELECT SUM(payments.amount) FROM payments WHERE payments.invoice_id=4) AS amount_paid', FALSE);
 	$query = $this->db->get('mytable');
 
 **$this->db->select_max()**

--- a/user_guide_src/source/general/urls.rst
+++ b/user_guide_src/source/general/urls.rst
@@ -42,13 +42,11 @@ By default, the **index.php** file will be included in your URLs::
 If your Apache server has *mod_rewrite* enabled, you can easily remove this
 file by using a .htaccess file with some simple rules. Here is an example
 of such a file, using the "negative" method in which everything is redirected
-except the specified items:
-
-::
+except the specified items::
 	
 	RewriteEngine On
-	RewriteCond %{REQUEST_FILENAME} !-f
-	RewriteCond %{REQUEST_FILENAME} !-d
+	RewriteCond %{REQUEST_FILENAME} -f [OR]
+	RewriteCond %{REQUEST_FILENAME} -d [OR]
 	RewriteRule ^(.*)$ index.php/$1 [L]
 
 In the above example, any HTTP request other than those for existing

--- a/user_guide_src/source/general/urls.rst
+++ b/user_guide_src/source/general/urls.rst
@@ -44,6 +44,8 @@ file by using a .htaccess file with some simple rules. Here is an example
 of such a file, using the "negative" method in which everything is redirected
 except the specified items::
 	
+.. code-block:: console
+
 	RewriteEngine On
 	RewriteCond %{REQUEST_FILENAME} !-f
 	RewriteCond %{REQUEST_FILENAME} !-d

--- a/user_guide_src/source/general/urls.rst
+++ b/user_guide_src/source/general/urls.rst
@@ -45,8 +45,8 @@ of such a file, using the "negative" method in which everything is redirected
 except the specified items::
 	
 	RewriteEngine On
-	RewriteCond %{REQUEST_FILENAME} -f [OR]
-	RewriteCond %{REQUEST_FILENAME} -d [OR]
+	RewriteCond %{REQUEST_FILENAME} !-f
+	RewriteCond %{REQUEST_FILENAME} !-d
 	RewriteRule ^(.*)$ index.php/$1 [L]
 
 In the above example, any HTTP request other than those for existing

--- a/user_guide_src/source/libraries/input.rst
+++ b/user_guide_src/source/libraries/input.rst
@@ -202,7 +202,7 @@ Class Reference
 		data::
 
 			$this->input->cookie('some_cookie');
-			$this->input->cookie('some_cookie, TRUE); // with XSS filter
+			$this->input->cookie('some_cookie', TRUE); // with XSS filter
 
 		To return an array of multiple cookie values, pass all the required keys
 		as an array.

--- a/user_guide_src/source/libraries/loader.rst
+++ b/user_guide_src/source/libraries/loader.rst
@@ -125,7 +125,7 @@ Class Reference
 
 			$config = array (
 				'mailtype' => 'html',
-				'charset'  => 'utf-8,
+				'charset'  => 'utf-8',
 				'priority' => '1'
 			);
 


### PR DESCRIPTION
Three of the user guide pages had mismatched quotes, causing sphinx problems.
urls.rst still has a block that sphinx doesn't like :(