### PR TITLE
fix for get_where not honoring table aliasses

### DIFF
--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -1528,6 +1528,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	{
 		if ($table !== '')
 		{
+			$this->_track_aliases($table);
 			$this->from($table);
 		}
 


### PR DESCRIPTION
the line:
`$this->_track_aliases($table);`
is missing from get_where(), this is inconsistent with get()
https://github.com/bcit-ci/CodeIgniter/blob/4aaf3847dbd3a33bdd3341a93462be4f0cbcaeef/system/database/DB_query_builder.php#L1448
https://github.com/bcit-ci/CodeIgniter/blob/4aaf3847dbd3a33bdd3341a93462be4f0cbcaeef/system/database/DB_query_builder.php#L1531