### PR TITLE
Security fix

### DIFF
--- a/system/libraries/Image_lib.php
+++ b/system/libraries/Image_lib.php
@@ -972,7 +972,7 @@ class CI_Image_lib {
 			$cmd_inner = 'pnmscale -xysize '.$this->width.' '.$this->height;
 		}
 
-		$cmd = $this->library_path.$cmd_in.' '.escapeshellarg($this->full_src_path).' | '.$cmd_inner.' | '.$cmd_out.' > '.$this->dest_folder.'netpbm.tmp';
+		$cmd = $this->library_path.$cmd_in.' '.escapeshellarg($this->full_src_path).' | '.$cmd_inner.' | '.$cmd_out.' > '.escapeshellcmd($this->dest_folder).'netpbm.tmp';
 
 		$retval = 1;
 		// exec() might be disabled


### PR DESCRIPTION
 escape `dest_folder` so that a specially crafted destination folder cannot inject arbitrary commands to `exec`