### PR TITLE
Re-enable Query Builder for ODBC driver

### DIFF
--- a/system/database/drivers/odbc/odbc_driver.php
+++ b/system/database/drivers/odbc/odbc_driver.php
@@ -50,7 +50,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  * @author		EllisLab Dev Team
  * @link		https://codeigniter.com/user_guide/database/
  */
-class CI_DB_odbc_driver extends CI_DB_driver {
+class CI_DB_odbc_driver extends CI_DB {
 
 	/**
 	 * Database driver


### PR DESCRIPTION
Undo of a change made in CI 3.1.0: ODBC driver does not support Query Builder usage any more.