### PR TITLE
Fix width and height validation

### DIFF
--- a/system/libraries/Image_lib.php
+++ b/system/libraries/Image_lib.php
@@ -488,9 +488,12 @@ class CI_Image_lib {
 							continue;
 						}
 					}
-					elseif (in_array($key, array('width', 'height'), TRUE) && ! ctype_digit((string) $val))
+					elseif (in_array($key, array('width', 'height'), TRUE))
 					{
-						continue;
+						if ( ! is_numeric($val))
+							continue;
+						elseif ( ! is_int($val))
+							$val = intval($val);
 					}
 
 					$this->$key = $val;


### PR DESCRIPTION
The new validation introduced in eac4adf is causing previous-worked job like cropping to break if the input width and height are floating point numbers (e.g. values returned by Jcrop) since no width and height will be given to the image processor.

This change allows float-type width and height pass.