### PR TITLE
[cs] use short syntax for arrays

### DIFF
--- a/system/core/Benchmark.php
+++ b/system/core/Benchmark.php
@@ -56,7 +56,7 @@ class CI_Benchmark {
 	 *
 	 * @var	array
 	 */
-	public $marker = array();
+	public $marker = [];
 
 	/**
 	 * Set a benchmark marker

--- a/system/core/CodeIgniter.php
+++ b/system/core/CodeIgniter.php
@@ -106,7 +106,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  */
 	if ( ! empty($assign_to_config['subclass_prefix']))
 	{
-		get_config(array('subclass_prefix' => $assign_to_config['subclass_prefix']));
+		get_config(['subclass_prefix' => $assign_to_config['subclass_prefix']]);
 	}
 
 /*
@@ -365,7 +365,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 		}
 		elseif (method_exists($class, '_remap'))
 		{
-			$params = array($method, array_slice($URI->rsegments, 2));
+			$params = [$method, array_slice($URI->rsegments, 2)];
 			$method = '_remap';
 		}
 		elseif ( ! method_exists($class, $method))
@@ -383,7 +383,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 		 * ReflectionMethod::isConstructor() is the ONLY reliable check,
 		 * knowing which method will be executed as a constructor.
 		 */
-		elseif ( ! is_callable(array($class, $method)))
+		elseif ( ! is_callable([$class, $method]))
 		{
 			$reflection = new ReflectionMethod($class, $method);
 			if ( ! $reflection->isPublic() OR $reflection->isConstructor())
@@ -433,10 +433,10 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 			$class = $error_class;
 			$method = $error_method;
 
-			$URI->rsegments = array(
+			$URI->rsegments = [
 				1 => $class,
 				2 => $method
-			);
+			];
 		}
 		else
 		{
@@ -478,7 +478,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  *  Call the requested method
  * ------------------------------------------------------
  */
-	call_user_func_array(array(&$CI, $method), $params);
+	call_user_func_array([&$CI, $method], $params);
 
 	// Mark a benchmark end point
 	$BM->mark('controller_execution_time_( '.$class.' / '.$method.' )_end');

--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -139,7 +139,7 @@ if ( ! function_exists('load_class'))
 	 */
 	function &load_class($class, $directory = 'libraries', $param = NULL)
 	{
-		static $_classes = array();
+		static $_classes = [];
 
 		// Does the class exist? If so, we're done...
 		if (isset($_classes[$class]))
@@ -151,7 +151,7 @@ if ( ! function_exists('load_class'))
 
 		// Look for the class first in the local application/libraries folder
 		// then in the native system/libraries folder
-		foreach (array(APPPATH, BASEPATH) as $path)
+		foreach ([APPPATH, BASEPATH] as $path)
 		{
 			if (file_exists($path.$directory.'/'.$class.'.php'))
 			{
@@ -210,7 +210,7 @@ if ( ! function_exists('is_loaded'))
 	 */
 	function &is_loaded($class = '')
 	{
-		static $_is_loaded = array();
+		static $_is_loaded = [];
 
 		if ($class !== '')
 		{
@@ -234,7 +234,7 @@ if ( ! function_exists('get_config'))
 	 * @param	array
 	 * @return	array
 	 */
-	function &get_config(Array $replace = array())
+	function &get_config(Array $replace = [])
 	{
 		static $config;
 
@@ -320,7 +320,7 @@ if ( ! function_exists('get_mimes'))
 		{
 			$_mimes = file_exists(APPPATH.'config/mimes.php')
 				? include(APPPATH.'config/mimes.php')
-				: array();
+				: [];
 
 			if (file_exists(APPPATH.'config/'.ENVIRONMENT.'/mimes.php'))
 			{
@@ -495,7 +495,7 @@ if ( ! function_exists('set_status_header'))
 		if (empty($text))
 		{
 			is_int($code) OR $code = (int) $code;
-			$stati = array(
+			$stati = [
 				100	=> 'Continue',
 				101	=> 'Switching Protocols',
 
@@ -546,7 +546,7 @@ if ( ! function_exists('set_status_header'))
 				504	=> 'Gateway Timeout',
 				505	=> 'HTTP Version Not Supported',
 				511	=> 'Network Authentication Required',
-			);
+			];
 
 			if (isset($stati[$code]))
 			{
@@ -564,7 +564,7 @@ if ( ! function_exists('set_status_header'))
 			return;
 		}
 
-		$server_protocol = (isset($_SERVER['SERVER_PROTOCOL']) && in_array($_SERVER['SERVER_PROTOCOL'], array('HTTP/1.0', 'HTTP/1.1', 'HTTP/2'), TRUE))
+		$server_protocol = (isset($_SERVER['SERVER_PROTOCOL']) && in_array($_SERVER['SERVER_PROTOCOL'], ['HTTP/1.0', 'HTTP/1.1', 'HTTP/2'], TRUE))
 			? $_SERVER['SERVER_PROTOCOL'] : 'HTTP/1.1';
 		header($server_protocol.' '.$code.' '.$text, TRUE, $code);
 	}
@@ -617,7 +617,7 @@ if ( ! function_exists('_error_handler'))
 		$_error->log_exception($severity, $message, $filepath, $line);
 
 		// Should we display the error?
-		if (str_ireplace(array('off', 'none', 'no', 'false', 'null'), '', ini_get('display_errors')))
+		if (str_ireplace(['off', 'none', 'no', 'false', 'null'], '', ini_get('display_errors')))
 		{
 			$_error->show_php_error($severity, $message, $filepath, $line);
 		}
@@ -653,7 +653,7 @@ if ( ! function_exists('_exception_handler'))
 
 		is_cli() OR set_status_header(500);
 		// Should we display the error?
-		if (str_ireplace(array('off', 'none', 'no', 'false', 'null'), '', ini_get('display_errors')))
+		if (str_ireplace(['off', 'none', 'no', 'false', 'null'], '', ini_get('display_errors')))
 		{
 			$_error->show_exception($exception);
 		}
@@ -706,7 +706,7 @@ if ( ! function_exists('remove_invisible_characters'))
 	 */
 	function remove_invisible_characters($str, $url_encoded = TRUE)
 	{
-		$non_displayables = array();
+		$non_displayables = [];
 
 		// every control character except newline (dec 10),
 		// carriage return (dec 13) and horizontal tab (dec 09)
@@ -837,7 +837,7 @@ if ( ! function_exists('function_usable'))
 			{
 				$_suhosin_func_blacklist = extension_loaded('suhosin')
 					? explode(',', trim(ini_get('suhosin.executor.func.blacklist')))
-					: array();
+					: [];
 			}
 
 			return ! in_array($function_name, $_suhosin_func_blacklist, TRUE);

--- a/system/core/Config.php
+++ b/system/core/Config.php
@@ -55,14 +55,14 @@ class CI_Config {
 	 *
 	 * @var	array
 	 */
-	public $config = array();
+	public $config = [];
 
 	/**
 	 * List of all loaded config files
 	 *
 	 * @var	array
 	 */
-	public $is_loaded =	array();
+	public $is_loaded =	[];
 
 	/**
 	 * List of paths to search when trying to load a config file.
@@ -70,7 +70,7 @@ class CI_Config {
 	 * @used-by	CI_Loader
 	 * @var		array
 	 */
-	public $_config_paths =	array(APPPATH);
+	public $_config_paths =	[APPPATH];
 
 	// --------------------------------------------------------------------
 
@@ -130,7 +130,7 @@ class CI_Config {
 
 		foreach ($this->_config_paths as $path)
 		{
-			foreach (array($file, ENVIRONMENT.DIRECTORY_SEPARATOR.$file) as $location)
+			foreach ([$file, ENVIRONMENT.DIRECTORY_SEPARATOR.$file] as $location)
 			{
 				$file_path = $path.'config/'.$location.'.php';
 				if (in_array($file_path, $this->is_loaded, TRUE))

--- a/system/core/Exceptions.php
+++ b/system/core/Exceptions.php
@@ -60,7 +60,7 @@ class CI_Exceptions {
 	 *
 	 * @var	array
 	 */
-	public $levels = array(
+	public $levels = [
 		E_ERROR			=>	'Error',
 		E_WARNING		=>	'Warning',
 		E_PARSE			=>	'Parsing Error',
@@ -73,7 +73,7 @@ class CI_Exceptions {
 		E_USER_WARNING		=>	'User Warning',
 		E_USER_NOTICE		=>	'User Notice',
 		E_STRICT		=>	'Runtime Notice'
-	);
+	];
 
 	/**
 	 * Class constructor

--- a/system/core/Hooks.php
+++ b/system/core/Hooks.php
@@ -62,14 +62,14 @@ class CI_Hooks {
 	 *
 	 * @var	array
 	 */
-	public $hooks =	array();
+	public $hooks =	[];
 
 	/**
 	 * Array with class objects to use hooks methods
 	 *
 	 * @var array
 	 */
-	protected $_objects = array();
+	protected $_objects = [];
 
 	/**
 	 * In progress flag

--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -62,7 +62,7 @@ class CI_Input {
 	 *
 	 * @var array
 	 */
-	protected $headers = array();
+	protected $headers = [];
 
 	/**
 	 * Raw input stream data
@@ -129,7 +129,7 @@ class CI_Input {
 		// allow fetching multiple keys at once
 		if (is_array($index))
 		{
-			$output = array();
+			$output = [];
 			foreach ($index as $key)
 			{
 				$output[$key] = $this->_fetch_from_array($array, $key, $xss_clean);
@@ -280,7 +280,7 @@ class CI_Input {
 		{
 			// $this->raw_input_stream will trigger __get().
 			parse_str($this->raw_input_stream, $this->_input_stream);
-			is_array($this->_input_stream) OR $this->_input_stream = array();
+			is_array($this->_input_stream) OR $this->_input_stream = [];
 		}
 
 		return $this->_fetch_from_array($this->_input_stream, $index, $xss_clean);
@@ -309,7 +309,7 @@ class CI_Input {
 		if (is_array($name))
 		{
 			// always leave 'name' in last place, as the loop will break otherwise, due to $$item
-			foreach (array('value', 'expire', 'domain', 'path', 'prefix', 'secure', 'httponly', 'name') as $item)
+			foreach (['value', 'expire', 'domain', 'path', 'prefix', 'secure', 'httponly', 'name'] as $item)
 			{
 				if (isset($name[$item]))
 				{
@@ -379,7 +379,7 @@ class CI_Input {
 
 		if ($proxy_ips)
 		{
-			foreach (array('HTTP_X_FORWARDED_FOR', 'HTTP_CLIENT_IP', 'HTTP_X_CLIENT_IP', 'HTTP_X_CLUSTER_CLIENT_IP') as $header)
+			foreach (['HTTP_X_FORWARDED_FOR', 'HTTP_CLIENT_IP', 'HTTP_X_CLIENT_IP', 'HTTP_X_CLUSTER_CLIENT_IP'] as $header)
 			{
 				if (($spoof = $this->server($header)) !== NULL)
 				{

--- a/system/core/Lang.php
+++ b/system/core/Lang.php
@@ -53,14 +53,14 @@ class CI_Lang {
 	 *
 	 * @var	array
 	 */
-	public $language =	array();
+	public $language =	[];
 
 	/**
 	 * List of loaded language files
 	 *
 	 * @var	array
 	 */
-	public $is_loaded =	array();
+	public $is_loaded =	[];
 
 	/**
 	 * Class constructor
@@ -159,7 +159,7 @@ class CI_Lang {
 
 			if ($return === TRUE)
 			{
-				return array();
+				return [];
 			}
 			return;
 		}

--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -63,66 +63,66 @@ class CI_Loader {
 	 *
 	 * @var	array
 	 */
-	protected $_ci_view_paths =	array(VIEWPATH	=> TRUE);
+	protected $_ci_view_paths =	[VIEWPATH	=> TRUE];
 
 	/**
 	 * List of paths to load libraries from
 	 *
 	 * @var	array
 	 */
-	protected $_ci_library_paths =	array(APPPATH, BASEPATH);
+	protected $_ci_library_paths =	[APPPATH, BASEPATH];
 
 	/**
 	 * List of paths to load models from
 	 *
 	 * @var	array
 	 */
-	protected $_ci_model_paths =	array(APPPATH);
+	protected $_ci_model_paths =	[APPPATH];
 
 	/**
 	 * List of paths to load helpers from
 	 *
 	 * @var	array
 	 */
-	protected $_ci_helper_paths =	array(APPPATH, BASEPATH);
+	protected $_ci_helper_paths =	[APPPATH, BASEPATH];
 
 	/**
 	 * List of cached variables
 	 *
 	 * @var	array
 	 */
-	protected $_ci_cached_vars =	array();
+	protected $_ci_cached_vars =	[];
 
 	/**
 	 * List of loaded classes
 	 *
 	 * @var	array
 	 */
-	protected $_ci_classes =	array();
+	protected $_ci_classes =	[];
 
 	/**
 	 * List of loaded models
 	 *
 	 * @var	array
 	 */
-	protected $_ci_models =	array();
+	protected $_ci_models =	[];
 
 	/**
 	 * List of loaded helpers
 	 *
 	 * @var	array
 	 */
-	protected $_ci_helpers =	array();
+	protected $_ci_helpers =	[];
 
 	/**
 	 * List of class name mappings
 	 *
 	 * @var	array
 	 */
-	protected $_ci_varmap =	array(
+	protected $_ci_varmap =	[
 		'unit_test' => 'unit',
 		'user_agent' => 'agent'
-	);
+	];
 
 	// --------------------------------------------------------------------
 
@@ -485,9 +485,9 @@ class CI_Loader {
 	 *				or leave it to the Output class
 	 * @return	object|string
 	 */
-	public function view($view, $vars = array(), $return = FALSE)
+	public function view($view, $vars = [], $return = FALSE)
 	{
-		return $this->_ci_load(array('_ci_view' => $view, '_ci_vars' => $this->_ci_prepare_view_vars($vars), '_ci_return' => $return));
+		return $this->_ci_load(['_ci_view' => $view, '_ci_vars' => $this->_ci_prepare_view_vars($vars), '_ci_return' => $return]);
 	}
 
 	// --------------------------------------------------------------------
@@ -501,7 +501,7 @@ class CI_Loader {
 	 */
 	public function file($path, $return = FALSE)
 	{
-		return $this->_ci_load(array('_ci_path' => $path, '_ci_return' => $return));
+		return $this->_ci_load(['_ci_path' => $path, '_ci_return' => $return]);
 	}
 
 	// --------------------------------------------------------------------
@@ -521,7 +521,7 @@ class CI_Loader {
 	public function vars($vars, $val = '')
 	{
 		$vars = is_string($vars)
-			? array($vars => $val)
+			? [$vars => $val]
 			: $this->_ci_prepare_view_vars($vars);
 
 		foreach ($vars as $key => $val)
@@ -543,7 +543,7 @@ class CI_Loader {
 	 */
 	public function clear_vars()
 	{
-		$this->_ci_cached_vars = array();
+		$this->_ci_cached_vars = [];
 		return $this;
 	}
 
@@ -584,9 +584,9 @@ class CI_Loader {
 	 * @param	string|string[]	$helpers	Helper name(s)
 	 * @return	object
 	 */
-	public function helper($helpers = array())
+	public function helper($helpers = [])
 	{
-		is_array($helpers) OR $helpers = array($helpers);
+		is_array($helpers) OR $helpers = [$helpers];
 		foreach ($helpers as &$helper)
 		{
 			$filename = basename($helper);
@@ -661,7 +661,7 @@ class CI_Loader {
 	 * @param	string|string[]	$helpers	Helper name(s)
 	 * @return	object
 	 */
-	public function helpers($helpers = array())
+	public function helpers($helpers = [])
 	{
 		return $this->helper($helpers);
 	}
@@ -779,7 +779,7 @@ class CI_Loader {
 		array_unshift($this->_ci_model_paths, $path);
 		array_unshift($this->_ci_helper_paths, $path);
 
-		$this->_ci_view_paths = array($path.'views/' => $view_cascade) + $this->_ci_view_paths;
+		$this->_ci_view_paths = [$path.'views/' => $view_cascade] + $this->_ci_view_paths;
 
 		// Add config file path
 		$config =& $this->_ci_get_component('config');
@@ -830,7 +830,7 @@ class CI_Loader {
 		else
 		{
 			$path = rtrim($path, '/').'/';
-			foreach (array('_ci_library_paths', '_ci_model_paths', '_ci_helper_paths') as $var)
+			foreach (['_ci_library_paths', '_ci_model_paths', '_ci_helper_paths'] as $var)
 			{
 				if (($key = array_search($path, $this->{$var})) !== FALSE)
 				{
@@ -850,11 +850,11 @@ class CI_Loader {
 		}
 
 		// make sure the application default paths are still in the array
-		$this->_ci_library_paths = array_unique(array_merge($this->_ci_library_paths, array(APPPATH, BASEPATH)));
-		$this->_ci_helper_paths = array_unique(array_merge($this->_ci_helper_paths, array(APPPATH, BASEPATH)));
-		$this->_ci_model_paths = array_unique(array_merge($this->_ci_model_paths, array(APPPATH)));
-		$this->_ci_view_paths = array_merge($this->_ci_view_paths, array(APPPATH.'views/' => TRUE));
-		$config->_config_paths = array_unique(array_merge($config->_config_paths, array(APPPATH)));
+		$this->_ci_library_paths = array_unique(array_merge($this->_ci_library_paths, [APPPATH, BASEPATH]));
+		$this->_ci_helper_paths = array_unique(array_merge($this->_ci_helper_paths, [APPPATH, BASEPATH]));
+		$this->_ci_model_paths = array_unique(array_merge($this->_ci_model_paths, [APPPATH]));
+		$this->_ci_view_paths = array_merge($this->_ci_view_paths, [APPPATH.'views/' => TRUE]);
+		$config->_config_paths = array_unique(array_merge($config->_config_paths, [APPPATH]));
 
 		return $this;
 	}
@@ -877,7 +877,7 @@ class CI_Loader {
 	protected function _ci_load($_ci_data)
 	{
 		// Set the default data variables
-		foreach (array('_ci_view', '_ci_vars', '_ci_path', '_ci_return') as $_ci_val)
+		foreach (['_ci_view', '_ci_vars', '_ci_path', '_ci_return'] as $_ci_val)
 		{
 			$$_ci_val = isset($_ci_data[$_ci_val]) ? $_ci_data[$_ci_val] : FALSE;
 		}
@@ -1317,7 +1317,7 @@ class CI_Loader {
 		}
 
 		// Autoload helpers and languages
-		foreach (array('helper', 'language') as $type)
+		foreach (['helper', 'language'] as $type)
 		{
 			if (isset($autoload[$type]) && count($autoload[$type]) > 0)
 			{
@@ -1338,7 +1338,7 @@ class CI_Loader {
 			if (in_array('database', $autoload['libraries']))
 			{
 				$this->database();
-				$autoload['libraries'] = array_diff($autoload['libraries'], array('database'));
+				$autoload['libraries'] = array_diff($autoload['libraries'], ['database']);
 			}
 
 			// Load all other libraries
@@ -1369,7 +1369,7 @@ class CI_Loader {
 		{
 			$vars = is_object($vars)
 				? get_object_vars($vars)
-				: array();
+				: [];
 		}
 
 		foreach (array_keys($vars) as $key)

--- a/system/core/Log.php
+++ b/system/core/Log.php
@@ -74,7 +74,7 @@ class CI_Log {
 	 *
 	 * @var array
 	 */
-	protected $_threshold_array = array();
+	protected $_threshold_array = [];
 
 	/**
 	 * Format of timestamp for log files
@@ -102,7 +102,7 @@ class CI_Log {
 	 *
 	 * @var array
 	 */
-	protected $_levels = array('ERROR' => 1, 'DEBUG' => 2, 'INFO' => 3, 'ALL' => 4);
+	protected $_levels = ['ERROR' => 1, 'DEBUG' => 2, 'INFO' => 3, 'ALL' => 4];
 
 	/**
 	 * mbstring.func_overload flag

--- a/system/core/Output.php
+++ b/system/core/Output.php
@@ -69,14 +69,14 @@ class CI_Output {
 	 *
 	 * @var	array
 	 */
-	public $headers = array();
+	public $headers = [];
 
 	/**
 	 * List of mime types
 	 *
 	 * @var	array
 	 */
-	public $mimes =	array();
+	public $mimes =	[];
 
 	/**
 	 * Mime-type for the current page
@@ -111,7 +111,7 @@ class CI_Output {
 	 *
 	 * @var	array
 	 */
-	protected $_profiler_sections =	array();
+	protected $_profiler_sections =	[];
 
 	/**
 	 * Parse markers flag
@@ -224,7 +224,7 @@ class CI_Output {
 			return $this;
 		}
 
-		$this->headers[] = array($header, $replace);
+		$this->headers[] = [$header, $replace];
 		return $this;
 	}
 
@@ -265,7 +265,7 @@ class CI_Output {
 		$header = 'Content-Type: '.$mime_type
 			.(empty($charset) ? '' : '; charset='.$charset);
 
-		$this->headers[] = array($header, TRUE);
+		$this->headers[] = [$header, TRUE];
 		return $this;
 	}
 
@@ -454,7 +454,7 @@ class CI_Output {
 		if ($this->parse_exec_vars === TRUE)
 		{
 			$memory	= round(memory_get_usage() / 1024 / 1024, 2).'MB';
-			$output = str_replace(array('{elapsed_time}', '{memory_usage}'), array($elapsed, $memory), $output);
+			$output = str_replace(['{elapsed_time}', '{memory_usage}'], [$elapsed, $memory], $output);
 		}
 
 		// --------------------------------------------------------------------
@@ -609,10 +609,10 @@ class CI_Output {
 		$expire = time() + ($this->cache_expiration * 60);
 
 		// Put together our serialized info.
-		$cache_info = serialize(array(
+		$cache_info = serialize([
 			'expire'	=> $expire,
 			'headers'	=> $this->headers
-		));
+		]);
 
 		$output = $cache_info.'ENDCI--->'.$output;
 

--- a/system/core/Router.php
+++ b/system/core/Router.php
@@ -62,7 +62,7 @@ class CI_Router {
 	 *
 	 * @var	array
 	 */
-	public $routes =	array();
+	public $routes =	[];
 
 	/**
 	 * Current class name
@@ -207,10 +207,10 @@ class CI_Router {
 					$this->set_method($_GET[$_f]);
 				}
 
-				$this->uri->rsegments = array(
+				$this->uri->rsegments = [
 					1 => $this->class,
 					2 => $this->method
-				);
+				];
 			}
 			else
 			{
@@ -245,7 +245,7 @@ class CI_Router {
 	 * @param	array	$segments	URI segments
 	 * @return	void
 	 */
-	protected function _set_request($segments = array())
+	protected function _set_request($segments = [])
 	{
 		$segments = $this->_validate_request($segments);
 		// If we don't have any segments left - try the default controller;
@@ -310,10 +310,10 @@ class CI_Router {
 		$this->set_method($method);
 
 		// Assign routed segments, index starting from 1
-		$this->uri->rsegments = array(
+		$this->uri->rsegments = [
 			1 => $class,
 			2 => $method
-		);
+		];
 
 		log_message('debug', 'No URI present. Default controller set.');
 	}
@@ -393,7 +393,7 @@ class CI_Router {
 			}
 
 			// Convert wildcards to RegEx
-			$key = str_replace(array(':any', ':num'), array('[^/]+', '[0-9]+'), $key);
+			$key = str_replace([':any', ':num'], ['[^/]+', '[0-9]+'], $key);
 
 			// Does the RegEx match?
 			if (preg_match('#^'.$key.'$#', $uri, $matches))
@@ -433,7 +433,7 @@ class CI_Router {
 	 */
 	public function set_class($class)
 	{
-		$this->class = str_replace(array('/', '.'), '', $class);
+		$this->class = str_replace(['/', '.'], '', $class);
 	}
 
 	// --------------------------------------------------------------------

--- a/system/core/Security.php
+++ b/system/core/Security.php
@@ -53,7 +53,7 @@ class CI_Security {
 	 *
 	 * @var	array
 	 */
-	public $filename_bad_chars =	array(
+	public $filename_bad_chars =	[
 		'../', '<!--', '-->', '<', '>',
 		"'", '"', '&', '$', '#',
 		'{', '}', '[', ']', '=',
@@ -70,7 +70,7 @@ class CI_Security {
 		'%3f',		// ?
 		'%3b',		// ;
 		'%3d'		// =
-	);
+	];
 
 	/**
 	 * Character set
@@ -132,7 +132,7 @@ class CI_Security {
 	 *
 	 * @var	array
 	 */
-	protected $_never_allowed_str =	array(
+	protected $_never_allowed_str =	[
 		'document.cookie' => '[removed]',
 		'document.write'  => '[removed]',
 		'.parentNode'     => '[removed]',
@@ -143,14 +143,14 @@ class CI_Security {
 		'<![CDATA['       => '&lt;![CDATA[',
 		'<comment>'	  => '&lt;comment&gt;',
 		'<%'              => '&lt;&#37;'
-	);
+	];
 
 	/**
 	 * List of never allowed regex replacements
 	 *
 	 * @var	array
 	 */
-	protected $_never_allowed_regex = array(
+	protected $_never_allowed_regex = [
 		'javascript\s*:',
 		'(document|(document\.)?window)\.(location|on\w*)',
 		'expression\s*(\(|&\#40;)', // CSS and IE
@@ -160,7 +160,7 @@ class CI_Security {
 		'vbs\s*:', // IE
 		'Redirect\s+30\d',
 		"([\"'])?data\s*:[^\\1]*?base64[^\\1]*?,[^\\1]*?\\1?"
-	);
+	];
 
 	/**
 	 * Class constructor
@@ -175,7 +175,7 @@ class CI_Security {
 		if (config_item('csrf_protection') && ! is_cli())
 		{
 			// CSRF config
-			foreach (array('csrf_expire', 'csrf_token_name', 'csrf_cookie_name') as $key)
+			foreach (['csrf_expire', 'csrf_token_name', 'csrf_cookie_name'] as $key)
 			{
 				if (NULL !== ($val = config_item($key)))
 				{
@@ -381,7 +381,7 @@ class CI_Security {
 			{
 				$oldstr = $str;
 				$str = rawurldecode($str);
-				$str = preg_replace_callback('#%(?:\s*[0-9a-f]){2,}#i', array($this, '_urldecodespaces'), $str);
+				$str = preg_replace_callback('#%(?:\s*[0-9a-f]){2,}#i', [$this, '_urldecodespaces'], $str);
 			}
 			while ($oldstr !== $str);
 			unset($oldstr);
@@ -394,8 +394,8 @@ class CI_Security {
 		 * We only convert entities that are within tags since
 		 * these are the ones that will pose security problems.
 		 */
-		$str = preg_replace_callback("/[^a-z0-9>]+[a-z0-9]+=([\'\"]).*?\\1/si", array($this, '_convert_attribute'), $str);
-		$str = preg_replace_callback('/<\w+.*/si', array($this, '_decode_entity'), $str);
+		$str = preg_replace_callback("/[^a-z0-9>]+[a-z0-9]+=([\'\"]).*?\\1/si", [$this, '_convert_attribute'], $str);
+		$str = preg_replace_callback('/<\w+.*/si', [$this, '_decode_entity'], $str);
 
 		// Remove Invisible Characters Again!
 		$str = remove_invisible_characters($str);
@@ -434,7 +434,7 @@ class CI_Security {
 		}
 		else
 		{
-			$str = str_replace(array('<?', '?'.'>'), array('&lt;?', '?&gt;'), $str);
+			$str = str_replace(['<?', '?'.'>'], ['&lt;?', '?&gt;'], $str);
 		}
 
 		/*
@@ -443,11 +443,11 @@ class CI_Security {
 		 * This corrects words like:  j a v a s c r i p t
 		 * These words are compacted back to their correct state.
 		 */
-		$words = array(
+		$words = [
 			'javascript', 'expression', 'vbscript', 'jscript', 'wscript',
 			'vbs', 'script', 'base64', 'applet', 'alert', 'document',
 			'write', 'cookie', 'window', 'confirm', 'prompt', 'eval'
-		);
+		];
 
 		foreach ($words as $word)
 		{
@@ -455,7 +455,7 @@ class CI_Security {
 
 			// We only want to do this when it is followed by a non-word character
 			// That way valid stuff like "dealer to" does not become "dealerto"
-			$str = preg_replace_callback('#('.substr($word, 0, -3).')(\W)#is', array($this, '_compact_exploded_words'), $str);
+			$str = preg_replace_callback('#('.substr($word, 0, -3).')(\W)#is', [$this, '_compact_exploded_words'], $str);
 		}
 
 		/*
@@ -476,12 +476,12 @@ class CI_Security {
 
 			if (preg_match('/<a/i', $str))
 			{
-				$str = preg_replace_callback('#<a(?:rea)?[^a-z0-9>]+([^>]*?)(?:>|$)#si', array($this, '_js_link_removal'), $str);
+				$str = preg_replace_callback('#<a(?:rea)?[^a-z0-9>]+([^>]*?)(?:>|$)#si', [$this, '_js_link_removal'], $str);
 			}
 
 			if (preg_match('/<img/i', $str))
 			{
-				$str = preg_replace_callback('#<img[^a-z0-9]+([^>]*?)(?:\s?/?>|$)#si', array($this, '_js_img_removal'), $str);
+				$str = preg_replace_callback('#<img[^a-z0-9]+([^>]*?)(?:\s?/?>|$)#si', [$this, '_js_img_removal'], $str);
 			}
 
 			if (preg_match('/script|xss/i', $str))
@@ -520,7 +520,7 @@ class CI_Security {
 		do
 		{
 			$old_str = $str;
-			$str = preg_replace_callback($pattern, array($this, '_sanitize_naughty_html'), $str);
+			$str = preg_replace_callback($pattern, [$this, '_sanitize_naughty_html'], $str);
 		}
 		while ($old_str !== $str);
 		unset($old_str);
@@ -684,7 +684,7 @@ class CI_Security {
 			// Decode standard entities, avoiding false positives
 			if (preg_match_all('/&[a-z]{2,}(?![a-z;])/i', $str, $matches))
 			{
-				$replace = array();
+				$replace = [];
 				$matches = array_unique(array_map('strtolower', $matches[0]));
 				foreach ($matches as &$match)
 				{
@@ -750,10 +750,10 @@ class CI_Security {
 	public function strip_image_tags($str)
 	{
 		return preg_replace(
-			array(
+			[
 				'#<img[\s/]+.*?src\s*=\s*(["\'])([^\\1]+?)\\1.*?\>#i',
 				'#<img[\s/]+.*?src\s*=\s*?(([^\s"\'=<>`]+)).*?\>#i'
-			),
+			],
 			'\\2',
 			$str
 		);
@@ -807,16 +807,16 @@ class CI_Security {
 	 */
 	protected function _sanitize_naughty_html($matches)
 	{
-		static $naughty_tags    = array(
+		static $naughty_tags    = [
 			'alert', 'area', 'prompt', 'confirm', 'applet', 'audio', 'basefont', 'base', 'behavior', 'bgsound',
 			'blink', 'body', 'embed', 'expression', 'form', 'frameset', 'frame', 'head', 'html', 'ilayer',
 			'iframe', 'input', 'button', 'select', 'isindex', 'layer', 'link', 'meta', 'keygen', 'object',
 			'plaintext', 'style', 'script', 'textarea', 'title', 'math', 'video', 'svg', 'xml', 'xss'
-		);
+		];
 
-		static $evil_attributes = array(
+		static $evil_attributes = [
 			'on\w+', 'style', 'xmlns', 'formaction', 'form', 'xlink:href', 'FSCommand', 'seekSegmentTime'
-		);
+		];
 
 		// First, escape unclosed tags
 		if (empty($matches['closeTag']))
@@ -832,7 +832,7 @@ class CI_Security {
 		elseif (isset($matches['attributes']))
 		{
 			// We'll store the already fitlered attributes here
-			$attributes = array();
+			$attributes = [];
 
 			// Attribute-catching pattern
 			$attributes_pattern = '#'
@@ -952,7 +952,7 @@ class CI_Security {
 	 */
 	protected function _convert_attribute($match)
 	{
-		return str_replace(array('>', '<', '\\'), array('&gt;', '&lt;', '\\\\'), $match[0]);
+		return str_replace(['>', '<', '\\'], ['&gt;', '&lt;', '\\\\'], $match[0]);
 	}
 
 	// --------------------------------------------------------------------

--- a/system/core/URI.php
+++ b/system/core/URI.php
@@ -55,7 +55,7 @@ class CI_URI {
 	 *
 	 * @var	array
 	 */
-	public $keyval = array();
+	public $keyval = [];
 
 	/**
 	 * Current URI string
@@ -71,7 +71,7 @@ class CI_URI {
 	 *
 	 * @var	array
 	 */
-	public $segments = array();
+	public $segments = [];
 
 	/**
 	 * List of routed URI segments
@@ -80,7 +80,7 @@ class CI_URI {
 	 *
 	 * @var	array
 	 */
-	public $rsegments = array();
+	public $rsegments = [];
 
 	/**
 	 * Permitted URI chars
@@ -317,7 +317,7 @@ class CI_URI {
 	 */
 	protected function _remove_relative_directory($uri)
 	{
-		$uris = array();
+		$uris = [];
 		$tok = strtok($uri, '/');
 		while ($tok !== FALSE)
 		{
@@ -406,7 +406,7 @@ class CI_URI {
 	 * @param	array	$default	Default values
 	 * @return	array
 	 */
-	public function uri_to_assoc($n = 3, $default = array())
+	public function uri_to_assoc($n = 3, $default = [])
 	{
 		return $this->_uri_to_assoc($n, $default, 'segment');
 	}
@@ -424,7 +424,7 @@ class CI_URI {
 	 * @param 	array	$default	Default values
 	 * @return 	array
 	 */
-	public function ruri_to_assoc($n = 3, $default = array())
+	public function ruri_to_assoc($n = 3, $default = [])
 	{
 		return $this->_uri_to_assoc($n, $default, 'rsegment');
 	}
@@ -443,7 +443,7 @@ class CI_URI {
 	 * @param	string	$which		Array name ('segment' or 'rsegment')
 	 * @return	array
 	 */
-	protected function _uri_to_assoc($n = 3, $default = array(), $which = 'segment')
+	protected function _uri_to_assoc($n = 3, $default = [], $which = 'segment')
 	{
 		if ( ! is_numeric($n))
 		{
@@ -461,14 +461,14 @@ class CI_URI {
 		if ($this->$total_segments() < $n)
 		{
 			return (count($default) === 0)
-				? array()
+				? []
 				: array_fill_keys($default, NULL);
 		}
 
 		$segments = array_slice($this->$segment_array(), ($n - 1));
 		$i = 0;
 		$lastval = '';
-		$retval = array();
+		$retval = [];
 		foreach ($segments as $seg)
 		{
 			if ($i % 2)
@@ -496,7 +496,7 @@ class CI_URI {
 		}
 
 		// Cache the array for reuse
-		isset($this->keyval[$which]) OR $this->keyval[$which] = array();
+		isset($this->keyval[$which]) OR $this->keyval[$which] = [];
 		$this->keyval[$which][$n] = $retval;
 		return $retval;
 	}
@@ -513,7 +513,7 @@ class CI_URI {
 	 */
 	public function assoc_to_uri($array)
 	{
-		$temp = array();
+		$temp = [];
 		foreach ((array) $array as $key => $val)
 		{
 			$temp[] = $key;

--- a/system/core/compat/hash.php
+++ b/system/core/compat/hash.php
@@ -181,7 +181,7 @@ if ( ! function_exists('hash_pbkdf2'))
 		// Pre-hash password inputs longer than the algorithm's block size
 		// (i.e. prepare HMAC key) to mitigate potential DoS attacks.
 		static $block_sizes;
-		empty($block_sizes) && $block_sizes = array(
+		empty($block_sizes) && $block_sizes = [
 			'gost' => 32,
 			'haval128,3' => 128,
 			'haval160,3' => 128,
@@ -219,7 +219,7 @@ if ( ! function_exists('hash_pbkdf2'))
 			'tiger160,4' => 64,
 			'tiger192,4' => 64,
 			'whirlpool' => 64
-		);
+		];
 
 		if (isset($block_sizes[$algo], $password[$block_sizes[$algo]]))
 		{

--- a/system/core/compat/password.php
+++ b/system/core/compat/password.php
@@ -74,8 +74,8 @@ if ( ! function_exists('password_get_info'))
 	function password_get_info($hash)
 	{
 		return (strlen($hash) < 60 OR sscanf($hash, '$2y$%d', $hash) !== 1)
-			? array('algo' => 0, 'algoName' => 'unknown', 'options' => array())
-			: array('algo' => 1, 'algoName' => 'bcrypt', 'options' => array('cost' => $hash));
+			? ['algo' => 0, 'algoName' => 'unknown', 'options' => []]
+			: ['algo' => 1, 'algoName' => 'bcrypt', 'options' => ['cost' => $hash]];
 	}
 }
 
@@ -92,7 +92,7 @@ if ( ! function_exists('password_hash'))
 	 * @param	array	$options
 	 * @return	mixed
 	 */
-	function password_hash($password, $algo, array $options = array())
+	function password_hash($password, $algo, array $options = [])
 	{
 		static $func_overload;
 		isset($func_overload) OR $func_overload = (extension_loaded('mbstring') && ini_get('mbstring.func_overload'));
@@ -200,7 +200,7 @@ if ( ! function_exists('password_needs_rehash'))
 	 * @param	array	$options
 	 * @return	bool
 	 */
-	function password_needs_rehash($hash, $algo, array $options = array())
+	function password_needs_rehash($hash, $algo, array $options = [])
 	{
 		$info = password_get_info($hash);
 

--- a/system/core/compat/standard.php
+++ b/system/core/compat/standard.php
@@ -69,7 +69,7 @@ if ( ! function_exists('array_column'))
 	 */
 	function array_column(array $array, $column_key, $index_key = NULL)
 	{
-		if ( ! in_array($type = gettype($column_key), array('integer', 'string', 'NULL'), TRUE))
+		if ( ! in_array($type = gettype($column_key), ['integer', 'string', 'NULL'], TRUE))
 		{
 			if ($type === 'double')
 			{
@@ -86,7 +86,7 @@ if ( ! function_exists('array_column'))
 			}
 		}
 
-		if ( ! in_array($type = gettype($index_key), array('integer', 'string', 'NULL'), TRUE))
+		if ( ! in_array($type = gettype($index_key), ['integer', 'string', 'NULL'], TRUE))
 		{
 			if ($type === 'double')
 			{
@@ -103,7 +103,7 @@ if ( ! function_exists('array_column'))
 			}
 		}
 
-		$result = array();
+		$result = [];
 		foreach ($array as &$a)
 		{
 			if ($column_key === NULL)

--- a/system/database/DB.php
+++ b/system/database/DB.php
@@ -117,14 +117,14 @@ function &DB($params = '', $query_builder_override = NULL)
 			show_error('Invalid DB Connection String');
 		}
 
-		$params = array(
+		$params = [
 			'dbdriver'	=> $dsn['scheme'],
 			'hostname'	=> isset($dsn['host']) ? rawurldecode($dsn['host']) : '',
 			'port'		=> isset($dsn['port']) ? rawurldecode($dsn['port']) : '',
 			'username'	=> isset($dsn['user']) ? rawurldecode($dsn['user']) : '',
 			'password'	=> isset($dsn['pass']) ? rawurldecode($dsn['pass']) : '',
 			'database'	=> isset($dsn['path']) ? rawurldecode(substr($dsn['path'], 1)) : ''
-		);
+		];
 
 		// Were additional config items set?
 		if (isset($dsn['query']))
@@ -133,7 +133,7 @@ function &DB($params = '', $query_builder_override = NULL)
 
 			foreach ($extra as $key => $val)
 			{
-				if (is_string($val) && in_array(strtoupper($val), array('TRUE', 'FALSE', 'NULL')))
+				if (is_string($val) && in_array(strtoupper($val), ['TRUE', 'FALSE', 'NULL']))
 				{
 					$val = var_export($val, TRUE);
 				}

--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -212,7 +212,7 @@ abstract class CI_DB_driver {
 	 * @see	CI_DB_driver::$save_queries
 	 * @var	string[]
 	 */
-	public $queries			= array();
+	public $queries			= [];
 
 	/**
 	 * Query times
@@ -221,7 +221,7 @@ abstract class CI_DB_driver {
 	 *
 	 * @var	array
 	 */
-	public $query_times		= array();
+	public $query_times		= [];
 
 	/**
 	 * Data cache
@@ -230,7 +230,7 @@ abstract class CI_DB_driver {
 	 *
 	 * @var	array
 	 */
-	public $data_cache		= array();
+	public $data_cache		= [];
 
 	/**
 	 * Transaction enabled flag
@@ -314,7 +314,7 @@ abstract class CI_DB_driver {
 	 *
 	 * @var	string[]
 	 */
-	protected $_reserved_identifiers	= array('*');
+	protected $_reserved_identifiers	= ['*'];
 
 	/**
 	 * Identifier escape character
@@ -342,7 +342,7 @@ abstract class CI_DB_driver {
 	 *
 	 * @var	array
 	 */
-	protected $_random_keyword = array('RAND()', 'RAND(%d)');
+	protected $_random_keyword = ['RAND()', 'RAND(%d)'];
 
 	/**
 	 * COUNT string
@@ -502,7 +502,7 @@ abstract class CI_DB_driver {
 	 */
 	public function error()
 	{
-		return array('code' => NULL, 'message' => NULL);
+		return ['code' => NULL, 'message' => NULL];
 	}
 
 	// --------------------------------------------------------------------
@@ -653,7 +653,7 @@ abstract class CI_DB_driver {
 				}
 
 				// Display errors
-				return $this->display_error(array('Error Number: '.$error['code'], $error['message'], $sql));
+				return $this->display_error(['Error Number: '.$error['code'], $error['message'], $sql]);
 			}
 
 			return FALSE;
@@ -924,7 +924,7 @@ abstract class CI_DB_driver {
 		}
 		elseif ( ! is_array($binds))
 		{
-			$binds = array($binds);
+			$binds = [$binds];
 			$bind_count = 1;
 		}
 		else
@@ -1037,7 +1037,7 @@ abstract class CI_DB_driver {
 	{
 		if (is_array($str))
 		{
-			$str = array_map(array(&$this, 'escape'), $str);
+			$str = array_map([&$this, 'escape'], $str);
 			return $str;
 		}
 		elseif (is_string($str) OR (is_object($str) && method_exists($str, '__toString')))
@@ -1083,8 +1083,8 @@ abstract class CI_DB_driver {
 		if ($like === TRUE)
 		{
 			return str_replace(
-				array($this->_like_escape_chr, '%', '_'),
-				array($this->_like_escape_chr.$this->_like_escape_chr, $this->_like_escape_chr.'%', $this->_like_escape_chr.'_'),
+				[$this->_like_escape_chr, '%', '_'],
+				[$this->_like_escape_chr.$this->_like_escape_chr, $this->_like_escape_chr.'%', $this->_like_escape_chr.'_'],
 				$str
 			);
 		}
@@ -1188,7 +1188,7 @@ abstract class CI_DB_driver {
 			return ($this->db_debug) ? $this->display_error('db_unsupported_function') : FALSE;
 		}
 
-		$this->data_cache['table_names'] = array();
+		$this->data_cache['table_names'] = [];
 		$query = $this->query($sql);
 
 		foreach ($query->result_array() as $row)
@@ -1257,7 +1257,7 @@ abstract class CI_DB_driver {
 		}
 
 		$query = $this->query($sql);
-		$this->data_cache['field_names'][$table] = array();
+		$this->data_cache['field_names'][$table] = [];
 
 		foreach ($query->result_array() as $row)
 		{
@@ -1351,12 +1351,12 @@ abstract class CI_DB_driver {
 		{
 			if (is_array($this->_escape_char))
 			{
-				$preg_ec = array(
+				$preg_ec = [
 					preg_quote($this->_escape_char[0]),
 					preg_quote($this->_escape_char[1]),
 					$this->_escape_char[0],
 					$this->_escape_char[1]
-				);
+				];
 			}
 			else
 			{
@@ -1389,7 +1389,7 @@ abstract class CI_DB_driver {
 	 */
 	public function insert_string($table, $data)
 	{
-		$fields = $values = array();
+		$fields = $values = [];
 
 		foreach ($data as $key => $val)
 		{
@@ -1436,7 +1436,7 @@ abstract class CI_DB_driver {
 
 		$this->where($where);
 
-		$fields = array();
+		$fields = [];
 		foreach ($data as $key => $val)
 		{
 			$fields[$this->protect_identifiers($key)] = $this->escape($val);
@@ -1501,7 +1501,7 @@ abstract class CI_DB_driver {
 			$_les = ($this->_like_escape_str !== '')
 				? '\s+'.preg_quote(trim(sprintf($this->_like_escape_str, $this->_like_escape_chr)), '/')
 				: '';
-			$_operators = array(
+			$_operators = [
 				'\s*(?:<|>|!)?=\s*',             // =, <=, >=, !=
 				'\s*<>?\s*',                     // <, <>
 				'\s*>\s*',                       // >
@@ -1514,7 +1514,7 @@ abstract class CI_DB_driver {
 				'\s+NOT IN\s*\(.*\)',        // NOT IN (list)
 				'\s+LIKE\s+\S.*('.$_les.')?',    // LIKE 'expr'[ ESCAPE '%s']
 				'\s+NOT LIKE\s+\S.*('.$_les.')?' // NOT LIKE 'expr'[ ESCAPE '%s']
-			);
+			];
 
 		}
 
@@ -1691,7 +1691,7 @@ abstract class CI_DB_driver {
 		}
 		else
 		{
-			$message = is_array($error) ? $error : array(str_replace('%s', $swap, $LANG->line($error)));
+			$message = is_array($error) ? $error : [str_replace('%s', $swap, $LANG->line($error))];
 		}
 
 		// Find the most likely culprit of the error by going through
@@ -1711,7 +1711,7 @@ abstract class CI_DB_driver {
 				if (strpos($call['file'], BASEPATH.'database') === FALSE && strpos($call['class'], 'Loader') === FALSE)
 				{
 					// Found it - use a relative path for safety
-					$message[] = 'Filename: '.str_replace(array(APPPATH, BASEPATH), '', $call['file']);
+					$message[] = 'Filename: '.str_replace([APPPATH, BASEPATH], '', $call['file']);
 					$message[] = 'Line Number: '.$call['line'];
 					break;
 				}
@@ -1760,7 +1760,7 @@ abstract class CI_DB_driver {
 
 		if (is_array($item))
 		{
-			$escaped_array = array();
+			$escaped_array = [];
 			foreach ($item as $k => $v)
 			{
 				$escaped_array[$this->protect_identifiers($k)] = $this->protect_identifiers($v, $prefix_single, $protect_identifiers, $field_exists);

--- a/system/database/DB_forge.php
+++ b/system/database/DB_forge.php
@@ -58,21 +58,21 @@ abstract class CI_DB_forge {
 	 *
 	 * @var	array
 	 */
-	public $fields		= array();
+	public $fields		= [];
 
 	/**
 	 * Keys data
 	 *
 	 * @var	array
 	 */
-	public $keys		= array();
+	public $keys		= [];
 
 	/**
 	 * Primary Keys data
 	 *
 	 * @var	array
 	 */
-	public $primary_keys	= array();
+	public $primary_keys	= [];
 
 	/**
 	 * Database character set
@@ -281,13 +281,13 @@ abstract class CI_DB_forge {
 		{
 			if ($field === 'id')
 			{
-				$this->add_field(array(
-					'id' => array(
+				$this->add_field([
+					'id' => [
 						'type' => 'INT',
 						'constraint' => 9,
 						'auto_increment' => TRUE
-					)
-				));
+					]
+				]);
 				$this->add_key('id', TRUE);
 			}
 			else
@@ -319,7 +319,7 @@ abstract class CI_DB_forge {
 	 * @param	array	$attributes	Associative array of table attributes
 	 * @return	bool
 	 */
-	public function create_table($table, $if_not_exists = FALSE, array $attributes = array())
+	public function create_table($table, $if_not_exists = FALSE, array $attributes = [])
 	{
 		if ($table === '')
 		{
@@ -564,7 +564,7 @@ abstract class CI_DB_forge {
 	public function add_column($table, $field, $_after = NULL)
 	{
 		// Work-around for literal column definitions
-		is_array($field) OR $field = array($field);
+		is_array($field) OR $field = [$field];
 
 		foreach (array_keys($field) as $k)
 		{
@@ -574,7 +574,7 @@ abstract class CI_DB_forge {
 				$field[$k]['after'] = $_after;
 			}
 
-			$this->add_field(array($k => $field[$k]));
+			$this->add_field([$k => $field[$k]]);
 		}
 
 		$sqls = $this->_alter_table('ADD', $this->db->dbprefix.$table, $this->_process_fields());
@@ -627,11 +627,11 @@ abstract class CI_DB_forge {
 	public function modify_column($table, $field)
 	{
 		// Work-around for literal column definitions
-		is_array($field) OR $field = array($field);
+		is_array($field) OR $field = [$field];
 
 		foreach (array_keys($field) as $k)
 		{
-			$this->add_field(array($k => $field[$k]));
+			$this->add_field([$k => $field[$k]]);
 		}
 
 		if (count($this->fields) === 0)
@@ -681,7 +681,7 @@ abstract class CI_DB_forge {
 			? 'ADD '
 			: $alter_type.' COLUMN ';
 
-		$sqls = array();
+		$sqls = [];
 		for ($i = 0, $c = count($field); $i < $c; $i++)
 		{
 			$sqls[] = $sql
@@ -701,13 +701,13 @@ abstract class CI_DB_forge {
 	 */
 	protected function _process_fields($create_table = FALSE)
 	{
-		$fields = array();
+		$fields = [];
 
 		foreach ($this->fields as $key => $attributes)
 		{
 			if (is_int($key) && ! is_array($attributes))
 			{
-				$fields[] = array('_literal' => $attributes);
+				$fields[] = ['_literal' => $attributes];
 				continue;
 			}
 
@@ -720,7 +720,7 @@ abstract class CI_DB_forge {
 
 			isset($attributes['TYPE']) && $this->_attr_type($attributes);
 
-			$field = array(
+			$field = [
 				'name'			=> $key,
 				'new_name'		=> isset($attributes['NAME']) ? $attributes['NAME'] : NULL,
 				'type'			=> isset($attributes['TYPE']) ? $attributes['TYPE'] : NULL,
@@ -731,7 +731,7 @@ abstract class CI_DB_forge {
 				'default'		=> '',
 				'auto_increment'	=> '',
 				'_literal'		=> FALSE
-			);
+			];
 
 			isset($attributes['TYPE']) && $this->_attr_unsigned($attributes, $field);
 
@@ -996,7 +996,7 @@ abstract class CI_DB_forge {
 	 */
 	protected function _process_indexes($table)
 	{
-		$sqls = array();
+		$sqls = [];
 
 		for ($i = 0, $c = count($this->keys); $i < $c; $i++)
 		{
@@ -1017,7 +1017,7 @@ abstract class CI_DB_forge {
 				continue;
 			}
 
-			is_array($this->keys[$i]) OR $this->keys[$i] = array($this->keys[$i]);
+			is_array($this->keys[$i]) OR $this->keys[$i] = [$this->keys[$i]];
 
 			$sqls[] = 'CREATE INDEX '.$this->db->escape_identifiers($table.'_'.implode('_', $this->keys[$i]))
 				.' ON '.$this->db->escape_identifiers($table)
@@ -1038,7 +1038,7 @@ abstract class CI_DB_forge {
 	 */
 	protected function _reset()
 	{
-		$this->fields = $this->keys = $this->primary_keys = array();
+		$this->fields = $this->keys = $this->primary_keys = [];
 	}
 
 }

--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -70,7 +70,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 *
 	 * @var	array
 	 */
-	protected $qb_select			= array();
+	protected $qb_select			= [];
 
 	/**
 	 * QB DISTINCT flag
@@ -84,42 +84,42 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 *
 	 * @var	array
 	 */
-	protected $qb_from			= array();
+	protected $qb_from			= [];
 
 	/**
 	 * QB JOIN data
 	 *
 	 * @var	array
 	 */
-	protected $qb_join			= array();
+	protected $qb_join			= [];
 
 	/**
 	 * QB WHERE data
 	 *
 	 * @var	array
 	 */
-	protected $qb_where			= array();
+	protected $qb_where			= [];
 
 	/**
 	 * QB GROUP BY data
 	 *
 	 * @var	array
 	 */
-	protected $qb_groupby			= array();
+	protected $qb_groupby			= [];
 
 	/**
 	 * QB HAVING data
 	 *
 	 * @var	array
 	 */
-	protected $qb_having			= array();
+	protected $qb_having			= [];
 
 	/**
 	 * QB keys
 	 *
 	 * @var	array
 	 */
-	protected $qb_keys			= array();
+	protected $qb_keys			= [];
 
 	/**
 	 * QB LIMIT data
@@ -140,28 +140,28 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 *
 	 * @var	array
 	 */
-	protected $qb_orderby			= array();
+	protected $qb_orderby			= [];
 
 	/**
 	 * QB data sets
 	 *
 	 * @var	array
 	 */
-	protected $qb_set			= array();
+	protected $qb_set			= [];
 
 	/**
 	 * QB data set for update_batch()
 	 *
 	 * @var	array
 	 */
-	protected $qb_set_ub			= array();
+	protected $qb_set_ub			= [];
 
 	/**
 	 * QB aliased tables list
 	 *
 	 * @var	array
 	 */
-	protected $qb_aliased_tables		= array();
+	protected $qb_aliased_tables		= [];
 
 	/**
 	 * QB WHERE group started flag
@@ -191,84 +191,84 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 *
 	 * @var	array
 	 */
-	protected $qb_cache_exists			= array();
+	protected $qb_cache_exists			= [];
 
 	/**
 	 * QB Cache SELECT data
 	 *
 	 * @var	array
 	 */
-	protected $qb_cache_select			= array();
+	protected $qb_cache_select			= [];
 
 	/**
 	 * QB Cache FROM data
 	 *
 	 * @var	array
 	 */
-	protected $qb_cache_from			= array();
+	protected $qb_cache_from			= [];
 
 	/**
 	 * QB Cache JOIN data
 	 *
 	 * @var	array
 	 */
-	protected $qb_cache_join			= array();
+	protected $qb_cache_join			= [];
 
 	/**
 	 * QB Cache aliased tables list
 	 *
 	 * @var	array
 	 */
-	protected $qb_cache_aliased_tables			= array();
+	protected $qb_cache_aliased_tables			= [];
 
 	/**
 	 * QB Cache WHERE data
 	 *
 	 * @var	array
 	 */
-	protected $qb_cache_where			= array();
+	protected $qb_cache_where			= [];
 
 	/**
 	 * QB Cache GROUP BY data
 	 *
 	 * @var	array
 	 */
-	protected $qb_cache_groupby			= array();
+	protected $qb_cache_groupby			= [];
 
 	/**
 	 * QB Cache HAVING data
 	 *
 	 * @var	array
 	 */
-	protected $qb_cache_having			= array();
+	protected $qb_cache_having			= [];
 
 	/**
 	 * QB Cache ORDER BY data
 	 *
 	 * @var	array
 	 */
-	protected $qb_cache_orderby			= array();
+	protected $qb_cache_orderby			= [];
 
 	/**
 	 * QB Cache data sets
 	 *
 	 * @var	array
 	 */
-	protected $qb_cache_set				= array();
+	protected $qb_cache_set				= [];
 
 	/**
 	 * QB No Escape data
 	 *
 	 * @var	array
 	 */
-	protected $qb_no_escape 			= array();
+	protected $qb_no_escape 			= [];
 
 	/**
 	 * QB Cache No Escape data
 	 *
 	 * @var	array
 	 */
-	protected $qb_cache_no_escape			= array();
+	protected $qb_cache_no_escape			= [];
 
 	// --------------------------------------------------------------------
 
@@ -400,7 +400,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 
 		$type = strtoupper($type);
 
-		if ( ! in_array($type, array('MAX', 'MIN', 'AVG', 'SUM')))
+		if ( ! in_array($type, ['MAX', 'MIN', 'AVG', 'SUM']))
 		{
 			show_error('Invalid function type: '.$type);
 		}
@@ -529,7 +529,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 		{
 			$type = strtoupper(trim($type));
 
-			if ( ! in_array($type, array('LEFT', 'RIGHT', 'OUTER', 'INNER', 'LEFT OUTER', 'RIGHT OUTER'), TRUE))
+			if ( ! in_array($type, ['LEFT', 'RIGHT', 'OUTER', 'INNER', 'LEFT OUTER', 'RIGHT OUTER'], TRUE))
 			{
 				$type = '';
 			}
@@ -558,9 +558,9 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 			// Split multiple conditions
 			if (preg_match_all('/\sAND\s|\sOR\s/i', $cond, $joints, PREG_OFFSET_CAPTURE))
 			{
-				$conditions = array();
+				$conditions = [];
 				$joints = $joints[0];
-				array_unshift($joints, array('', 0));
+				array_unshift($joints, ['', 0]);
 
 				for ($i = count($joints) - 1, $pos = strlen($cond); $i >= 0; $i--)
 				{
@@ -572,8 +572,8 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 			}
 			else
 			{
-				$conditions = array($cond);
-				$joints = array('');
+				$conditions = [$cond];
+				$joints = [''];
 			}
 
 			$cond = ' ON ';
@@ -664,7 +664,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 
 		if ( ! is_array($key))
 		{
-			$key = array($key => $value);
+			$key = [$key => $value];
 		}
 
 		// If the escape value was not set will base it on the global setting
@@ -698,10 +698,10 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 				$k = substr($k, 0, $match[0][1]).($match[1][0] === '=' ? ' IS NULL' : ' IS NOT NULL');
 			}
 
-			$this->{$qb_key}[] = array('condition' => $prefix.$k.$v, 'escape' => $escape);
+			$this->{$qb_key}[] = ['condition' => $prefix.$k.$v, 'escape' => $escape];
 			if ($this->qb_caching === TRUE)
 			{
-				$this->{$qb_cache_key}[] = array('condition' => $prefix.$k.$v, 'escape' => $escape);
+				$this->{$qb_cache_key}[] = ['condition' => $prefix.$k.$v, 'escape' => $escape];
 				$this->qb_cache_exists[] = substr($qb_key, 3);
 			}
 
@@ -887,7 +887,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 
 		if ( ! is_array($values))
 		{
-			$values = array($values);
+			$values = [$values];
 		}
 
 		is_bool($escape) OR $escape = $this->_protect_identifiers;
@@ -896,7 +896,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 
 		if ($escape === TRUE)
 		{
-			$wh_in = array();
+			$wh_in = [];
 			foreach ($values as $value)
 			{
 				$wh_in[] = $this->escape($value);
@@ -911,10 +911,10 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 			? $this->_group_get_type('')
 			: $this->_group_get_type($type);
 
-		$wh_in = array(
+		$wh_in = [
 			'condition' => $prefix.$key.$not.' IN('.implode(', ', $wh_in).')',
 			'escape' => $escape
-		);
+		];
 
 		$this->{$qb_key}[] = $wh_in;
 		if ($this->qb_caching === TRUE)
@@ -1024,7 +1024,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	{
 		if ( ! is_array($field))
 		{
-			$field = array($field => $match);
+			$field = [$field => $match];
 		}
 
 		is_bool($escape) OR $escape = $this->_protect_identifiers;
@@ -1064,10 +1064,10 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 				$like_statement .= sprintf($this->_like_escape_str, $this->_like_escape_chr);
 			}
 
-			$this->qb_where[] = array('condition' => $like_statement, 'escape' => $escape);
+			$this->qb_where[] = ['condition' => $like_statement, 'escape' => $escape];
 			if ($this->qb_caching === TRUE)
 			{
-				$this->qb_cache_where[] = array('condition' => $like_statement, 'escape' => $escape);
+				$this->qb_cache_where[] = ['condition' => $like_statement, 'escape' => $escape];
 				$this->qb_cache_exists[] = 'where';
 			}
 		}
@@ -1090,10 +1090,10 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 
 		$this->qb_where_group_started = TRUE;
 		$prefix = (count($this->qb_where) === 0 && count($this->qb_cache_where) === 0) ? '' : $type;
-		$where = array(
+		$where = [
 			'condition' => $prefix.$not.str_repeat(' ', ++$this->qb_where_group_count).' (',
 			'escape' => FALSE
-		);
+		];
 
 		$this->qb_where[] = $where;
 		if ($this->qb_caching)
@@ -1150,10 +1150,10 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	public function group_end()
 	{
 		$this->qb_where_group_started = FALSE;
-		$where = array(
+		$where = [
 			'condition' => str_repeat(' ', $this->qb_where_group_count--).')',
 			'escape' => FALSE
-		);
+		];
 
 		$this->qb_where[] = $where;
 		if ($this->qb_caching)
@@ -1205,7 +1205,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 		{
 			$by = ($escape === TRUE)
 				? explode(',', $by)
-				: array($by);
+				: [$by];
 		}
 
 		foreach ($by as $val)
@@ -1214,7 +1214,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 
 			if ($val !== '')
 			{
-				$val = array('field' => $val, 'escape' => $escape);
+				$val = ['field' => $val, 'escape' => $escape];
 
 				$this->qb_groupby[] = $val;
 				if ($this->qb_caching === TRUE)
@@ -1291,23 +1291,23 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 		}
 		elseif ($direction !== '')
 		{
-			$direction = in_array($direction, array('ASC', 'DESC'), TRUE) ? ' '.$direction : '';
+			$direction = in_array($direction, ['ASC', 'DESC'], TRUE) ? ' '.$direction : '';
 		}
 
 		is_bool($escape) OR $escape = $this->_protect_identifiers;
 
 		if ($escape === FALSE)
 		{
-			$qb_orderby[] = array('field' => $orderby, 'direction' => $direction, 'escape' => FALSE);
+			$qb_orderby[] = ['field' => $orderby, 'direction' => $direction, 'escape' => FALSE];
 		}
 		else
 		{
-			$qb_orderby = array();
+			$qb_orderby = [];
 			foreach (explode(',', $orderby) as $field)
 			{
 				$qb_orderby[] = ($direction === '' && preg_match('/\s+(ASC|DESC)$/i', rtrim($field), $match, PREG_OFFSET_CAPTURE))
-					? array('field' => ltrim(substr($field, 0, $match[0][1])), 'direction' => ' '.$match[1][0], 'escape' => TRUE)
-					: array('field' => trim($field), 'direction' => $direction, 'escape' => TRUE);
+					? ['field' => ltrim(substr($field, 0, $match[0][1])), 'direction' => ' '.$match[1][0], 'escape' => TRUE]
+					: ['field' => trim($field), 'direction' => $direction, 'escape' => TRUE];
 			}
 		}
 
@@ -1385,7 +1385,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 
 		if ( ! is_array($key))
 		{
-			$key = array($key => $value);
+			$key = [$key => $value];
 		}
 
 		is_bool($escape) OR $escape = $this->_protect_identifiers;
@@ -1634,7 +1634,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 
 		if ( ! is_array($key))
 		{
-			$key = array($key => $value);
+			$key = [$key => $value];
 		}
 
 		is_bool($escape) OR $escape = $this->_protect_identifiers;
@@ -1648,7 +1648,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 			if (count(array_diff($keys, array_keys($row))) > 0 OR count(array_diff(array_keys($row), $keys)) > 0)
 			{
 				// batch function above returns an error on an empty array
-				$this->qb_set[] = array();
+				$this->qb_set[] = [];
 				return;
 			}
 
@@ -1656,7 +1656,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 
 			if ($escape !== FALSE)
 			{
-				$clean = array();
+				$clean = [];
 				foreach ($row as $value)
 				{
 					$clean[] = $this->escape($value);
@@ -1945,7 +1945,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 
 		if ($table !== '')
 		{
-			$this->qb_from = array($this->protect_identifiers($table, TRUE, NULL, FALSE));
+			$this->qb_from = [$this->protect_identifiers($table, TRUE, NULL, FALSE)];
 		}
 		elseif ( ! isset($this->qb_from[0]))
 		{
@@ -2013,7 +2013,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 				$affected_rows += $this->affected_rows();
 			}
 
-			$this->qb_where = array();
+			$this->qb_where = [];
 		}
 
 		$this->_reset_write();
@@ -2034,7 +2034,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 */
 	protected function _update_batch($table, $values, $index)
 	{
-		$ids = array();
+		$ids = [];
 		foreach ($values as $key => $val)
 		{
 			$ids[] = $val[$index]['value'];
@@ -2085,7 +2085,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 		foreach ($key as $k => $v)
 		{
 			$index_set = FALSE;
-			$clean = array();
+			$clean = [];
 			foreach ($v as $k2 => $v2)
 			{
 				if ($k2 === $index)
@@ -2093,10 +2093,10 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 					$index_set = TRUE;
 				}
 
-				$clean[$k2] = array(
+				$clean[$k2] = [
 					'field'  => $this->protect_identifiers($k2, FALSE, $escape),
 					'value'  => ($escape === FALSE ? $v2 : $this->escape($v2))
-				);
+				];
 			}
 
 			if ($index_set === FALSE)
@@ -2616,7 +2616,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 			return $object;
 		}
 
-		$array = array();
+		$array = [];
 		foreach (get_object_vars($object) as $key => $val)
 		{
 			// There are some built in keys we need to ignore for this conversion
@@ -2646,7 +2646,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 			return $object;
 		}
 
-		$array = array();
+		$array = [];
 		$out = get_object_vars($object);
 		$fields = array_keys($out);
 
@@ -2707,19 +2707,19 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 */
 	public function flush_cache()
 	{
-		$this->_reset_run(array(
-			'qb_cache_select'		=> array(),
-			'qb_cache_from'			=> array(),
-			'qb_cache_join'			=> array(),
-			'qb_cache_where'		=> array(),
-			'qb_cache_groupby'		=> array(),
-			'qb_cache_having'		=> array(),
-			'qb_cache_orderby'		=> array(),
-			'qb_cache_set'			=> array(),
-			'qb_cache_exists'		=> array(),
-			'qb_cache_no_escape'	=> array(),
-			'qb_cache_aliased_tables'	=> array()
-		));
+		$this->_reset_run([
+			'qb_cache_select'		=> [],
+			'qb_cache_from'			=> [],
+			'qb_cache_join'			=> [],
+			'qb_cache_where'		=> [],
+			'qb_cache_groupby'		=> [],
+			'qb_cache_having'		=> [],
+			'qb_cache_orderby'		=> [],
+			'qb_cache_set'			=> [],
+			'qb_cache_exists'		=> [],
+			'qb_cache_no_escape'	=> [],
+			'qb_cache_aliased_tables'	=> []
+		]);
 
 		return $this;
 	}
@@ -2785,7 +2785,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	{
 		$str = trim($str);
 
-		if (empty($str) OR ctype_digit($str) OR (string) (float) $str === $str OR in_array(strtoupper($str), array('TRUE', 'FALSE'), TRUE))
+		if (empty($str) OR ctype_digit($str) OR (string) (float) $str === $str OR in_array(strtoupper($str), ['TRUE', 'FALSE'], TRUE))
 		{
 			return TRUE;
 		}
@@ -2795,7 +2795,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 		if (empty($_str))
 		{
 			$_str = ($this->_escape_char !== '"')
-				? array('"', "'") : array("'");
+				? ['"', "'"] : ["'"];
 		}
 
 		return in_array($str[0], $_str, TRUE);
@@ -2842,20 +2842,20 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 */
 	protected function _reset_select()
 	{
-		$this->_reset_run(array(
-			'qb_select'		=> array(),
-			'qb_from'		=> array(),
-			'qb_join'		=> array(),
-			'qb_where'		=> array(),
-			'qb_groupby'		=> array(),
-			'qb_having'		=> array(),
-			'qb_orderby'		=> array(),
-			'qb_aliased_tables'	=> array(),
-			'qb_no_escape'		=> array(),
+		$this->_reset_run([
+			'qb_select'		=> [],
+			'qb_from'		=> [],
+			'qb_join'		=> [],
+			'qb_where'		=> [],
+			'qb_groupby'		=> [],
+			'qb_having'		=> [],
+			'qb_orderby'		=> [],
+			'qb_aliased_tables'	=> [],
+			'qb_no_escape'		=> [],
 			'qb_distinct'		=> FALSE,
 			'qb_limit'		=> FALSE,
 			'qb_offset'		=> FALSE
-		));
+		]);
 	}
 
 	// --------------------------------------------------------------------
@@ -2869,16 +2869,16 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 */
 	protected function _reset_write()
 	{
-		$this->_reset_run(array(
-			'qb_set'	=> array(),
-			'qb_set_ub'	=> array(),
-			'qb_from'	=> array(),
-			'qb_join'	=> array(),
-			'qb_where'	=> array(),
-			'qb_orderby'	=> array(),
-			'qb_keys'	=> array(),
+		$this->_reset_run([
+			'qb_set'	=> [],
+			'qb_set_ub'	=> [],
+			'qb_from'	=> [],
+			'qb_join'	=> [],
+			'qb_where'	=> [],
+			'qb_orderby'	=> [],
+			'qb_keys'	=> [],
 			'qb_limit'	=> FALSE
-		));
+		]);
 	}
 
 }

--- a/system/database/DB_result.php
+++ b/system/database/DB_result.php
@@ -69,21 +69,21 @@ class CI_DB_result {
 	 *
 	 * @var	array[]
 	 */
-	public $result_array			= array();
+	public $result_array			= [];
 
 	/**
 	 * Result Object
 	 *
 	 * @var	object[]
 	 */
-	public $result_object			= array();
+	public $result_object			= [];
 
 	/**
 	 * Custom Result Object
 	 *
 	 * @var	object[]
 	 */
-	public $custom_result_object		= array();
+	public $custom_result_object		= [];
 
 	/**
 	 * Current Row index
@@ -185,7 +185,7 @@ class CI_DB_result {
 		}
 		elseif ( ! $this->result_id OR $this->num_rows === 0)
 		{
-			return array();
+			return [];
 		}
 
 		// Don't fetch the result set again if we already have it
@@ -215,7 +215,7 @@ class CI_DB_result {
 		}
 
 		is_null($this->row_data) OR $this->data_seek(0);
-		$this->custom_result_object[$class_name] = array();
+		$this->custom_result_object[$class_name] = [];
 
 		while ($row = $this->_fetch_object($class_name))
 		{
@@ -244,7 +244,7 @@ class CI_DB_result {
 		// array.
 		if ( ! $this->result_id OR $this->num_rows === 0)
 		{
-			return array();
+			return [];
 		}
 
 		if (($c = count($this->result_array)) > 0)
@@ -285,7 +285,7 @@ class CI_DB_result {
 		// array.
 		if ( ! $this->result_id OR $this->num_rows === 0)
 		{
-			return array();
+			return [];
 		}
 
 		if (($c = count($this->result_object)) > 0)
@@ -578,7 +578,7 @@ class CI_DB_result {
 	 */
 	public function list_fields()
 	{
-		return array();
+		return [];
 	}
 
 	// --------------------------------------------------------------------
@@ -594,7 +594,7 @@ class CI_DB_result {
 	 */
 	public function field_data()
 	{
-		return array();
+		return [];
 	}
 
 	// --------------------------------------------------------------------
@@ -643,7 +643,7 @@ class CI_DB_result {
 	 */
 	protected function _fetch_assoc()
 	{
-		return array();
+		return [];
 	}
 
 	// --------------------------------------------------------------------

--- a/system/database/DB_utility.php
+++ b/system/database/DB_utility.php
@@ -109,7 +109,7 @@ abstract class CI_DB_utility {
 			return ($this->db->db_debug) ? $this->db->display_error('db_unsupported_feature') : FALSE;
 		}
 
-		$this->db->data_cache['db_names'] = array();
+		$this->db->data_cache['db_names'] = [];
 
 		$query = $this->db->query($this->_list_databases);
 		if ($query === FALSE)
@@ -177,7 +177,7 @@ abstract class CI_DB_utility {
 			return ($this->db->db_debug) ? $this->db->display_error('db_unsupported_feature') : FALSE;
 		}
 
-		$result = array();
+		$result = [];
 		foreach ($this->db->list_tables() as $table_name)
 		{
 			$res = $this->db->query(sprintf($this->_optimize_table, $this->db->escape_identifiers($table_name)));
@@ -249,7 +249,7 @@ abstract class CI_DB_utility {
 		// Next blast through the result array and build out the rows
 		while ($row = $query->unbuffered_row('array'))
 		{
-			$line = array();
+			$line = [];
 			foreach ($row as $item)
 			{
 				$line[] = $enclosure.str_replace($enclosure, $enclosure.$enclosure, $item).$enclosure;
@@ -269,10 +269,10 @@ abstract class CI_DB_utility {
 	 * @param	array	$params	Any preferences
 	 * @return	string
 	 */
-	public function xml_from_result(CI_DB_result $query, $params = array())
+	public function xml_from_result(CI_DB_result $query, $params = [])
 	{
 		// Set our default values
-		foreach (array('root' => 'root', 'element' => 'element', 'newline' => "\n", 'tab' => "\t") as $key => $val)
+		foreach (['root' => 'root', 'element' => 'element', 'newline' => "\n", 'tab' => "\t"] as $key => $val)
 		{
 			if ( ! isset($params[$key]))
 			{
@@ -309,27 +309,27 @@ abstract class CI_DB_utility {
 	 * @param	array	$params
 	 * @return	string
 	 */
-	public function backup($params = array())
+	public function backup($params = [])
 	{
 		// If the parameters have not been submitted as an
 		// array then we know that it is simply the table
 		// name, which is a valid short cut.
 		if (is_string($params))
 		{
-			$params = array('tables' => $params);
+			$params = ['tables' => $params];
 		}
 
 		// Set up our default preferences
-		$prefs = array(
-			'tables'		=> array(),
-			'ignore'		=> array(),
+		$prefs = [
+			'tables'		=> [],
+			'ignore'		=> [],
 			'filename'		=> '',
 			'format'		=> 'gzip', // gzip, zip, txt
 			'add_drop'		=> TRUE,
 			'add_insert'		=> TRUE,
 			'newline'		=> "\n",
 			'foreign_key_checks'	=> TRUE
-		);
+		];
 
 		// Did the user submit any preferences? If so set them....
 		if (count($params) > 0)
@@ -351,7 +351,7 @@ abstract class CI_DB_utility {
 		}
 
 		// Validate the format
-		if ( ! in_array($prefs['format'], array('gzip', 'zip', 'txt'), TRUE))
+		if ( ! in_array($prefs['format'], ['gzip', 'zip', 'txt'], TRUE))
 		{
 			$prefs['format'] = 'txt';
 		}

--- a/system/database/drivers/cubrid/cubrid_driver.php
+++ b/system/database/drivers/cubrid/cubrid_driver.php
@@ -80,7 +80,7 @@ class CI_DB_cubrid_driver extends CI_DB {
 	 *
 	 * @var	array
 	 */
-	protected $_random_keyword = array('RANDOM()', 'RANDOM(%d)');
+	protected $_random_keyword = ['RANDOM()', 'RANDOM(%d)'];
 
 	// --------------------------------------------------------------------
 
@@ -337,7 +337,7 @@ class CI_DB_cubrid_driver extends CI_DB {
 		}
 		$query = $query->result_object();
 
-		$retval = array();
+		$retval = [];
 		for ($i = 0, $c = count($query); $i < $c; $i++)
 		{
 			$retval[$i]			= new stdClass();
@@ -367,7 +367,7 @@ class CI_DB_cubrid_driver extends CI_DB {
 	 */
 	public function error()
 	{
-		return array('code' => cubrid_errno($this->conn_id), 'message' => cubrid_error($this->conn_id));
+		return ['code' => cubrid_errno($this->conn_id), 'message' => cubrid_error($this->conn_id)];
 	}
 
 	// --------------------------------------------------------------------

--- a/system/database/drivers/cubrid/cubrid_forge.php
+++ b/system/database/drivers/cubrid/cubrid_forge.php
@@ -82,7 +82,7 @@ class CI_DB_cubrid_forge extends CI_DB_forge {
 	 *
 	 * @var	array
 	 */
-	protected $_unsigned		= array(
+	protected $_unsigned		= [
 		'SHORT'		=> 'INTEGER',
 		'SMALLINT'	=> 'INTEGER',
 		'INT'		=> 'BIGINT',
@@ -90,7 +90,7 @@ class CI_DB_cubrid_forge extends CI_DB_forge {
 		'BIGINT'	=> 'NUMERIC',
 		'FLOAT'		=> 'DOUBLE',
 		'REAL'		=> 'DOUBLE'
-	);
+	];
 
 	// --------------------------------------------------------------------
 
@@ -104,13 +104,13 @@ class CI_DB_cubrid_forge extends CI_DB_forge {
 	 */
 	protected function _alter_table($alter_type, $table, $field)
 	{
-		if (in_array($alter_type, array('DROP', 'ADD'), TRUE))
+		if (in_array($alter_type, ['DROP', 'ADD'], TRUE))
 		{
 			return parent::_alter_table($alter_type, $table, $field);
 		}
 
 		$sql = 'ALTER TABLE '.$this->db->escape_identifiers($table);
-		$sqls = array();
+		$sqls = [];
 		for ($i = 0, $c = count($field); $i < $c; $i++)
 		{
 			if ($field[$i]['_literal'] !== FALSE)
@@ -216,13 +216,13 @@ class CI_DB_cubrid_forge extends CI_DB_forge {
 				continue;
 			}
 
-			is_array($this->keys[$i]) OR $this->keys[$i] = array($this->keys[$i]);
+			is_array($this->keys[$i]) OR $this->keys[$i] = [$this->keys[$i]];
 
 			$sql .= ",\n\tKEY ".$this->db->escape_identifiers(implode('_', $this->keys[$i]))
 				.' ('.implode(', ', $this->db->escape_identifiers($this->keys[$i])).')';
 		}
 
-		$this->keys = array();
+		$this->keys = [];
 
 		return $sql;
 	}

--- a/system/database/drivers/cubrid/cubrid_result.php
+++ b/system/database/drivers/cubrid/cubrid_result.php
@@ -97,7 +97,7 @@ class CI_DB_cubrid_result extends CI_DB_result {
 	 */
 	public function field_data()
 	{
-		$retval = array();
+		$retval = [];
 
 		for ($i = 0, $c = $this->num_fields(); $i < $c; $i++)
 		{

--- a/system/database/drivers/cubrid/cubrid_utility.php
+++ b/system/database/drivers/cubrid/cubrid_utility.php
@@ -69,7 +69,7 @@ class CI_DB_cubrid_utility extends CI_DB_utility {
 	 * @param	array	Preferences
 	 * @return	mixed
 	 */
-	protected function _backup($params = array())
+	protected function _backup($params = [])
 	{
 		// No SQL based support in CUBRID as of version 8.4.0. Database or
 		// table backup can be performed using CUBRID Manager

--- a/system/database/drivers/ibase/ibase_driver.php
+++ b/system/database/drivers/ibase/ibase_driver.php
@@ -66,7 +66,7 @@ class CI_DB_ibase_driver extends CI_DB {
 	 *
 	 * @var	array
 	 */
-	protected $_random_keyword = array('RAND()', 'RAND()');
+	protected $_random_keyword = ['RAND()', 'RAND()'];
 
 	/**
 	 * IBase Transaction status flag
@@ -300,7 +300,7 @@ class CI_DB_ibase_driver extends CI_DB {
 	 */
 	public function error()
 	{
-		return array('code' => ibase_errcode(), 'message' => ibase_errmsg());
+		return ['code' => ibase_errcode(), 'message' => ibase_errmsg()];
 	}
 
 	// --------------------------------------------------------------------

--- a/system/database/drivers/ibase/ibase_forge.php
+++ b/system/database/drivers/ibase/ibase_forge.php
@@ -72,11 +72,11 @@ class CI_DB_ibase_forge extends CI_DB_forge {
 	 *
 	 * @var	array
 	 */
-	protected $_unsigned		= array(
+	protected $_unsigned		= [
 		'SMALLINT'	=> 'INTEGER',
 		'INTEGER'	=> 'INT64',
 		'FLOAT'		=> 'DOUBLE PRECISION'
-	);
+	];
 
 	/**
 	 * NULL value representation in CREATE/ALTER TABLE statements
@@ -141,13 +141,13 @@ class CI_DB_ibase_forge extends CI_DB_forge {
 	 */
 	protected function _alter_table($alter_type, $table, $field)
  	{
-		if (in_array($alter_type, array('DROP', 'ADD'), TRUE))
+		if (in_array($alter_type, ['DROP', 'ADD'], TRUE))
 		{
 			return parent::_alter_table($alter_type, $table, $field);
 		}
 
 		$sql = 'ALTER TABLE '.$this->db->escape_identifiers($table);
-		$sqls = array();
+		$sqls = [];
 		for ($i = 0, $c = count($field); $i < $c; $i++)
 		{
 			if ($field[$i]['_literal'] !== FALSE)

--- a/system/database/drivers/ibase/ibase_result.php
+++ b/system/database/drivers/ibase/ibase_result.php
@@ -69,7 +69,7 @@ class CI_DB_ibase_result extends CI_DB_result {
 	 */
 	public function list_fields()
 	{
-		$field_names = array();
+		$field_names = [];
 		for ($i = 0, $num_fields = $this->num_fields(); $i < $num_fields; $i++)
 		{
 			$info = ibase_field_info($this->result_id, $i);
@@ -90,7 +90,7 @@ class CI_DB_ibase_result extends CI_DB_result {
 	 */
 	public function field_data()
 	{
-		$retval = array();
+		$retval = [];
 		for ($i = 0, $c = $this->num_fields(); $i < $c; $i++)
 		{
 			$info = ibase_field_info($this->result_id, $i);

--- a/system/database/drivers/mssql/mssql_driver.php
+++ b/system/database/drivers/mssql/mssql_driver.php
@@ -66,7 +66,7 @@ class CI_DB_mssql_driver extends CI_DB {
 	 *
 	 * @var	array
 	 */
-	protected $_random_keyword = array('NEWID()', 'RAND(%d)');
+	protected $_random_keyword = ['NEWID()', 'RAND(%d)'];
 
 	/**
 	 * Quoted identifier flag
@@ -134,7 +134,7 @@ class CI_DB_mssql_driver extends CI_DB {
 		$query = $this->query('SELECT CASE WHEN (@@OPTIONS | 256) = @@OPTIONS THEN 1 ELSE 0 END AS qi');
 		$query = $query->row_array();
 		$this->_quoted_identifier = empty($query) ? FALSE : (bool) $query['qi'];
-		$this->_escape_char = ($this->_quoted_identifier) ? '"' : array('[', ']');
+		$this->_escape_char = ($this->_quoted_identifier) ? '"' : ['[', ']'];
 
 		return $this->conn_id;
 	}
@@ -159,7 +159,7 @@ class CI_DB_mssql_driver extends CI_DB {
 		if (mssql_select_db('['.$database.']', $this->conn_id))
 		{
 			$this->database = $database;
-			$this->data_cache = array();
+			$this->data_cache = [];
 			return TRUE;
 		}
 
@@ -321,7 +321,7 @@ class CI_DB_mssql_driver extends CI_DB {
 		}
 		$query = $query->result_object();
 
-		$retval = array();
+		$retval = [];
 		for ($i = 0, $c = count($query); $i < $c; $i++)
 		{
 			$retval[$i]			= new stdClass();
@@ -349,7 +349,7 @@ class CI_DB_mssql_driver extends CI_DB {
 		// We need this because the error info is discarded by the
 		// server the first time you request it, and query() already
 		// calls error() once for logging purposes when a query fails.
-		static $error = array('code' => 0, 'message' => NULL);
+		static $error = ['code' => 0, 'message' => NULL];
 
 		$message = mssql_get_last_message();
 		if ( ! empty($message))
@@ -375,7 +375,7 @@ class CI_DB_mssql_driver extends CI_DB {
 	protected function _update($table, $values)
 	{
 		$this->qb_limit = FALSE;
-		$this->qb_orderby = array();
+		$this->qb_orderby = [];
 		return parent::_update($table, $values);
 	}
 
@@ -448,7 +448,7 @@ class CI_DB_mssql_driver extends CI_DB {
 			else
 			{
 				// Use only field names and their aliases, everything else is out of our scope.
-				$select = array();
+				$select = [];
 				$field_regexp = ($this->_quoted_identifier)
 					? '("[^\"]+")' : '(\[[^\]]+\])';
 				for ($i = 0, $c = count($this->qb_select); $i < $c; $i++)

--- a/system/database/drivers/mssql/mssql_forge.php
+++ b/system/database/drivers/mssql/mssql_forge.php
@@ -67,12 +67,12 @@ class CI_DB_mssql_forge extends CI_DB_forge {
 	 *
 	 * @var	array
 	 */
-	protected $_unsigned		= array(
+	protected $_unsigned		= [
 		'TINYINT'	=> 'SMALLINT',
 		'SMALLINT'	=> 'INT',
 		'INT'		=> 'BIGINT',
 		'REAL'		=> 'FLOAT'
-	);
+	];
 
 	// --------------------------------------------------------------------
 
@@ -86,13 +86,13 @@ class CI_DB_mssql_forge extends CI_DB_forge {
 	 */
 	protected function _alter_table($alter_type, $table, $field)
 	{
-		if (in_array($alter_type, array('ADD', 'DROP'), TRUE))
+		if (in_array($alter_type, ['ADD', 'DROP'], TRUE))
 		{
 			return parent::_alter_table($alter_type, $table, $field);
 		}
 
 		$sql = 'ALTER TABLE '.$this->db->escape_identifiers($table).' ALTER COLUMN ';
-		$sqls = array();
+		$sqls = [];
 		for ($i = 0, $c = count($field); $i < $c; $i++)
 		{
 			$sqls[] = $sql.$this->_process_column($field[$i]);

--- a/system/database/drivers/mssql/mssql_result.php
+++ b/system/database/drivers/mssql/mssql_result.php
@@ -85,7 +85,7 @@ class CI_DB_mssql_result extends CI_DB_result {
 	 */
 	public function list_fields()
 	{
-		$field_names = array();
+		$field_names = [];
 		mssql_field_seek($this->result_id, 0);
 		while ($field = mssql_fetch_field($this->result_id))
 		{
@@ -106,7 +106,7 @@ class CI_DB_mssql_result extends CI_DB_result {
 	 */
 	public function field_data()
 	{
-		$retval = array();
+		$retval = [];
 		for ($i = 0, $c = $this->num_fields(); $i < $c; $i++)
 		{
 			$field = mssql_fetch_field($this->result_id, $i);

--- a/system/database/drivers/mssql/mssql_utility.php
+++ b/system/database/drivers/mssql/mssql_utility.php
@@ -68,7 +68,7 @@ class CI_DB_mssql_utility extends CI_DB_utility {
 	 * @param	array	$params	Preferences
 	 * @return	bool
 	 */
-	protected function _backup($params = array())
+	protected function _backup($params = [])
 	{
 		// Currently unsupported
 		return $this->db->display_error('db_unsupported_feature');

--- a/system/database/drivers/mysql/mysql_driver.php
+++ b/system/database/drivers/mysql/mysql_driver.php
@@ -220,7 +220,7 @@ class CI_DB_mysql_driver extends CI_DB {
 		if (mysql_select_db($database, $this->conn_id))
 		{
 			$this->database = $database;
-			$this->data_cache = array();
+			$this->data_cache = [];
 			return TRUE;
 		}
 
@@ -423,7 +423,7 @@ class CI_DB_mysql_driver extends CI_DB {
 		}
 		$query = $query->result_object();
 
-		$retval = array();
+		$retval = [];
 		for ($i = 0, $c = count($query); $i < $c; $i++)
 		{
 			$retval[$i]			= new stdClass();
@@ -453,7 +453,7 @@ class CI_DB_mysql_driver extends CI_DB {
 	 */
 	public function error()
 	{
-		return array('code' => mysql_errno($this->conn_id), 'message' => mysql_error($this->conn_id));
+		return ['code' => mysql_errno($this->conn_id), 'message' => mysql_error($this->conn_id)];
 	}
 
 	// --------------------------------------------------------------------

--- a/system/database/drivers/mysql/mysql_forge.php
+++ b/system/database/drivers/mysql/mysql_forge.php
@@ -68,7 +68,7 @@ class CI_DB_mysql_forge extends CI_DB_forge {
 	 *
 	 * @var	array
 	 */
-	protected $_unsigned		= array(
+	protected $_unsigned		= [
 		'TINYINT',
 		'SMALLINT',
 		'MEDIUMINT',
@@ -81,7 +81,7 @@ class CI_DB_mysql_forge extends CI_DB_forge {
 		'FLOAT',
 		'DECIMAL',
 		'NUMERIC'
-	);
+	];
 
 	/**
 	 * NULL value representation in CREATE/ALTER TABLE statements
@@ -164,7 +164,7 @@ class CI_DB_mysql_forge extends CI_DB_forge {
 			}
 		}
 
-		return array($sql.implode(',', $field));
+		return [$sql.implode(',', $field)];
 	}
 
 	// --------------------------------------------------------------------
@@ -229,13 +229,13 @@ class CI_DB_mysql_forge extends CI_DB_forge {
 				continue;
 			}
 
-			is_array($this->keys[$i]) OR $this->keys[$i] = array($this->keys[$i]);
+			is_array($this->keys[$i]) OR $this->keys[$i] = [$this->keys[$i]];
 
 			$sql .= ",\n\tKEY ".$this->db->escape_identifiers(implode('_', $this->keys[$i]))
 				.' ('.implode(', ', $this->db->escape_identifiers($this->keys[$i])).')';
 		}
 
-		$this->keys = array();
+		$this->keys = [];
 
 		return $sql;
 	}

--- a/system/database/drivers/mysql/mysql_result.php
+++ b/system/database/drivers/mysql/mysql_result.php
@@ -98,7 +98,7 @@ class CI_DB_mysql_result extends CI_DB_result {
 	 */
 	public function list_fields()
 	{
-		$field_names = array();
+		$field_names = [];
 		mysql_field_seek($this->result_id, 0);
 		while ($field = mysql_fetch_field($this->result_id))
 		{
@@ -119,7 +119,7 @@ class CI_DB_mysql_result extends CI_DB_result {
 	 */
 	public function field_data()
 	{
-		$retval = array();
+		$retval = [];
 		for ($i = 0, $c = $this->num_fields(); $i < $c; $i++)
 		{
 			$retval[$i]			= new stdClass();

--- a/system/database/drivers/mysql/mysql_utility.php
+++ b/system/database/drivers/mysql/mysql_utility.php
@@ -75,7 +75,7 @@ class CI_DB_mysql_utility extends CI_DB_utility {
 	 * @param	array	$params	Preferences
 	 * @return	mixed
 	 */
-	protected function _backup($params = array())
+	protected function _backup($params = [])
 	{
 		if (count($params) === 0)
 		{
@@ -149,12 +149,12 @@ class CI_DB_mysql_utility extends CI_DB_utility {
 
 			$i = 0;
 			$field_str = '';
-			$is_int = array();
+			$is_int = [];
 			while ($field = mysql_fetch_field($query->result_id))
 			{
 				// Most versions of MySQL store timestamp as a string
 				$is_int[$i] = in_array(strtolower(mysql_field_type($query->result_id, $i)),
-							array('tinyint', 'smallint', 'mediumint', 'int', 'bigint'), //, 'timestamp'),
+							['tinyint', 'smallint', 'mediumint', 'int', 'bigint'], //, 'timestamp'),
 							TRUE);
 
 				// Create a string of field names

--- a/system/database/drivers/mysqli/mysqli_driver.php
+++ b/system/database/drivers/mysqli/mysqli_driver.php
@@ -160,7 +160,7 @@ class CI_DB_mysqli_driver extends CI_DB {
 
 		if (is_array($this->encrypt))
 		{
-			$ssl = array();
+			$ssl = [];
 			empty($this->encrypt['ssl_key'])    OR $ssl['key']    = $this->encrypt['ssl_key'];
 			empty($this->encrypt['ssl_cert'])   OR $ssl['cert']   = $this->encrypt['ssl_cert'];
 			empty($this->encrypt['ssl_ca'])     OR $ssl['ca']     = $this->encrypt['ssl_ca'];
@@ -262,7 +262,7 @@ class CI_DB_mysqli_driver extends CI_DB {
 		if ($this->conn_id->select_db($database))
 		{
 			$this->database = $database;
-			$this->data_cache = array();
+			$this->data_cache = [];
 			return TRUE;
 		}
 
@@ -462,7 +462,7 @@ class CI_DB_mysqli_driver extends CI_DB {
 		}
 		$query = $query->result_object();
 
-		$retval = array();
+		$retval = [];
 		for ($i = 0, $c = count($query); $i < $c; $i++)
 		{
 			$retval[$i]			= new stdClass();
@@ -494,13 +494,13 @@ class CI_DB_mysqli_driver extends CI_DB {
 	{
 		if ( ! empty($this->_mysqli->connect_errno))
 		{
-			return array(
+			return [
 				'code'    => $this->_mysqli->connect_errno,
 				'message' => $this->_mysqli->connect_error
-			);
+			];
 		}
 
-		return array('code' => $this->conn_id->errno, 'message' => $this->conn_id->error);
+		return ['code' => $this->conn_id->errno, 'message' => $this->conn_id->error];
 	}
 
 	// --------------------------------------------------------------------

--- a/system/database/drivers/mysqli/mysqli_forge.php
+++ b/system/database/drivers/mysqli/mysqli_forge.php
@@ -70,7 +70,7 @@ class CI_DB_mysqli_forge extends CI_DB_forge {
 	 *
 	 * @var	array
 	 */
-	protected $_unsigned		= array(
+	protected $_unsigned		= [
 		'TINYINT',
 		'SMALLINT',
 		'MEDIUMINT',
@@ -83,7 +83,7 @@ class CI_DB_mysqli_forge extends CI_DB_forge {
 		'FLOAT',
 		'DECIMAL',
 		'NUMERIC'
-	);
+	];
 
 	/**
 	 * NULL value representation in CREATE/ALTER TABLE statements
@@ -166,7 +166,7 @@ class CI_DB_mysqli_forge extends CI_DB_forge {
 			}
 		}
 
-		return array($sql.implode(',', $field));
+		return [$sql.implode(',', $field)];
 	}
 
 	// --------------------------------------------------------------------
@@ -230,13 +230,13 @@ class CI_DB_mysqli_forge extends CI_DB_forge {
 				continue;
 			}
 
-			is_array($this->keys[$i]) OR $this->keys[$i] = array($this->keys[$i]);
+			is_array($this->keys[$i]) OR $this->keys[$i] = [$this->keys[$i]];
 
 			$sql .= ",\n\tKEY ".$this->db->escape_identifiers(implode('_', $this->keys[$i]))
 				.' ('.implode(', ', $this->db->escape_identifiers($this->keys[$i])).')';
 		}
 
-		$this->keys = array();
+		$this->keys = [];
 
 		return $sql;
 	}

--- a/system/database/drivers/mysqli/mysqli_result.php
+++ b/system/database/drivers/mysqli/mysqli_result.php
@@ -85,7 +85,7 @@ class CI_DB_mysqli_result extends CI_DB_result {
 	 */
 	public function list_fields()
 	{
-		$field_names = array();
+		$field_names = [];
 		$this->result_id->field_seek(0);
 		while ($field = $this->result_id->fetch_field())
 		{
@@ -106,7 +106,7 @@ class CI_DB_mysqli_result extends CI_DB_result {
 	 */
 	public function field_data()
 	{
-		$retval = array();
+		$retval = [];
 		$field_data = $this->result_id->fetch_fields();
 		for ($i = 0, $c = count($field_data); $i < $c; $i++)
 		{

--- a/system/database/drivers/mysqli/mysqli_utility.php
+++ b/system/database/drivers/mysqli/mysqli_utility.php
@@ -77,7 +77,7 @@ class CI_DB_mysqli_utility extends CI_DB_utility {
 	 * @param	array	$params	Preferences
 	 * @return	mixed
 	 */
-	protected function _backup($params = array())
+	protected function _backup($params = [])
 	{
 		if (count($params) === 0)
 		{
@@ -151,12 +151,12 @@ class CI_DB_mysqli_utility extends CI_DB_utility {
 
 			$i = 0;
 			$field_str = '';
-			$is_int = array();
+			$is_int = [];
 			while ($field = $query->result_id->fetch_field())
 			{
 				// Most versions of MySQL store timestamp as a string
 				$is_int[$i] = in_array(strtolower($field->type),
-							array('tinyint', 'smallint', 'mediumint', 'int', 'bigint'), //, 'timestamp'),
+							['tinyint', 'smallint', 'mediumint', 'int', 'bigint'], //, 'timestamp'),
 							TRUE);
 
 				// Create a string of field names

--- a/system/database/drivers/oci8/oci8_driver.php
+++ b/system/database/drivers/oci8/oci8_driver.php
@@ -116,14 +116,14 @@ class CI_DB_oci8_driver extends CI_DB {
 	 *
 	 * @var	string[]
 	 */
-	protected $_reserved_identifiers = array('*', 'rownum');
+	protected $_reserved_identifiers = ['*', 'rownum'];
 
 	/**
 	 * ORDER BY random keyword
 	 *
 	 * @var	array
 	 */
-	protected $_random_keyword = array('ASC', 'ASC'); // not currently supported
+	protected $_random_keyword = ['ASC', 'ASC']; // not currently supported
 
 	/**
 	 * COUNT string
@@ -147,17 +147,17 @@ class CI_DB_oci8_driver extends CI_DB {
 	{
 		parent::__construct($params);
 
-		$valid_dsns = array(
+		$valid_dsns = [
 			'tns'	=> '/^\(DESCRIPTION=(\(.+\)){2,}\)$/', // TNS
 			// Easy Connect string (Oracle 10g+)
 			'ec'	=> '/^(\/\/)?[a-z0-9.:_-]+(:[1-9][0-9]{0,4})?(\/[a-z0-9$_]+)?(:[^\/])?(\/[a-z0-9$_]+)?$/i',
 			'in'	=> '/^[a-z0-9$_]+$/i' // Instance name (defined in tnsnames.ora)
-		);
+		];
 
 		/* Space characters don't have any effect when actually
 		 * connecting, but can be a hassle while validating the DSN.
 		 */
-		$this->dsn = str_replace(array("\n", "\r", "\t", ' '), '', $this->dsn);
+		$this->dsn = str_replace(["\n", "\r", "\t", ' '], '', $this->dsn);
 
 		if ($this->dsn !== '')
 		{
@@ -171,7 +171,7 @@ class CI_DB_oci8_driver extends CI_DB {
 		}
 
 		// Legacy support for TNS in the hostname configuration field
-		$this->hostname = str_replace(array("\n", "\r", "\t", ' '), '', $this->hostname);
+		$this->hostname = str_replace(["\n", "\r", "\t", ' '], '', $this->hostname);
 		if (preg_match($valid_dsns['tns'], $this->hostname))
 		{
 			$this->dsn = $this->hostname;
@@ -206,7 +206,7 @@ class CI_DB_oci8_driver extends CI_DB {
 			return;
 		}
 
-		$this->database = str_replace(array("\n", "\r", "\t", ' '), '', $this->database);
+		$this->database = str_replace(["\n", "\r", "\t", ' '], '', $this->database);
 		foreach ($valid_dsns as $regexp)
 		{
 			if (preg_match($regexp, $this->database))
@@ -365,7 +365,7 @@ class CI_DB_oci8_driver extends CI_DB {
 
 		foreach ($params as $param)
 		{
-			foreach (array('name', 'value', 'type', 'length') as $val)
+			foreach (['name', 'value', 'type', 'length'] as $val)
 			{
 				if ( ! isset($param[$val]))
 				{
@@ -521,7 +521,7 @@ class CI_DB_oci8_driver extends CI_DB {
 		}
 		$query = $query->result_object();
 
-		$retval = array();
+		$retval = [];
 		for ($i = 0, $c = count($query); $i < $c; $i++)
 		{
 			$retval[$i]			= new stdClass();
@@ -581,7 +581,7 @@ class CI_DB_oci8_driver extends CI_DB {
 
 		return is_array($error)
 			? $error
-			: array('code' => '', 'message' => '');
+			: ['code' => '', 'message' => ''];
 	}
 
 	// --------------------------------------------------------------------

--- a/system/database/drivers/oci8/oci8_forge.php
+++ b/system/database/drivers/oci8/oci8_forge.php
@@ -103,7 +103,7 @@ class CI_DB_oci8_forge extends CI_DB_forge {
 		}
 
 		$sql = 'ALTER TABLE '.$this->db->escape_identifiers($table);
-		$sqls = array();
+		$sqls = [];
 		for ($i = 0, $c = count($field); $i < $c; $i++)
 		{
 			if ($field[$i]['_literal'] !== FALSE)

--- a/system/database/drivers/oci8/oci8_result.php
+++ b/system/database/drivers/oci8/oci8_result.php
@@ -121,7 +121,7 @@ class CI_DB_oci8_result extends CI_DB_result {
 	 */
 	public function list_fields()
 	{
-		$field_names = array();
+		$field_names = [];
 		for ($c = 1, $fieldCount = $this->num_fields(); $c <= $fieldCount; $c++)
 		{
 			$field_names[] = oci_field_name($this->stmt_id, $c);
@@ -140,7 +140,7 @@ class CI_DB_oci8_result extends CI_DB_result {
 	 */
 	public function field_data()
 	{
-		$retval = array();
+		$retval = [];
 		for ($c = 1, $fieldCount = $this->num_fields(); $c <= $fieldCount; $c++)
 		{
 			$F		= new stdClass();

--- a/system/database/drivers/oci8/oci8_utility.php
+++ b/system/database/drivers/oci8/oci8_utility.php
@@ -59,7 +59,7 @@ class CI_DB_oci8_utility extends CI_DB_utility {
 	 * @param	array	$params	Preferences
 	 * @return	mixed
 	 */
-	protected function _backup($params = array())
+	protected function _backup($params = [])
 	{
 		// Currently unsupported
 		return $this->db->display_error('db_unsupported_feature');

--- a/system/database/drivers/odbc/odbc_driver.php
+++ b/system/database/drivers/odbc/odbc_driver.php
@@ -89,7 +89,7 @@ class CI_DB_odbc_driver extends CI_DB_driver {
 	 *
 	 * @var	array
 	 */
-	protected $_random_keyword = array('RND()', 'RND(%d)');
+	protected $_random_keyword = ['RND()', 'RND(%d)'];
 
 	// --------------------------------------------------------------------
 
@@ -105,7 +105,7 @@ class CI_DB_odbc_driver extends CI_DB_driver {
 	 *
 	 * @var	array
 	 */
-	private $binds = array();
+	private $binds = [];
 
 	// --------------------------------------------------------------------
 
@@ -158,7 +158,7 @@ class CI_DB_odbc_driver extends CI_DB_driver {
 		}
 		elseif ( ! is_array($binds))
 		{
-			$binds = array($binds);
+			$binds = [$binds];
 			$bind_count = 1;
 		}
 		else
@@ -235,7 +235,7 @@ class CI_DB_odbc_driver extends CI_DB_driver {
 		}
 
 		$this->odbc_result = NULL;
-		$this->binds       = array();
+		$this->binds       = [];
 
 		return $success;
 	}
@@ -408,7 +408,7 @@ class CI_DB_odbc_driver extends CI_DB_driver {
 	 */
 	public function error()
 	{
-		return array('code' => odbc_error($this->conn_id), 'message' => odbc_errormsg($this->conn_id));
+		return ['code' => odbc_error($this->conn_id), 'message' => odbc_errormsg($this->conn_id)];
 	}
 
 	// --------------------------------------------------------------------

--- a/system/database/drivers/odbc/odbc_result.php
+++ b/system/database/drivers/odbc/odbc_result.php
@@ -102,7 +102,7 @@ class CI_DB_odbc_result extends CI_DB_result {
 	 */
 	public function list_fields()
 	{
-		$field_names = array();
+		$field_names = [];
 		$num_fields = $this->num_fields();
 
 		if ($num_fields > 0)
@@ -127,7 +127,7 @@ class CI_DB_odbc_result extends CI_DB_result {
 	 */
 	public function field_data()
 	{
-		$retval = array();
+		$retval = [];
 		for ($i = 0, $odbc_index = 1, $c = $this->num_fields(); $i < $c; $i++, $odbc_index++)
 		{
 			$retval[$i]			= new stdClass();
@@ -217,13 +217,13 @@ if ( ! function_exists('odbc_fetch_array'))
 	 */
 	function odbc_fetch_array(&$result, $rownumber = 1)
 	{
-		$rs = array();
+		$rs = [];
 		if ( ! odbc_fetch_into($result, $rs, $rownumber))
 		{
 			return FALSE;
 		}
 
-		$rs_assoc = array();
+		$rs_assoc = [];
 		foreach ($rs as $k => $v)
 		{
 			$field_name = odbc_field_name($result, $k+1);
@@ -250,7 +250,7 @@ if ( ! function_exists('odbc_fetch_object'))
 	 */
 	function odbc_fetch_object(&$result, $rownumber = 1)
 	{
-		$rs = array();
+		$rs = [];
 		if ( ! odbc_fetch_into($result, $rs, $rownumber))
 		{
 			return FALSE;

--- a/system/database/drivers/odbc/odbc_utility.php
+++ b/system/database/drivers/odbc/odbc_utility.php
@@ -54,7 +54,7 @@ class CI_DB_odbc_utility extends CI_DB_utility {
 	 * @param	array	$params	Preferences
 	 * @return	mixed
 	 */
-	protected function _backup($params = array())
+	protected function _backup($params = [])
 	{
 		// Currently unsupported
 		return $this->db->display_error('db_unsupported_feature');

--- a/system/database/drivers/pdo/pdo_driver.php
+++ b/system/database/drivers/pdo/pdo_driver.php
@@ -64,7 +64,7 @@ class CI_DB_pdo_driver extends CI_DB {
 	 *
 	 * @var	array
 	 */
-	public $options = array();
+	public $options = [];
 
 	// --------------------------------------------------------------------
 
@@ -95,7 +95,7 @@ class CI_DB_pdo_driver extends CI_DB {
 			$this->subdriver = $match[1];
 			return;
 		}
-		elseif (in_array($this->subdriver, array('mssql', 'sybase'), TRUE))
+		elseif (in_array($this->subdriver, ['mssql', 'sybase'], TRUE))
 		{
 			$this->subdriver = 'dblib';
 		}
@@ -103,7 +103,7 @@ class CI_DB_pdo_driver extends CI_DB {
 		{
 			$this->subdriver = '4d';
 		}
-		elseif ( ! in_array($this->subdriver, array('4d', 'cubrid', 'dblib', 'firebird', 'ibm', 'informix', 'mysql', 'oci', 'odbc', 'pgsql', 'sqlite', 'sqlsrv'), TRUE))
+		elseif ( ! in_array($this->subdriver, ['4d', 'cubrid', 'dblib', 'firebird', 'ibm', 'informix', 'mysql', 'oci', 'odbc', 'pgsql', 'sqlite', 'sqlsrv'], TRUE))
 		{
 			log_message('error', 'PDO: Invalid or non-existent subdriver');
 
@@ -291,7 +291,7 @@ class CI_DB_pdo_driver extends CI_DB {
 	 */
 	public function error()
 	{
-		$error = array('code' => '00000', 'message' => '');
+		$error = ['code' => '00000', 'message' => ''];
 		$pdo_error = $this->conn_id->errorInfo();
 
 		if (empty($pdo_error[0]))

--- a/system/database/drivers/pdo/pdo_result.php
+++ b/system/database/drivers/pdo/pdo_result.php
@@ -100,7 +100,7 @@ class CI_DB_pdo_result extends CI_DB_result {
 	 */
 	public function list_fields()
 	{
-		$field_names = array();
+		$field_names = [];
 		for ($i = 0, $c = $this->num_fields(); $i < $c; $i++)
 		{
 			// Might trigger an E_WARNING due to not all subdrivers
@@ -125,7 +125,7 @@ class CI_DB_pdo_result extends CI_DB_result {
 	{
 		try
 		{
-			$retval = array();
+			$retval = [];
 
 			for ($i = 0, $c = $this->num_fields(); $i < $c; $i++)
 			{

--- a/system/database/drivers/pdo/pdo_utility.php
+++ b/system/database/drivers/pdo/pdo_utility.php
@@ -54,7 +54,7 @@ class CI_DB_pdo_utility extends CI_DB_utility {
 	 * @param	array	$params	Preferences
 	 * @return	mixed
 	 */
-	protected function _backup($params = array())
+	protected function _backup($params = [])
 	{
 		// Currently unsupported
 		return $this->db->display_error('db_unsupported_feature');

--- a/system/database/drivers/pdo/subdrivers/pdo_4d_driver.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_4d_driver.php
@@ -64,7 +64,7 @@ class CI_DB_pdo_4d_driver extends CI_DB_pdo_driver {
 	 *
 	 * @var	string[]
 	 */
-	protected $_escape_char = array('[', ']');
+	protected $_escape_char = ['[', ']'];
 
 	// --------------------------------------------------------------------
 
@@ -162,7 +162,7 @@ class CI_DB_pdo_4d_driver extends CI_DB_pdo_driver {
 	protected function _update($table, $values)
 	{
 		$this->qb_limit = FALSE;
-		$this->qb_orderby = array();
+		$this->qb_orderby = [];
 		return parent::_update($table, $values);
 	}
 

--- a/system/database/drivers/pdo/subdrivers/pdo_4d_forge.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_4d_forge.php
@@ -86,12 +86,12 @@ class CI_DB_pdo_4d_forge extends CI_DB_pdo_forge {
 	 *
 	 * @var	array
 	 */
-	protected $_unsigned		= array(
+	protected $_unsigned		= [
 		'INT16'		=> 'INT',
 		'SMALLINT'	=> 'INT',
 		'INT'		=> 'INT64',
 		'INT32'		=> 'INT64'
-	);
+	];
 
 	/**
 	 * DEFAULT value representation in CREATE/ALTER TABLE statements
@@ -112,7 +112,7 @@ class CI_DB_pdo_4d_forge extends CI_DB_pdo_forge {
 	 */
 	protected function _alter_table($alter_type, $table, $field)
 	{
-		if (in_array($alter_type, array('ADD', 'DROP'), TRUE))
+		if (in_array($alter_type, ['ADD', 'DROP'], TRUE))
 		{
 			return parent::_alter_table($alter_type, $table, $field);
 		}

--- a/system/database/drivers/pdo/subdrivers/pdo_cubrid_driver.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_cubrid_driver.php
@@ -71,7 +71,7 @@ class CI_DB_pdo_cubrid_driver extends CI_DB_pdo_driver {
 	 *
 	 * @var array
 	 */
-	protected $_random_keyword = array('RANDOM()', 'RANDOM(%d)');
+	protected $_random_keyword = ['RANDOM()', 'RANDOM(%d)'];
 
 	// --------------------------------------------------------------------
 
@@ -150,7 +150,7 @@ class CI_DB_pdo_cubrid_driver extends CI_DB_pdo_driver {
 		}
 		$query = $query->result_object();
 
-		$retval = array();
+		$retval = [];
 		for ($i = 0, $c = count($query); $i < $c; $i++)
 		{
 			$retval[$i]			= new stdClass();

--- a/system/database/drivers/pdo/subdrivers/pdo_cubrid_forge.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_cubrid_forge.php
@@ -82,7 +82,7 @@ class CI_DB_pdo_cubrid_forge extends CI_DB_pdo_forge {
 	 *
 	 * @var	array
 	 */
-	protected $_unsigned		= array(
+	protected $_unsigned		= [
 		'SHORT'		=> 'INTEGER',
 		'SMALLINT'	=> 'INTEGER',
 		'INT'		=> 'BIGINT',
@@ -90,7 +90,7 @@ class CI_DB_pdo_cubrid_forge extends CI_DB_pdo_forge {
 		'BIGINT'	=> 'NUMERIC',
 		'FLOAT'		=> 'DOUBLE',
 		'REAL'		=> 'DOUBLE'
-	);
+	];
 
 	// --------------------------------------------------------------------
 
@@ -104,13 +104,13 @@ class CI_DB_pdo_cubrid_forge extends CI_DB_pdo_forge {
 	 */
 	protected function _alter_table($alter_type, $table, $field)
 	{
-		if (in_array($alter_type, array('DROP', 'ADD'), TRUE))
+		if (in_array($alter_type, ['DROP', 'ADD'], TRUE))
 		{
 			return parent::_alter_table($alter_type, $table, $field);
 		}
 
 		$sql = 'ALTER TABLE '.$this->db->escape_identifiers($table);
-		$sqls = array();
+		$sqls = [];
 		for ($i = 0, $c = count($field); $i < $c; $i++)
 		{
 			if ($field[$i]['_literal'] !== FALSE)
@@ -216,13 +216,13 @@ class CI_DB_pdo_cubrid_forge extends CI_DB_pdo_forge {
 				continue;
 			}
 
-			is_array($this->keys[$i]) OR $this->keys[$i] = array($this->keys[$i]);
+			is_array($this->keys[$i]) OR $this->keys[$i] = [$this->keys[$i]];
 
 			$sql .= ",\n\tKEY ".$this->db->escape_identifiers(implode('_', $this->keys[$i]))
 				.' ('.implode(', ', $this->db->escape_identifiers($this->keys[$i])).')';
 		}
 
-		$this->keys = array();
+		$this->keys = [];
 
 		return $sql;
 	}

--- a/system/database/drivers/pdo/subdrivers/pdo_dblib_driver.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_dblib_driver.php
@@ -66,7 +66,7 @@ class CI_DB_pdo_dblib_driver extends CI_DB_pdo_driver {
 	 *
 	 * @var	array
 	 */
-	protected $_random_keyword = array('NEWID()', 'RAND(%d)');
+	protected $_random_keyword = ['NEWID()', 'RAND(%d)'];
 
 	/**
 	 * Quoted identifier flag
@@ -142,7 +142,7 @@ class CI_DB_pdo_dblib_driver extends CI_DB_pdo_driver {
 		$query = $this->query('SELECT CASE WHEN (@@OPTIONS | 256) = @@OPTIONS THEN 1 ELSE 0 END AS qi');
 		$query = $query->row_array();
 		$this->_quoted_identifier = empty($query) ? FALSE : (bool) $query['qi'];
-		$this->_escape_char = ($this->_quoted_identifier) ? '"' : array('[', ']');
+		$this->_escape_char = ($this->_quoted_identifier) ? '"' : ['[', ']'];
 
 		return $this->conn_id;
 	}
@@ -209,7 +209,7 @@ class CI_DB_pdo_dblib_driver extends CI_DB_pdo_driver {
 		}
 		$query = $query->result_object();
 
-		$retval = array();
+		$retval = [];
 		for ($i = 0, $c = count($query); $i < $c; $i++)
 		{
 			$retval[$i]			= new stdClass();
@@ -236,7 +236,7 @@ class CI_DB_pdo_dblib_driver extends CI_DB_pdo_driver {
 	protected function _update($table, $values)
 	{
 		$this->qb_limit = FALSE;
-		$this->qb_orderby = array();
+		$this->qb_orderby = [];
 		return parent::_update($table, $values);
 	}
 
@@ -291,7 +291,7 @@ class CI_DB_pdo_dblib_driver extends CI_DB_pdo_driver {
 			else
 			{
 				// Use only field names and their aliases, everything else is out of our scope.
-				$select = array();
+				$select = [];
 				$field_regexp = ($this->_quoted_identifier)
 					? '("[^\"]+")' : '(\[[^\]]+\])';
 				for ($i = 0, $c = count($this->qb_select); $i < $c; $i++)

--- a/system/database/drivers/pdo/subdrivers/pdo_dblib_forge.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_dblib_forge.php
@@ -65,12 +65,12 @@ class CI_DB_pdo_dblib_forge extends CI_DB_pdo_forge {
 	 *
 	 * @var	array
 	 */
-	protected $_unsigned		= array(
+	protected $_unsigned		= [
 		'TINYINT'	=> 'SMALLINT',
 		'SMALLINT'	=> 'INT',
 		'INT'		=> 'BIGINT',
 		'REAL'		=> 'FLOAT'
-	);
+	];
 
 	// --------------------------------------------------------------------
 
@@ -84,13 +84,13 @@ class CI_DB_pdo_dblib_forge extends CI_DB_pdo_forge {
 	 */
 	protected function _alter_table($alter_type, $table, $field)
 	{
-		if (in_array($alter_type, array('ADD', 'DROP'), TRUE))
+		if (in_array($alter_type, ['ADD', 'DROP'], TRUE))
 		{
 			return parent::_alter_table($alter_type, $table, $field);
 		}
 
 		$sql = 'ALTER TABLE '.$this->db->escape_identifiers($table).' ALTER COLUMN ';
-		$sqls = array();
+		$sqls = [];
 		for ($i = 0, $c = count($field); $i < $c; $i++)
 		{
 			$sqls[] = $sql.$this->_process_column($field[$i]);

--- a/system/database/drivers/pdo/subdrivers/pdo_firebird_driver.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_firebird_driver.php
@@ -66,7 +66,7 @@ class CI_DB_pdo_firebird_driver extends CI_DB_pdo_driver {
 	 *
 	 * @var	array
 	 */
-	protected $_random_keyword = array('RAND()', 'RAND()');
+	protected $_random_keyword = ['RAND()', 'RAND()'];
 
 	// --------------------------------------------------------------------
 

--- a/system/database/drivers/pdo/subdrivers/pdo_firebird_forge.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_firebird_forge.php
@@ -58,11 +58,11 @@ class CI_DB_pdo_firebird_forge extends CI_DB_pdo_forge {
 	 *
 	 * @var	array
 	 */
-	protected $_unsigned		= array(
+	protected $_unsigned		= [
 		'SMALLINT'	=> 'INTEGER',
 		'INTEGER'	=> 'INT64',
 		'FLOAT'		=> 'DOUBLE PRECISION'
-	);
+	];
 
 	/**
 	 * NULL value representation in CREATE/ALTER TABLE statements
@@ -127,13 +127,13 @@ class CI_DB_pdo_firebird_forge extends CI_DB_pdo_forge {
 	 */
 	protected function _alter_table($alter_type, $table, $field)
  	{
-		if (in_array($alter_type, array('DROP', 'ADD'), TRUE))
+		if (in_array($alter_type, ['DROP', 'ADD'], TRUE))
 		{
 			return parent::_alter_table($alter_type, $table, $field);
 		}
 
 		$sql = 'ALTER TABLE '.$this->db->escape_identifiers($table);
-		$sqls = array();
+		$sqls = [];
 		for ($i = 0, $c = count($field); $i < $c; $i++)
 		{
 			if ($field[$i]['_literal'] !== FALSE)

--- a/system/database/drivers/pdo/subdrivers/pdo_ibm_driver.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_ibm_driver.php
@@ -202,7 +202,7 @@ class CI_DB_pdo_ibm_driver extends CI_DB_pdo_driver {
 	protected function _update($table, $values)
 	{
 		$this->qb_limit = FALSE;
-		$this->qb_orderby = array();
+		$this->qb_orderby = [];
 		return parent::_update($table, $values);
 	}
 

--- a/system/database/drivers/pdo/subdrivers/pdo_ibm_forge.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_ibm_forge.php
@@ -58,11 +58,11 @@ class CI_DB_pdo_ibm_forge extends CI_DB_pdo_forge {
 	 *
 	 * @var	array
 	 */
-	protected $_unsigned		= array(
+	protected $_unsigned		= [
 		'SMALLINT'	=> 'INTEGER',
 		'INT'		=> 'BIGINT',
 		'INTEGER'	=> 'BIGINT'
-	);
+	];
 
 	/**
 	 * DEFAULT value representation in CREATE/ALTER TABLE statements

--- a/system/database/drivers/pdo/subdrivers/pdo_informix_driver.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_informix_driver.php
@@ -66,7 +66,7 @@ class CI_DB_pdo_informix_driver extends CI_DB_pdo_driver {
 	 *
 	 * @var	array
 	 */
-	protected $_random_keyword = array('ASC', 'ASC'); // Currently not supported
+	protected $_random_keyword = ['ASC', 'ASC']; // Currently not supported
 
 	// --------------------------------------------------------------------
 
@@ -252,7 +252,7 @@ class CI_DB_pdo_informix_driver extends CI_DB_pdo_driver {
 	protected function _update($table, $values)
 	{
 		$this->qb_limit = FALSE;
-		$this->qb_orderby = array();
+		$this->qb_orderby = [];
 		return parent::_update($table, $values);
 	}
 

--- a/system/database/drivers/pdo/subdrivers/pdo_informix_forge.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_informix_forge.php
@@ -58,13 +58,13 @@ class CI_DB_pdo_informix_forge extends CI_DB_pdo_forge {
 	 *
 	 * @var	array
 	 */
-	protected $_unsigned		= array(
+	protected $_unsigned		= [
 		'SMALLINT'	=> 'INTEGER',
 		'INT'		=> 'BIGINT',
 		'INTEGER'	=> 'BIGINT',
 		'REAL'		=> 'DOUBLE PRECISION',
 		'SMALLFLOAT'	=> 'DOUBLE PRECISION'
-	);
+	];
 
 	/**
 	 * DEFAULT value representation in CREATE/ALTER TABLE statements

--- a/system/database/drivers/pdo/subdrivers/pdo_mysql_driver.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_mysql_driver.php
@@ -160,7 +160,7 @@ class CI_DB_pdo_mysql_driver extends CI_DB_pdo_driver {
 
 		if (is_array($this->encrypt))
 		{
-			$ssl = array();
+			$ssl = [];
 			empty($this->encrypt['ssl_key'])    OR $ssl[PDO::MYSQL_ATTR_SSL_KEY]    = $this->encrypt['ssl_key'];
 			empty($this->encrypt['ssl_cert'])   OR $ssl[PDO::MYSQL_ATTR_SSL_CERT]   = $this->encrypt['ssl_cert'];
 			empty($this->encrypt['ssl_ca'])     OR $ssl[PDO::MYSQL_ATTR_SSL_CA]     = $this->encrypt['ssl_ca'];
@@ -206,7 +206,7 @@ class CI_DB_pdo_mysql_driver extends CI_DB_pdo_driver {
 		if (FALSE !== $this->simple_query('USE '.$this->escape_identifiers($database)))
 		{
 			$this->database = $database;
-			$this->data_cache = array();
+			$this->data_cache = [];
 			return TRUE;
 		}
 
@@ -315,7 +315,7 @@ class CI_DB_pdo_mysql_driver extends CI_DB_pdo_driver {
 		}
 		$query = $query->result_object();
 
-		$retval = array();
+		$retval = [];
 		for ($i = 0, $c = count($query); $i < $c; $i++)
 		{
 			$retval[$i]			= new stdClass();

--- a/system/database/drivers/pdo/subdrivers/pdo_mysql_forge.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_mysql_forge.php
@@ -82,7 +82,7 @@ class CI_DB_pdo_mysql_forge extends CI_DB_pdo_forge {
 	 *
 	 * @var	array
 	 */
-	protected $_unsigned		= array(
+	protected $_unsigned		= [
 		'TINYINT',
 		'SMALLINT',
 		'MEDIUMINT',
@@ -95,7 +95,7 @@ class CI_DB_pdo_mysql_forge extends CI_DB_pdo_forge {
 		'FLOAT',
 		'DECIMAL',
 		'NUMERIC'
-	);
+	];
 
 	/**
 	 * NULL value representation in CREATE/ALTER TABLE statements
@@ -178,7 +178,7 @@ class CI_DB_pdo_mysql_forge extends CI_DB_pdo_forge {
 			}
 		}
 
-		return array($sql.implode(',', $field));
+		return [$sql.implode(',', $field)];
 	}
 
 	// --------------------------------------------------------------------
@@ -242,13 +242,13 @@ class CI_DB_pdo_mysql_forge extends CI_DB_pdo_forge {
 				continue;
 			}
 
-			is_array($this->keys[$i]) OR $this->keys[$i] = array($this->keys[$i]);
+			is_array($this->keys[$i]) OR $this->keys[$i] = [$this->keys[$i]];
 
 			$sql .= ",\n\tKEY ".$this->db->escape_identifiers(implode('_', $this->keys[$i]))
 				.' ('.implode(', ', $this->db->escape_identifiers($this->keys[$i])).')';
 		}
 
-		$this->keys = array();
+		$this->keys = [];
 
 		return $sql;
 	}

--- a/system/database/drivers/pdo/subdrivers/pdo_oci_driver.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_oci_driver.php
@@ -68,14 +68,14 @@ class CI_DB_pdo_oci_driver extends CI_DB_pdo_driver {
 	 *
 	 * @var	string[]
 	 */
-	protected $_reserved_identifiers = array('*', 'rownum');
+	protected $_reserved_identifiers = ['*', 'rownum'];
 
 	/**
 	 * ORDER BY random keyword
 	 *
 	 * @var	array
 	 */
-	protected $_random_keyword = array('ASC', 'ASC'); // Currently not supported
+	protected $_random_keyword = ['ASC', 'ASC']; // Currently not supported
 
 	/**
 	 * COUNT string
@@ -229,7 +229,7 @@ class CI_DB_pdo_oci_driver extends CI_DB_pdo_driver {
 		}
 		$query = $query->result_object();
 
-		$retval = array();
+		$retval = [];
 		for ($i = 0, $c = count($query); $i < $c; $i++)
 		{
 			$retval[$i]			= new stdClass();

--- a/system/database/drivers/pdo/subdrivers/pdo_oci_forge.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_oci_forge.php
@@ -96,7 +96,7 @@ class CI_DB_pdo_oci_forge extends CI_DB_pdo_forge {
 		}
 
 		$sql = 'ALTER TABLE '.$this->db->escape_identifiers($table);
-		$sqls = array();
+		$sqls = [];
 		for ($i = 0, $c = count($field); $i < $c; $i++)
 		{
 			if ($field[$i]['_literal'] !== FALSE)

--- a/system/database/drivers/pdo/subdrivers/pdo_odbc_driver.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_odbc_driver.php
@@ -89,7 +89,7 @@ class CI_DB_pdo_odbc_driver extends CI_DB_pdo_driver {
 	 *
 	 * @var	array
 	 */
-	protected $_random_keyword = array('RND()', 'RND(%d)');
+	protected $_random_keyword = ['RND()', 'RND(%d)'];
 
 	// --------------------------------------------------------------------
 

--- a/system/database/drivers/pdo/subdrivers/pdo_pgsql_driver.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_pgsql_driver.php
@@ -73,7 +73,7 @@ class CI_DB_pdo_pgsql_driver extends CI_DB_pdo_driver {
 	 *
 	 * @var	array
 	 */
-	protected $_random_keyword = array('RANDOM()', 'RANDOM()');
+	protected $_random_keyword = ['RANDOM()', 'RANDOM()'];
 
 	// --------------------------------------------------------------------
 
@@ -278,7 +278,7 @@ class CI_DB_pdo_pgsql_driver extends CI_DB_pdo_driver {
 		}
 		$query = $query->result_object();
 
-		$retval = array();
+		$retval = [];
 		for ($i = 0, $c = count($query); $i < $c; $i++)
 		{
 			$retval[$i]			= new stdClass();
@@ -305,7 +305,7 @@ class CI_DB_pdo_pgsql_driver extends CI_DB_pdo_driver {
 	protected function _update($table, $values)
 	{
 		$this->qb_limit = FALSE;
-		$this->qb_orderby = array();
+		$this->qb_orderby = [];
 		return parent::_update($table, $values);
 	}
 
@@ -323,7 +323,7 @@ class CI_DB_pdo_pgsql_driver extends CI_DB_pdo_driver {
 	 */
 	protected function _update_batch($table, $values, $index)
 	{
-		$ids = array();
+		$ids = [];
 		foreach ($values as $key => $val)
 		{
 			$ids[] = $val[$index]['value'];

--- a/system/database/drivers/pdo/subdrivers/pdo_pgsql_forge.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_pgsql_forge.php
@@ -58,7 +58,7 @@ class CI_DB_pdo_pgsql_forge extends CI_DB_pdo_forge {
 	 *
 	 * @var	array
 	 */
-	protected $_unsigned		= array(
+	protected $_unsigned		= [
 		'INT2'		=> 'INTEGER',
 		'SMALLINT'	=> 'INTEGER',
 		'INT'		=> 'BIGINT',
@@ -68,7 +68,7 @@ class CI_DB_pdo_pgsql_forge extends CI_DB_pdo_forge {
 		'BIGINT'	=> 'NUMERIC',
 		'REAL'		=> 'DOUBLE PRECISION',
 		'FLOAT'		=> 'DOUBLE PRECISION'
-	);
+	];
 
 	/**
 	 * NULL value representation in CREATE/ALTER TABLE statements
@@ -107,13 +107,13 @@ class CI_DB_pdo_pgsql_forge extends CI_DB_pdo_forge {
 	 */
 	protected function _alter_table($alter_type, $table, $field)
  	{
-		if (in_array($alter_type, array('DROP', 'ADD'), TRUE))
+		if (in_array($alter_type, ['DROP', 'ADD'], TRUE))
 		{
 			return parent::_alter_table($alter_type, $table, $field);
 		}
 
 		$sql = 'ALTER TABLE '.$this->db->escape_identifiers($table);
-		$sqls = array();
+		$sqls = [];
 		for ($i = 0, $c = count($field); $i < $c; $i++)
 		{
 			if ($field[$i]['_literal'] !== FALSE)

--- a/system/database/drivers/pdo/subdrivers/pdo_sqlite_driver.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_sqlite_driver.php
@@ -66,7 +66,7 @@ class CI_DB_pdo_sqlite_driver extends CI_DB_pdo_driver {
 	 *
 	 * @var	array
 	 */
-	protected $_random_keyword = array('RANDOM()', 'RANDOM()');
+	protected $_random_keyword = ['RANDOM()', 'RANDOM()'];
 
 	// --------------------------------------------------------------------
 
@@ -139,7 +139,7 @@ class CI_DB_pdo_sqlite_driver extends CI_DB_pdo_driver {
 			return FALSE;
 		}
 
-		$this->data_cache['field_names'][$table] = array();
+		$this->data_cache['field_names'][$table] = [];
 		foreach ($result->result_array() as $row)
 		{
 			$this->data_cache['field_names'][$table][] = $row['name'];
@@ -169,7 +169,7 @@ class CI_DB_pdo_sqlite_driver extends CI_DB_pdo_driver {
 			return FALSE;
 		}
 
-		$retval = array();
+		$retval = [];
 		for ($i = 0, $c = count($query); $i < $c; $i++)
 		{
 			$retval[$i]			= new stdClass();

--- a/system/database/drivers/pdo/subdrivers/pdo_sqlite_forge.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_sqlite_forge.php
@@ -231,7 +231,7 @@ class CI_DB_pdo_sqlite_forge extends CI_DB_pdo_forge {
 			$field['unique'] = '';
 			$field['auto_increment'] = ' AUTOINCREMENT';
 
-			$this->primary_keys = array();
+			$this->primary_keys = [];
 		}
 	}
 

--- a/system/database/drivers/pdo/subdrivers/pdo_sqlsrv_driver.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_sqlsrv_driver.php
@@ -66,7 +66,7 @@ class CI_DB_pdo_sqlsrv_driver extends CI_DB_pdo_driver {
 	 *
 	 * @var	array
 	 */
-	protected $_random_keyword = array('NEWID()', 'RAND(%d)');
+	protected $_random_keyword = ['NEWID()', 'RAND(%d)'];
 
 	/**
 	 * Quoted identifier flag
@@ -166,7 +166,7 @@ class CI_DB_pdo_sqlsrv_driver extends CI_DB_pdo_driver {
 		$query = $this->query('SELECT CASE WHEN (@@OPTIONS | 256) = @@OPTIONS THEN 1 ELSE 0 END AS qi');
 		$query = $query->row_array();
 		$this->_quoted_identifier = empty($query) ? FALSE : (bool) $query['qi'];
-		$this->_escape_char = ($this->_quoted_identifier) ? '"' : array('[', ']');
+		$this->_escape_char = ($this->_quoted_identifier) ? '"' : ['[', ']'];
 
 		return $this->conn_id;
 	}
@@ -233,7 +233,7 @@ class CI_DB_pdo_sqlsrv_driver extends CI_DB_pdo_driver {
 		}
 		$query = $query->result_object();
 
-		$retval = array();
+		$retval = [];
 		for ($i = 0, $c = count($query); $i < $c; $i++)
 		{
 			$retval[$i]			= new stdClass();
@@ -260,7 +260,7 @@ class CI_DB_pdo_sqlsrv_driver extends CI_DB_pdo_driver {
 	protected function _update($table, $values)
 	{
 		$this->qb_limit = FALSE;
-		$this->qb_orderby = array();
+		$this->qb_orderby = [];
 		return parent::_update($table, $values);
 	}
 
@@ -323,7 +323,7 @@ class CI_DB_pdo_sqlsrv_driver extends CI_DB_pdo_driver {
 			else
 			{
 				// Use only field names and their aliases, everything else is out of our scope.
-				$select = array();
+				$select = [];
 				$field_regexp = ($this->_quoted_identifier)
 					? '("[^\"]+")' : '(\[[^\]]+\])';
 				for ($i = 0, $c = count($this->qb_select); $i < $c; $i++)

--- a/system/database/drivers/pdo/subdrivers/pdo_sqlsrv_forge.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_sqlsrv_forge.php
@@ -65,12 +65,12 @@ class CI_DB_pdo_sqlsrv_forge extends CI_DB_pdo_forge {
 	 *
 	 * @var	array
 	 */
-	protected $_unsigned		= array(
+	protected $_unsigned		= [
 		'TINYINT'	=> 'SMALLINT',
 		'SMALLINT'	=> 'INT',
 		'INT'		=> 'BIGINT',
 		'REAL'		=> 'FLOAT'
-	);
+	];
 
 	// --------------------------------------------------------------------
 
@@ -84,13 +84,13 @@ class CI_DB_pdo_sqlsrv_forge extends CI_DB_pdo_forge {
 	 */
 	protected function _alter_table($alter_type, $table, $field)
 	{
-		if (in_array($alter_type, array('ADD', 'DROP'), TRUE))
+		if (in_array($alter_type, ['ADD', 'DROP'], TRUE))
 		{
 			return parent::_alter_table($alter_type, $table, $field);
 		}
 
 		$sql = 'ALTER TABLE '.$this->db->escape_identifiers($table).' ALTER COLUMN ';
-		$sqls = array();
+		$sqls = [];
 		for ($i = 0, $c = count($field); $i < $c; $i++)
 		{
 			$sqls[] = $sql.$this->_process_column($field[$i]);

--- a/system/database/drivers/postgre/postgre_driver.php
+++ b/system/database/drivers/postgre/postgre_driver.php
@@ -73,7 +73,7 @@ class CI_DB_postgre_driver extends CI_DB {
 	 *
 	 * @var	array
 	 */
-	protected $_random_keyword = array('RANDOM()', 'RANDOM()');
+	protected $_random_keyword = ['RANDOM()', 'RANDOM()'];
 
 	// --------------------------------------------------------------------
 
@@ -128,7 +128,7 @@ class CI_DB_postgre_driver extends CI_DB {
 		 *
 		 * postgre://username:password@localhost:5432/database?connect_timeout=5&sslmode=1
 		 */
-		foreach (array('connect_timeout', 'options', 'sslmode', 'service') as $key)
+		foreach (['connect_timeout', 'options', 'sslmode', 'service'] as $key)
 		{
 			if (isset($this->$key) && is_string($this->$key) && $this->$key !== '')
 			{
@@ -446,7 +446,7 @@ class CI_DB_postgre_driver extends CI_DB {
 		}
 		$query = $query->result_object();
 
-		$retval = array();
+		$retval = [];
 		for ($i = 0, $c = count($query); $i < $c; $i++)
 		{
 			$retval[$i]			= new stdClass();
@@ -471,7 +471,7 @@ class CI_DB_postgre_driver extends CI_DB {
 	 */
 	public function error()
 	{
-		return array('code' => '', 'message' => pg_last_error($this->conn_id));
+		return ['code' => '', 'message' => pg_last_error($this->conn_id)];
 	}
 
 	// --------------------------------------------------------------------
@@ -523,7 +523,7 @@ class CI_DB_postgre_driver extends CI_DB {
 	protected function _update($table, $values)
 	{
 		$this->qb_limit = FALSE;
-		$this->qb_orderby = array();
+		$this->qb_orderby = [];
 		return parent::_update($table, $values);
 	}
 
@@ -541,7 +541,7 @@ class CI_DB_postgre_driver extends CI_DB {
 	 */
 	protected function _update_batch($table, $values, $index)
 	{
-		$ids = array();
+		$ids = [];
 		foreach ($values as $key => $val)
 		{
 			$ids[] = $val[$index]['value'];

--- a/system/database/drivers/postgre/postgre_forge.php
+++ b/system/database/drivers/postgre/postgre_forge.php
@@ -53,7 +53,7 @@ class CI_DB_postgre_forge extends CI_DB_forge {
 	 *
 	 * @var	array
 	 */
-	protected $_unsigned		= array(
+	protected $_unsigned		= [
 		'INT2'		=> 'INTEGER',
 		'SMALLINT'	=> 'INTEGER',
 		'INT'		=> 'BIGINT',
@@ -63,7 +63,7 @@ class CI_DB_postgre_forge extends CI_DB_forge {
 		'BIGINT'	=> 'NUMERIC',
 		'REAL'		=> 'DOUBLE PRECISION',
 		'FLOAT'		=> 'DOUBLE PRECISION'
-	);
+	];
 
 	/**
 	 * NULL value representation in CREATE/ALTER TABLE statements
@@ -102,13 +102,13 @@ class CI_DB_postgre_forge extends CI_DB_forge {
 	 */
 	protected function _alter_table($alter_type, $table, $field)
  	{
-		if (in_array($alter_type, array('DROP', 'ADD'), TRUE))
+		if (in_array($alter_type, ['DROP', 'ADD'], TRUE))
 		{
 			return parent::_alter_table($alter_type, $table, $field);
 		}
 
 		$sql = 'ALTER TABLE '.$this->db->escape_identifiers($table);
-		$sqls = array();
+		$sqls = [];
 		for ($i = 0, $c = count($field); $i < $c; $i++)
 		{
 			if ($field[$i]['_literal'] !== FALSE)

--- a/system/database/drivers/postgre/postgre_result.php
+++ b/system/database/drivers/postgre/postgre_result.php
@@ -85,7 +85,7 @@ class CI_DB_postgre_result extends CI_DB_result {
 	 */
 	public function list_fields()
 	{
-		$field_names = array();
+		$field_names = [];
 		for ($i = 0, $c = $this->num_fields(); $i < $c; $i++)
 		{
 			$field_names[] = pg_field_name($this->result_id, $i);
@@ -105,7 +105,7 @@ class CI_DB_postgre_result extends CI_DB_result {
 	 */
 	public function field_data()
 	{
-		$retval = array();
+		$retval = [];
 		for ($i = 0, $c = $this->num_fields(); $i < $c; $i++)
 		{
 			$retval[$i]			= new stdClass();

--- a/system/database/drivers/postgre/postgre_utility.php
+++ b/system/database/drivers/postgre/postgre_utility.php
@@ -70,7 +70,7 @@ class CI_DB_postgre_utility extends CI_DB_utility {
 	 * @param	array	$params	Preferences
 	 * @return	mixed
 	 */
-	protected function _backup($params = array())
+	protected function _backup($params = [])
 	{
 		// Currently unsupported
 		return $this->db->display_error('db_unsupported_feature');

--- a/system/database/drivers/sqlite3/sqlite3_driver.php
+++ b/system/database/drivers/sqlite3/sqlite3_driver.php
@@ -66,7 +66,7 @@ class CI_DB_sqlite3_driver extends CI_DB {
 	 *
 	 * @var	array
 	 */
-	protected $_random_keyword = array('RANDOM()', 'RANDOM()');
+	protected $_random_keyword = ['RANDOM()', 'RANDOM()'];
 
 	// --------------------------------------------------------------------
 
@@ -241,7 +241,7 @@ class CI_DB_sqlite3_driver extends CI_DB {
 			return FALSE;
 		}
 
-		$this->data_cache['field_names'][$table] = array();
+		$this->data_cache['field_names'][$table] = [];
 		foreach ($result->result_array() as $row)
 		{
 			$this->data_cache['field_names'][$table][] = $row['name'];
@@ -271,7 +271,7 @@ class CI_DB_sqlite3_driver extends CI_DB {
 			return FALSE;
 		}
 
-		$retval = array();
+		$retval = [];
 		for ($i = 0, $c = count($query); $i < $c; $i++)
 		{
 			$retval[$i]			= new stdClass();
@@ -297,7 +297,7 @@ class CI_DB_sqlite3_driver extends CI_DB {
 	 */
 	public function error()
 	{
-		return array('code' => $this->conn_id->lastErrorCode(), 'message' => $this->conn_id->lastErrorMsg());
+		return ['code' => $this->conn_id->lastErrorCode(), 'message' => $this->conn_id->lastErrorMsg()];
 	}
 
 	// --------------------------------------------------------------------

--- a/system/database/drivers/sqlite3/sqlite3_forge.php
+++ b/system/database/drivers/sqlite3/sqlite3_forge.php
@@ -218,7 +218,7 @@ class CI_DB_sqlite3_forge extends CI_DB_forge {
 			$field['unique'] = '';
 			$field['auto_increment'] = ' AUTOINCREMENT';
 
-			$this->primary_keys = array();
+			$this->primary_keys = [];
 		}
 	}
 

--- a/system/database/drivers/sqlite3/sqlite3_result.php
+++ b/system/database/drivers/sqlite3/sqlite3_result.php
@@ -69,7 +69,7 @@ class CI_DB_sqlite3_result extends CI_DB_result {
 	 */
 	public function list_fields()
 	{
-		$field_names = array();
+		$field_names = [];
 		for ($i = 0, $c = $this->num_fields(); $i < $c; $i++)
 		{
 			$field_names[] = $this->result_id->columnName($i);
@@ -89,15 +89,15 @@ class CI_DB_sqlite3_result extends CI_DB_result {
 	 */
 	public function field_data()
 	{
-		static $data_types = array(
+		static $data_types = [
 			SQLITE3_INTEGER	=> 'integer',
 			SQLITE3_FLOAT	=> 'float',
 			SQLITE3_TEXT	=> 'text',
 			SQLITE3_BLOB	=> 'blob',
 			SQLITE3_NULL	=> 'null'
-		);
+		];
 
-		$retval = array();
+		$retval = [];
 		for ($i = 0, $c = $this->num_fields(); $i < $c; $i++)
 		{
 			$retval[$i]			= new stdClass();

--- a/system/database/drivers/sqlite3/sqlite3_utility.php
+++ b/system/database/drivers/sqlite3/sqlite3_utility.php
@@ -52,7 +52,7 @@ class CI_DB_sqlite3_utility extends CI_DB_utility {
 	 * @param	array	$params	Preferences
 	 * @return	mixed
 	 */
-	protected function _backup($params = array())
+	protected function _backup($params = [])
 	{
 		// Not supported
 		return $this->db->display_error('db_unsupported_feature');

--- a/system/database/drivers/sqlsrv/sqlsrv_driver.php
+++ b/system/database/drivers/sqlsrv/sqlsrv_driver.php
@@ -78,7 +78,7 @@ class CI_DB_sqlsrv_driver extends CI_DB {
 	 *
 	 * @var	array
 	 */
-	protected $_random_keyword = array('NEWID()', 'RAND(%d)');
+	protected $_random_keyword = ['NEWID()', 'RAND(%d)'];
 
 	/**
 	 * Quoted identifier flag
@@ -121,10 +121,10 @@ class CI_DB_sqlsrv_driver extends CI_DB {
 	 */
 	public function db_connect($pooling = FALSE)
 	{
-		$charset = in_array(strtolower($this->char_set), array('utf-8', 'utf8'), TRUE)
+		$charset = in_array(strtolower($this->char_set), ['utf-8', 'utf8'], TRUE)
 			? 'UTF-8' : SQLSRV_ENC_CHAR;
 
-		$connection = array(
+		$connection = [
 			'UID'			=> empty($this->username) ? '' : $this->username,
 			'PWD'			=> empty($this->password) ? '' : $this->password,
 			'Database'		=> $this->database,
@@ -132,7 +132,7 @@ class CI_DB_sqlsrv_driver extends CI_DB {
 			'CharacterSet'		=> $charset,
 			'Encrypt'		=> ($this->encrypt === TRUE) ? 1 : 0,
 			'ReturnDatesAsStrings'	=> 1
-		);
+		];
 
 		// If the username and password are both empty, assume this is a
 		// 'Windows Authentication Mode' connection.
@@ -147,7 +147,7 @@ class CI_DB_sqlsrv_driver extends CI_DB {
 			$query = $this->query('SELECT CASE WHEN (@@OPTIONS | 256) = @@OPTIONS THEN 1 ELSE 0 END AS qi');
 			$query = $query->row_array();
 			$this->_quoted_identifier = empty($query) ? FALSE : (bool) $query['qi'];
-			$this->_escape_char = ($this->_quoted_identifier) ? '"' : array('[', ']');
+			$this->_escape_char = ($this->_quoted_identifier) ? '"' : ['[', ']'];
 		}
 
 		return $this->conn_id;
@@ -171,7 +171,7 @@ class CI_DB_sqlsrv_driver extends CI_DB {
 		if ($this->_execute('USE '.$this->escape_identifiers($database)))
 		{
 			$this->database = $database;
-			$this->data_cache = array();
+			$this->data_cache = [];
 			return TRUE;
 		}
 
@@ -190,7 +190,7 @@ class CI_DB_sqlsrv_driver extends CI_DB {
 	{
 		return ($this->scrollable === FALSE OR $this->is_write_type($sql))
 			? sqlsrv_query($this->conn_id, $sql)
-			: sqlsrv_query($this->conn_id, $sql, NULL, array('Scrollable' => $this->scrollable));
+			: sqlsrv_query($this->conn_id, $sql, NULL, ['Scrollable' => $this->scrollable]);
 	}
 
 	// --------------------------------------------------------------------
@@ -339,7 +339,7 @@ class CI_DB_sqlsrv_driver extends CI_DB {
 		}
 		$query = $query->result_object();
 
-		$retval = array();
+		$retval = [];
 		for ($i = 0, $c = count($query); $i < $c; $i++)
 		{
 			$retval[$i]			= new stdClass();
@@ -364,7 +364,7 @@ class CI_DB_sqlsrv_driver extends CI_DB {
 	 */
 	public function error()
 	{
-		$error = array('code' => '00000', 'message' => '');
+		$error = ['code' => '00000', 'message' => ''];
 		$sqlsrv_errors = sqlsrv_errors(SQLSRV_ERR_ERRORS);
 
 		if ( ! is_array($sqlsrv_errors))
@@ -404,7 +404,7 @@ class CI_DB_sqlsrv_driver extends CI_DB {
 	protected function _update($table, $values)
 	{
 		$this->qb_limit = FALSE;
-		$this->qb_orderby = array();
+		$this->qb_orderby = [];
 		return parent::_update($table, $values);
 	}
 
@@ -485,7 +485,7 @@ class CI_DB_sqlsrv_driver extends CI_DB {
 			else
 			{
 				// Use only field names and their aliases, everything else is out of our scope.
-				$select = array();
+				$select = [];
 				$field_regexp = ($this->_quoted_identifier)
 					? '("[^\"]+")' : '(\[[^\]]+\])';
 				for ($i = 0, $c = count($this->qb_select); $i < $c; $i++)

--- a/system/database/drivers/sqlsrv/sqlsrv_forge.php
+++ b/system/database/drivers/sqlsrv/sqlsrv_forge.php
@@ -65,12 +65,12 @@ class CI_DB_sqlsrv_forge extends CI_DB_forge {
 	 *
 	 * @var	array
 	 */
-	protected $_unsigned		= array(
+	protected $_unsigned		= [
 		'TINYINT'	=> 'SMALLINT',
 		'SMALLINT'	=> 'INT',
 		'INT'		=> 'BIGINT',
 		'REAL'		=> 'FLOAT'
-	);
+	];
 
 	// --------------------------------------------------------------------
 
@@ -84,13 +84,13 @@ class CI_DB_sqlsrv_forge extends CI_DB_forge {
 	 */
 	protected function _alter_table($alter_type, $table, $field)
 	{
-		if (in_array($alter_type, array('ADD', 'DROP'), TRUE))
+		if (in_array($alter_type, ['ADD', 'DROP'], TRUE))
 		{
 			return parent::_alter_table($alter_type, $table, $field);
 		}
 
 		$sql = 'ALTER TABLE '.$this->db->escape_identifiers($table).' ALTER COLUMN ';
-		$sqls = array();
+		$sqls = [];
 		for ($i = 0, $c = count($field); $i < $c; $i++)
 		{
 			$sqls[] = $sql.$this->_process_column($field[$i]);

--- a/system/database/drivers/sqlsrv/sqlsrv_result.php
+++ b/system/database/drivers/sqlsrv/sqlsrv_result.php
@@ -80,7 +80,7 @@ class CI_DB_sqlsrv_result extends CI_DB_result {
 	public function num_rows()
 	{
 		// sqlsrv_num_rows() doesn't work with the FORWARD and DYNAMIC cursors (FALSE is the same as FORWARD)
-		if ( ! in_array($this->scrollable, array(FALSE, SQLSRV_CURSOR_FORWARD, SQLSRV_CURSOR_DYNAMIC), TRUE))
+		if ( ! in_array($this->scrollable, [FALSE, SQLSRV_CURSOR_FORWARD, SQLSRV_CURSOR_DYNAMIC], TRUE))
 		{
 			return parent::num_rows();
 		}
@@ -113,7 +113,7 @@ class CI_DB_sqlsrv_result extends CI_DB_result {
 	 */
 	public function list_fields()
 	{
-		$field_names = array();
+		$field_names = [];
 		foreach (sqlsrv_field_metadata($this->result_id) as $offset => $field)
 		{
 			$field_names[] = $field['Name'];
@@ -133,7 +133,7 @@ class CI_DB_sqlsrv_result extends CI_DB_result {
 	 */
 	public function field_data()
 	{
-		$retval = array();
+		$retval = [];
 		foreach (sqlsrv_field_metadata($this->result_id) as $i => $field)
 		{
 			$retval[$i]		= new stdClass();

--- a/system/database/drivers/sqlsrv/sqlsrv_utility.php
+++ b/system/database/drivers/sqlsrv/sqlsrv_utility.php
@@ -68,7 +68,7 @@ class CI_DB_sqlsrv_utility extends CI_DB_utility {
 	 * @param	array	$params	Preferences
 	 * @return	bool
 	 */
-	protected function _backup($params = array())
+	protected function _backup($params = [])
 	{
 		// Currently unsupported
 		return $this->db->display_error('db_unsupported_feature');

--- a/system/helpers/array_helper.php
+++ b/system/helpers/array_helper.php
@@ -101,9 +101,9 @@ if ( ! function_exists('elements'))
 	 */
 	function elements($items, array $array, $default = NULL)
 	{
-		$return = array();
+		$return = [];
 
-		is_array($items) OR $items = array($items);
+		is_array($items) OR $items = [$items];
 
 		foreach ($items as $item)
 		{

--- a/system/helpers/captcha_helper.php
+++ b/system/helpers/captcha_helper.php
@@ -62,7 +62,7 @@ if ( ! function_exists('create_captcha'))
 	 */
 	function create_captcha($data = '', $img_path = '', $img_url = '', $font_path = '')
 	{
-		$defaults = array(
+		$defaults = [
 			'word'		=> '',
 			'img_path'	=> '',
 			'img_url'	=> '',
@@ -75,13 +75,13 @@ if ( ! function_exists('create_captcha'))
 			'font_size'	=> 16,
 			'img_id'	=> '',
 			'pool'		=> '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ',
-			'colors'	=> array(
-				'background'	=> array(255,255,255),
-				'border'	=> array(153,102,102),
-				'text'		=> array(204,153,153),
-				'grid'		=> array(255,182,182)
-			)
-		);
+			'colors'	=> [
+				'background'	=> [255,255,255],
+				'border'	=> [153,102,102],
+				'text'		=> [204,153,153],
+				'grid'		=> [255,182,182]
+			]
+		];
 
 		foreach ($defaults as $key => $val)
 		{
@@ -111,8 +111,8 @@ if ( ! function_exists('create_captcha'))
 		$current_dir = @opendir($img_path);
 		while ($filename = @readdir($current_dir))
 		{
-			if (in_array(substr($filename, -4), array('.jpg', '.png'))
-				&& (str_replace(array('.jpg', '.png'), '', $filename) + $expiration) < $now)
+			if (in_array(substr($filename, -4), ['.jpg', '.png'])
+				&& (str_replace(['.jpg', '.png'], '', $filename) + $expiration) < $now)
 			{
 				@unlink($img_path.$filename);
 			}
@@ -337,6 +337,6 @@ if ( ! function_exists('create_captcha'))
 		$img = '<img '.($img_id === '' ? '' : 'id="'.$img_id.'"').' src="'.$img_url.$img_filename.'" style="width: '.$img_width.'; height: '.$img_height .'; border: 0;" alt="'.$img_alt.'" />';
 		ImageDestroy($im);
 
-		return array('word' => $word, 'time' => $now, 'image' => $img, 'filename' => $img_filename);
+		return ['word' => $word, 'time' => $now, 'image' => $img, 'filename' => $img_filename];
 	}
 }

--- a/system/helpers/date_helper.php
+++ b/system/helpers/date_helper.php
@@ -146,7 +146,7 @@ if ( ! function_exists('timespan'))
 
 		$seconds = ($time <= $seconds) ? 1 : $time - $seconds;
 
-		$str = array();
+		$str = [];
 		$years = floor($seconds / 31557600);
 
 		if ($years > 0)
@@ -267,7 +267,7 @@ if ( ! function_exists('days_in_month'))
 			}
 		}
 
-		$days_in_month	= array(31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31);
+		$days_in_month	= [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 		return $days_in_month[$month - 1];
 	}
 }
@@ -345,7 +345,7 @@ if ( ! function_exists('mysql_to_unix'))
 		// since the formatting changed with MySQL 4.1
 		// YYYY-MM-DD HH:MM:SS
 
-		$time = str_replace(array('-', ':', ' '), '', $time);
+		$time = str_replace(['-', ':', ' '], '', $time);
 
 		// YYYYMMDDHHMMSS
 		return mktime(
@@ -475,7 +475,7 @@ if ( ! function_exists('nice_date'))
 		// Date like: YYYYMM
 		if (preg_match('/^\d{6}$/i', $bad_date))
 		{
-			if (in_array(substr($bad_date, 0, 2), array('19', '20')))
+			if (in_array(substr($bad_date, 0, 2), ['19', '20']))
 			{
 				$year  = substr($bad_date, 0, 4);
 				$month = substr($bad_date, 4, 2);
@@ -573,7 +573,7 @@ if ( ! function_exists('timezones'))
 		// Note: Don't change the order of these even though
 		// some items appear to be in the wrong order
 
-		$zones = array(
+		$zones = [
 			'UM12'		=> -12,
 			'UM11'		=> -11,
 			'UM10'		=> -10,
@@ -614,7 +614,7 @@ if ( ! function_exists('timezones'))
 			'UP1275'	=> +12.75,
 			'UP13'		=> +13,
 			'UP14'		=> +14
-		);
+		];
 
 		if ($tz === '')
 		{
@@ -663,10 +663,10 @@ if ( ! function_exists('date_range'))
 
 		if ($is_unix && ($unix_start == $mixed OR date($format, $unix_start) === date($format, $mixed)))
 		{
-			return array(date($format, $unix_start));
+			return [date($format, $unix_start)];
 		}
 
-		$range = array();
+		$range = [];
 
 		$from = new DateTime();
 		$from->setTimestamp($unix_start);

--- a/system/helpers/directory_helper.php
+++ b/system/helpers/directory_helper.php
@@ -68,7 +68,7 @@ if ( ! function_exists('directory_map'))
 	{
 		if ($fp = @opendir($source_dir))
 		{
-			$filedata	= array();
+			$filedata	= [];
 			$new_depth	= $directory_depth - 1;
 			$source_dir	= rtrim($source_dir, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
 

--- a/system/helpers/file_helper.php
+++ b/system/helpers/file_helper.php
@@ -156,14 +156,14 @@ if ( ! function_exists('get_filenames'))
 	 */
 	function get_filenames($source_dir, $include_path = FALSE, $_recursion = FALSE)
 	{
-		static $_filedata = array();
+		static $_filedata = [];
 
 		if ($fp = @opendir($source_dir))
 		{
 			// reset the array and make sure $source_dir has a trailing slash on the initial call
 			if ($_recursion === FALSE)
 			{
-				$_filedata = array();
+				$_filedata = [];
 				$source_dir = rtrim(realpath($source_dir), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
 			}
 
@@ -206,7 +206,7 @@ if ( ! function_exists('get_dir_file_info'))
 	 */
 	function get_dir_file_info($source_dir, $top_level_only = TRUE, $_recursion = FALSE)
 	{
-		static $_filedata = array();
+		static $_filedata = [];
 		$relative_path = $source_dir;
 
 		if ($fp = @opendir($source_dir))
@@ -214,7 +214,7 @@ if ( ! function_exists('get_dir_file_info'))
 			// reset the array and make sure $source_dir has a trailing slash on the initial call
 			if ($_recursion === FALSE)
 			{
-				$_filedata = array();
+				$_filedata = [];
 				$source_dir = rtrim(realpath($source_dir), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
 			}
 
@@ -256,7 +256,7 @@ if ( ! function_exists('get_file_info'))
 	 * @param	mixed	array or comma separated string of information returned
 	 * @return	array
 	 */
-	function get_file_info($file, $returned_values = array('name', 'server_path', 'size', 'date'))
+	function get_file_info($file, $returned_values = ['name', 'server_path', 'size', 'date'])
 	{
 		if ( ! file_exists($file))
 		{

--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -61,7 +61,7 @@ if ( ! function_exists('form_open'))
 	 * @param	array	a key/value pair hidden data
 	 * @return	string
 	 */
-	function form_open($action = '', $attributes = array(), $hidden = array())
+	function form_open($action = '', $attributes = [], $hidden = [])
 	{
 		$CI =& get_instance();
 
@@ -151,7 +151,7 @@ if ( ! function_exists('form_open_multipart'))
 	 * @param	array	a key/value pair hidden data
 	 * @return	string
 	 */
-	function form_open_multipart($action = '', $attributes = array(), $hidden = array())
+	function form_open_multipart($action = '', $attributes = [], $hidden = [])
 	{
 		if (is_string($attributes))
 		{
@@ -231,11 +231,11 @@ if ( ! function_exists('form_input'))
 	 */
 	function form_input($data = '', $value = '', $extra = '')
 	{
-		$defaults = array(
+		$defaults = [
 			'type' => 'text',
 			'name' => is_array($data) ? '' : $data,
 			'value' => $value
-		);
+		];
 
 		return '<input '._parse_form_attributes($data, $defaults)._attributes_to_string($extra)." />\n";
 	}
@@ -257,7 +257,7 @@ if ( ! function_exists('form_password'))
 	 */
 	function form_password($data = '', $value = '', $extra = '')
 	{
-		is_array($data) OR $data = array('name' => $data);
+		is_array($data) OR $data = ['name' => $data];
 		$data['type'] = 'password';
 		return form_input($data, $value, $extra);
 	}
@@ -278,8 +278,8 @@ if ( ! function_exists('form_upload'))
 	 */
 	function form_upload($data = '', $extra = '')
 	{
-		$defaults = array('type' => 'file', 'name' => '');
-		is_array($data) OR $data = array('name' => $data);
+		$defaults = ['type' => 'file', 'name' => ''];
+		is_array($data) OR $data = ['name' => $data];
 		$data['type'] = 'file';
 
 		return '<input '._parse_form_attributes($data, $defaults)._attributes_to_string($extra)." />\n";
@@ -300,11 +300,11 @@ if ( ! function_exists('form_textarea'))
 	 */
 	function form_textarea($data = '', $value = '', $extra = '')
 	{
-		$defaults = array(
+		$defaults = [
 			'name' => is_array($data) ? '' : $data,
 			'cols' => '40',
 			'rows' => '10'
-		);
+		];
 
 		if ( ! is_array($data) OR ! isset($data['value']))
 		{
@@ -335,7 +335,7 @@ if ( ! function_exists('form_multiselect'))
 	 * @param	mixed
 	 * @return	string
 	 */
-	function form_multiselect($name = '', $options = array(), $selected = array(), $extra = '')
+	function form_multiselect($name = '', $options = [], $selected = [], $extra = '')
 	{
 		$extra = _attributes_to_string($extra);
 		if (stripos($extra, 'multiple') === FALSE)
@@ -360,9 +360,9 @@ if ( ! function_exists('form_dropdown'))
 	 * @param	mixed	$extra
 	 * @return	string
 	 */
-	function form_dropdown($data = '', $options = array(), $selected = array(), $extra = '')
+	function form_dropdown($data = '', $options = [], $selected = [], $extra = '')
 	{
-		$defaults = array();
+		$defaults = [];
 
 		if (is_array($data))
 		{
@@ -380,11 +380,11 @@ if ( ! function_exists('form_dropdown'))
 		}
 		else
 		{
-			$defaults = array('name' => $data);
+			$defaults = ['name' => $data];
 		}
 
-		is_array($selected) OR $selected = array($selected);
-		is_array($options) OR $options = array($options);
+		is_array($selected) OR $selected = [$selected];
+		is_array($options) OR $options = [$options];
 
 		// If no selected state was submitted we will attempt to set it automatically
 		if (empty($selected))
@@ -393,12 +393,12 @@ if ( ! function_exists('form_dropdown'))
 			{
 				if (isset($data['name'], $_POST[$data['name']]))
 				{
-					$selected = array($_POST[$data['name']]);
+					$selected = [$_POST[$data['name']]];
 				}
 			}
 			elseif (isset($_POST[$data]))
 			{
-				$selected = array($_POST[$data]);
+				$selected = [$_POST[$data]];
 			}
 		}
 
@@ -457,7 +457,7 @@ if ( ! function_exists('form_checkbox'))
 	 */
 	function form_checkbox($data = '', $value = '', $checked = FALSE, $extra = '')
 	{
-		$defaults = array('type' => 'checkbox', 'name' => ( ! is_array($data) ? $data : ''), 'value' => $value);
+		$defaults = ['type' => 'checkbox', 'name' => ( ! is_array($data) ? $data : ''), 'value' => $value];
 
 		if (is_array($data) && array_key_exists('checked', $data))
 		{
@@ -501,7 +501,7 @@ if ( ! function_exists('form_radio'))
 	 */
 	function form_radio($data = '', $value = '', $checked = FALSE, $extra = '')
 	{
-		is_array($data) OR $data = array('name' => $data);
+		is_array($data) OR $data = ['name' => $data];
 		$data['type'] = 'radio';
 
 		return form_checkbox($data, $value, $checked, $extra);
@@ -522,11 +522,11 @@ if ( ! function_exists('form_submit'))
 	 */
 	function form_submit($data = '', $value = '', $extra = '')
 	{
-		$defaults = array(
+		$defaults = [
 			'type' => 'submit',
 			'name' => is_array($data) ? '' : $data,
 			'value' => $value
-		);
+		];
 
 		return '<input '._parse_form_attributes($data, $defaults)._attributes_to_string($extra)." />\n";
 	}
@@ -546,11 +546,11 @@ if ( ! function_exists('form_reset'))
 	 */
 	function form_reset($data = '', $value = '', $extra = '')
 	{
-		$defaults = array(
+		$defaults = [
 			'type' => 'reset',
 			'name' => is_array($data) ? '' : $data,
 			'value' => $value
-		);
+		];
 
 		return '<input '._parse_form_attributes($data, $defaults)._attributes_to_string($extra)." />\n";
 	}
@@ -570,10 +570,10 @@ if ( ! function_exists('form_button'))
 	 */
 	function form_button($data = '', $content = '', $extra = '')
 	{
-		$defaults = array(
+		$defaults = [
 			'name' => is_array($data) ? '' : $data,
 			'type' => 'button'
-		);
+		];
 
 		if (is_array($data) && isset($data['content']))
 		{
@@ -599,7 +599,7 @@ if ( ! function_exists('form_label'))
 	 * @param	mixed	Additional attributes
 	 * @return	string
 	 */
-	function form_label($label_text = '', $id = '', $attributes = array())
+	function form_label($label_text = '', $id = '', $attributes = [])
 	{
 
 		$label = '<label';
@@ -629,7 +629,7 @@ if ( ! function_exists('form_fieldset'))
 	 * @param	array	Additional attributes
 	 * @return	string
 	 */
-	function form_fieldset($legend_text = '', $attributes = array())
+	function form_fieldset($legend_text = '', $attributes = [])
 	{
 		$fieldset = '<fieldset'._attributes_to_string($attributes).">\n";
 		if ($legend_text !== '')

--- a/system/helpers/html_helper.php
+++ b/system/helpers/html_helper.php
@@ -120,7 +120,7 @@ if ( ! function_exists('_list'))
 	 * @param	int
 	 * @return	string
 	 */
-	function _list($type = 'ul', $list = array(), $attributes = '', $depth = 0)
+	function _list($type = 'ul', $list = [], $attributes = '', $depth = 0)
 	{
 		// If an array wasn't submitted there's nothing to do...
 		if ( ! is_array($list))
@@ -179,7 +179,7 @@ if ( ! function_exists('img'))
 	{
 		if ( ! is_array($src) )
 		{
-			$src = array('src' => $src);
+			$src = ['src' => $src];
 		}
 
 		// If there is no alt attribute defined, set it to an empty string
@@ -247,7 +247,7 @@ if ( ! function_exists('doctype'))
 
 			if (empty($_doctypes) OR ! is_array($_doctypes))
 			{
-				$doctypes = array();
+				$doctypes = [];
 				return FALSE;
 			}
 
@@ -352,15 +352,15 @@ if ( ! function_exists('meta'))
 		// or a multidimensional one, we need to do a little prepping.
 		if ( ! is_array($name))
 		{
-			$name = array(array('name' => $name, 'content' => $content, 'type' => $type, 'newline' => $newline));
+			$name = [['name' => $name, 'content' => $content, 'type' => $type, 'newline' => $newline]];
 		}
 		elseif (isset($name['name']))
 		{
 			// Turn single array into multidimensional
-			$name = array($name);
+			$name = [$name];
 		}
 
-		$allowed_types = array('charset', 'http-equiv', 'name', 'property');
+		$allowed_types = ['charset', 'http-equiv', 'name', 'property'];
 		$str = '';
 		foreach ($name as $meta)
 		{

--- a/system/helpers/inflector_helper.php
+++ b/system/helpers/inflector_helper.php
@@ -68,7 +68,7 @@ if ( ! function_exists('singular'))
 			return $result;
 		}
 
-		$singular_rules = array(
+		$singular_rules = [
 			'/(matr)ices$/'		=> '\1ix',
 			'/(vert|ind)ices$/'	=> '\1ex',
 			'/^(ox)en/'		=> '\1',
@@ -97,7 +97,7 @@ if ( ! function_exists('singular'))
 			'/(n)ews$/'		=> '\1\2ews',
 			'/(quiz)zes$/'		=> '\1',
 			'/([^us])s$/'		=> '\1'
-		);
+		];
 
 		foreach ($singular_rules as $rule => $replacement)
 		{
@@ -133,7 +133,7 @@ if ( ! function_exists('plural'))
 			return $result;
 		}
 
-		$plural_rules = array(
+		$plural_rules = [
 			'/(quiz)$/'                => '\1zes',      // quizzes
 			'/^(ox)$/'                 => '\1\2en',     // ox
 			'/([m|l])ouse$/'           => '\1ice',      // mouse, louse
@@ -154,7 +154,7 @@ if ( ! function_exists('plural'))
 			'/(ax|cris|test)is$/'      => '\1es',       // axis, crisis
 			'/s$/'                     => 's',          // no change (compatibility)
 			'/$/'                      => 's',
-		);
+		];
 
 		foreach ($plural_rules as $rule => $replacement)
 		{
@@ -238,7 +238,7 @@ if ( ! function_exists('is_countable'))
 	{
 		return ! in_array(
 			strtolower($word),
-			array(
+			[
 				'audio',
 				'bison',
 				'chassis',
@@ -270,7 +270,7 @@ if ( ! function_exists('is_countable'))
 				'swine',
 				'traffic',
 				'wheat'
-			)
+			]
 		);
 	}
 }
@@ -292,7 +292,7 @@ if ( ! function_exists('ordinal_format'))
 			return $number;
 		}
 
-		$last_digit = array(
+		$last_digit = [
 			0 => 'th',
 			1 => 'st',
 			2 => 'nd',
@@ -303,7 +303,7 @@ if ( ! function_exists('ordinal_format'))
 			7 => 'th',
 			8 => 'th',
 			9 => 'th'
-		);
+		];
 
 		if (($number % 100) >= 11 && ($number % 100) <= 13)
 		{

--- a/system/helpers/language_helper.php
+++ b/system/helpers/language_helper.php
@@ -61,7 +61,7 @@ if ( ! function_exists('lang'))
 	 * @param	array	$attributes	Any additional HTML attributes
 	 * @return	string
 	 */
-	function lang($line, $for = '', $attributes = array())
+	function lang($line, $for = '', $attributes = [])
 	{
 		$line = get_instance()->lang->line($line);
 

--- a/system/helpers/security_helper.php
+++ b/system/helpers/security_helper.php
@@ -108,6 +108,6 @@ if ( ! function_exists('encode_php_tags'))
 	 */
 	function encode_php_tags($str)
 	{
-		return str_replace(array('<?', '?>'), array('&lt;?', '?&gt;'), $str);
+		return str_replace(['<?', '?>'], ['&lt;?', '?&gt;'], $str);
 	}
 }

--- a/system/helpers/string_helper.php
+++ b/system/helpers/string_helper.php
@@ -89,7 +89,7 @@ if ( ! function_exists('strip_quotes'))
 	 */
 	function strip_quotes($str)
 	{
-		return str_replace(array('"', "'"), '', $str);
+		return str_replace(['"', "'"], '', $str);
 	}
 }
 
@@ -107,7 +107,7 @@ if ( ! function_exists('quotes_to_entities'))
 	 */
 	function quotes_to_entities($str)
 	{
-		return str_replace(array("\'","\"","'",'"'), array("&#39;","&quot;","&#39;","&quot;"), $str);
+		return str_replace(["\'","\"","'",'"'], ["&#39;","&quot;","&#39;","&quot;"], $str);
 	}
 }
 

--- a/system/helpers/text_helper.php
+++ b/system/helpers/text_helper.php
@@ -102,7 +102,7 @@ if ( ! function_exists('character_limiter'))
 		}
 
 		// a bit complicated, but faster than preg_replace with \s+
-		$str = preg_replace('/ {2,}/', ' ', str_replace(array("\r", "\n", "\t", "\v", "\f"), ' ', $str));
+		$str = preg_replace('/ {2,}/', ' ', str_replace(["\r", "\n", "\t", "\v", "\f"], ' ', $str));
 
 		if (mb_strlen($str) <= $n)
 		{
@@ -141,7 +141,7 @@ if ( ! function_exists('ascii_to_entities'))
 		$length = defined('MB_OVERLOAD_STRING')
 			? mb_strlen($str, '8bit') - 1
 			: strlen($str) - 1;
-		for ($i = 0, $count = 1, $temp = array(); $i <= $length; $i++)
+		for ($i = 0, $count = 1, $temp = []; $i <= $length; $i++)
 		{
 			$ordinal = ord($str[$i]);
 
@@ -176,7 +176,7 @@ if ( ! function_exists('ascii_to_entities'))
 
 					$out .= '&#'.$number.';';
 					$count = 1;
-					$temp = array();
+					$temp = [];
 				}
 				// If this is the last iteration, just output whatever we have
 				elseif ($i === $length)
@@ -235,8 +235,8 @@ if ( ! function_exists('entities_to_ascii'))
 		if ($all)
 		{
 			return str_replace(
-				array('&amp;', '&lt;', '&gt;', '&quot;', '&apos;', '&#45;'),
-				array('&', '<', '>', '"', "'", '-'),
+				['&amp;', '&lt;', '&gt;', '&quot;', '&apos;', '&#45;'],
+				['&', '<', '>', '"', "'", '-'],
 				$str
 			);
 		}
@@ -329,8 +329,8 @@ if ( ! function_exists('highlight_code'))
 		 * and thus, thwart the highlighting.
 		 */
 		$str = str_replace(
-			array('&lt;', '&gt;', '<?', '?>', '<%', '%>', '\\', '</script>'),
-			array('<', '>', 'phptagopen', 'phptagclose', 'asptagopen', 'asptagclose', 'backslashtmp', 'scriptclose'),
+			['&lt;', '&gt;', '<?', '?>', '<%', '%>', '\\', '</script>'],
+			['<', '>', 'phptagopen', 'phptagclose', 'asptagopen', 'asptagclose', 'backslashtmp', 'scriptclose'],
 			$str
 		);
 
@@ -340,23 +340,23 @@ if ( ! function_exists('highlight_code'))
 
 		// Remove our artificially added PHP, and the syntax highlighting that came with it
 		$str = preg_replace(
-			array(
+			[
 				'/<span style="color: #([A-Z0-9]+)">&lt;\?php(&nbsp;| )/i',
 				'/(<span style="color: #[A-Z0-9]+">.*?)\?&gt;<\/span>\n<\/span>\n<\/code>/is',
 				'/<span style="color: #[A-Z0-9]+"\><\/span>/i'
-			),
-			array(
+			],
+			[
 				'<span style="color: #$1">',
 				"$1</span>\n</span>\n</code>",
 				''
-			),
+			],
 			$str
 		);
 
 		// Replace our markers back to PHP tags.
 		return str_replace(
-			array('phptagopen', 'phptagclose', 'asptagopen', 'asptagclose', 'backslashtmp', 'scriptclose'),
-			array('&lt;?', '?&gt;', '&lt;%', '%&gt;', '\\', '&lt;/script&gt;'),
+			['phptagopen', 'phptagclose', 'asptagopen', 'asptagclose', 'backslashtmp', 'scriptclose'],
+			['&lt;?', '?&gt;', '&lt;%', '%&gt;', '\\', '&lt;/script&gt;'],
 			$str
 		);
 	}
@@ -413,8 +413,8 @@ if ( ! function_exists('convert_accented_characters'))
 
 			if (empty($foreign_characters) OR ! is_array($foreign_characters))
 			{
-				$array_from = array();
-				$array_to = array();
+				$array_from = [];
+				$array_to = [];
 
 				return $str;
 			}
@@ -453,12 +453,12 @@ if ( ! function_exists('word_wrap'))
 		// Standardize newlines
 		if (strpos($str, "\r") !== FALSE)
 		{
-			$str = str_replace(array("\r\n", "\r"), "\n", $str);
+			$str = str_replace(["\r\n", "\r"], "\n", $str);
 		}
 
 		// If the current word is surrounded by {unwrap} tags we'll
 		// strip the entire chunk and replace it with a marker.
-		$unwrap = array();
+		$unwrap = [];
 		if (preg_match_all('|\{unwrap\}(.+?)\{/unwrap\}|s', $str, $matches))
 		{
 			for ($i = 0, $c = count($matches[0]); $i < $c; $i++)

--- a/system/helpers/url_helper.php
+++ b/system/helpers/url_helper.php
@@ -209,7 +209,7 @@ if ( ! function_exists('anchor_popup'))
 
 		if ( ! is_array($attributes))
 		{
-			$attributes = array($attributes);
+			$attributes = [$attributes];
 
 			// Ref: http://www.w3schools.com/jsref/met_win_open.asp
 			$window_name = '_blank';
@@ -224,7 +224,7 @@ if ( ! function_exists('anchor_popup'))
 			$window_name = '_blank';
 		}
 
-		foreach (array('width' => '800', 'height' => '600', 'scrollbars' => 'yes', 'menubar' => 'no', 'status' => 'yes', 'resizable' => 'yes', 'screenx' => '0', 'screeny' => '0') as $key => $val)
+		foreach (['width' => '800', 'height' => '600', 'scrollbars' => 'yes', 'menubar' => 'no', 'status' => 'yes', 'resizable' => 'yes', 'screenx' => '0', 'screeny' => '0'] as $key => $val)
 		{
 			$atts[$key] = isset($attributes[$key]) ? $attributes[$key] : $val;
 			unset($attributes[$key]);
@@ -320,7 +320,7 @@ if ( ! function_exists('safe_mailto'))
 
 		$x[] = '>';
 
-		$temp = array();
+		$temp = [];
 		for ($i = 0, $l = strlen($title); $i < $l; $i++)
 		{
 			$ordinal = ord($title[$i]);
@@ -344,7 +344,7 @@ if ( ! function_exists('safe_mailto'))
 							: (($temp[0] % 32) * 64) + ($temp[1] % 64);
 					$x[] = '|'.$number;
 					$count = 1;
-					$temp = array();
+					$temp = [];
 				}
 			}
 		}
@@ -490,12 +490,12 @@ if ( ! function_exists('url_title'))
 
 		$q_separator = preg_quote($separator, '#');
 
-		$trans = array(
+		$trans = [
 			'&.+?;'			=> '',
 			'[^\w\d _-]'		=> '',
 			'\s+'			=> $separator,
 			'('.$q_separator.')+'	=> $separator
-		);
+		];
 
 		$str = strip_tags($str);
 		foreach ($trans as $key => $val)

--- a/system/helpers/xml_helper.php
+++ b/system/helpers/xml_helper.php
@@ -72,8 +72,8 @@ if ( ! function_exists('xml_convert'))
 		}
 
 		$str = str_replace(
-			array('&', '<', '>', '"', "'", '-'),
-			array('&amp;', '&lt;', '&gt;', '&quot;', '&apos;', '&#45;'),
+			['&', '<', '>', '"', "'", '-'],
+			['&amp;', '&lt;', '&gt;', '&quot;', '&apos;', '&#45;'],
 			$str
 		);
 

--- a/system/libraries/Cache/Cache.php
+++ b/system/libraries/Cache/Cache.php
@@ -53,7 +53,7 @@ class CI_Cache extends CI_Driver_Library {
 	 *
 	 * @var array
 	 */
-	protected $valid_drivers = array(
+	protected $valid_drivers = [
 		'apc',
 		'apcu',
 		'dummy',
@@ -61,7 +61,7 @@ class CI_Cache extends CI_Driver_Library {
 		'memcached',
 		'redis',
 		'wincache'
-	);
+	];
 
 	/**
 	 * Path of cache files (if file-based cache)
@@ -99,7 +99,7 @@ class CI_Cache extends CI_Driver_Library {
 	 * @param	array	$config = array()
 	 * @return	void
 	 */
-	public function __construct($config = array())
+	public function __construct($config = [])
 	{
 		isset($config['adapter']) && $this->_adapter = $config['adapter'];
 		isset($config['backup']) && $this->_backup_driver = $config['backup'];

--- a/system/libraries/Cache/drivers/Cache_apc.php
+++ b/system/libraries/Cache/drivers/Cache_apc.php
@@ -107,7 +107,7 @@ class CI_Cache_apc extends CI_Driver {
 
 		return apc_store(
 			$id,
-			($raw === TRUE ? $data : array(serialize($data), time(), $ttl)),
+			($raw === TRUE ? $data : [serialize($data), time(), $ttl]),
 			$ttl
 		);
 	}
@@ -198,11 +198,11 @@ class CI_Cache_apc extends CI_Driver {
 
 		list($data, $time, $ttl) = $stored;
 
-		return array(
+		return [
 			'expire'	=> $time + $ttl,
 			'mtime'		=> $time,
 			'data'		=> unserialize($data)
-		);
+		];
 	}
 
 	// ------------------------------------------------------------------------

--- a/system/libraries/Cache/drivers/Cache_apcu.php
+++ b/system/libraries/Cache/drivers/Cache_apcu.php
@@ -106,7 +106,7 @@ class CI_Cache_apcu extends CI_Driver {
 
 		return apcu_store(
 			$id,
-			($raw === TRUE ? $data : array($data, time(), $ttl)),
+			($raw === TRUE ? $data : [$data, time(), $ttl]),
 			$ttl
 		);
 	}
@@ -196,11 +196,11 @@ class CI_Cache_apcu extends CI_Driver {
 
 		list($data, $time, $ttl) = $stored;
 
-		return array(
+		return [
 			'expire'  => $time + $ttl,
 			'mtime'   => $time,
 			'data'    => $data
-		);
+		];
 	}
 
 	// ------------------------------------------------------------------------

--- a/system/libraries/Cache/drivers/Cache_file.php
+++ b/system/libraries/Cache/drivers/Cache_file.php
@@ -95,11 +95,11 @@ class CI_Cache_file extends CI_Driver {
 	 */
 	public function save($id, $data, $ttl = 60, $raw = FALSE)
 	{
-		$contents = array(
+		$contents = [
 			'time'		=> time(),
 			'ttl'		=> $ttl,
 			'data'		=> $data
-		);
+		];
 
 		if (write_file($this->_cache_path.$id, serialize($contents)))
 		{
@@ -138,7 +138,7 @@ class CI_Cache_file extends CI_Driver {
 
 		if ($data === FALSE)
 		{
-			$data = array('data' => 0, 'ttl' => 60);
+			$data = ['data' => 0, 'ttl' => 60];
 		}
 		elseif ( ! is_int($data['data']))
 		{
@@ -166,7 +166,7 @@ class CI_Cache_file extends CI_Driver {
 
 		if ($data === FALSE)
 		{
-			$data = array('data' => 0, 'ttl' => 60);
+			$data = ['data' => 0, 'ttl' => 60];
 		}
 		elseif ( ! is_int($data['data']))
 		{
@@ -232,10 +232,10 @@ class CI_Cache_file extends CI_Driver {
 				return FALSE;
 			}
 
-			return array(
+			return [
 				'expire' => $data['time'] + $data['ttl'],
 				'mtime'	 => $mtime
-			);
+			];
 		}
 
 		return FALSE;

--- a/system/libraries/Cache/drivers/Cache_memcached.php
+++ b/system/libraries/Cache/drivers/Cache_memcached.php
@@ -60,13 +60,13 @@ class CI_Cache_memcached extends CI_Driver {
 	 *
 	 * @var array
 	 */
-	protected $_config = array(
-		'default' => array(
+	protected $_config = [
+		'default' => [
 			'host'		=> '127.0.0.1',
 			'port'		=> 11211,
 			'weight'	=> 1
-		)
-	);
+		]
+	];
 
 	// ------------------------------------------------------------------------
 
@@ -171,7 +171,7 @@ class CI_Cache_memcached extends CI_Driver {
 	{
 		if ($raw !== TRUE)
 		{
-			$data = array($data, time(), $ttl);
+			$data = [$data, time(), $ttl];
 		}
 
 		if ($this->_memcached instanceof Memcached)
@@ -270,11 +270,11 @@ class CI_Cache_memcached extends CI_Driver {
 
 		list($data, $time, $ttl) = $stored;
 
-		return array(
+		return [
 			'expire'	=> $time + $ttl,
 			'mtime'		=> $time,
 			'data'		=> $data
-		);
+		];
 	}
 
 	// ------------------------------------------------------------------------

--- a/system/libraries/Cache/drivers/Cache_redis.php
+++ b/system/libraries/Cache/drivers/Cache_redis.php
@@ -54,13 +54,13 @@ class CI_Cache_redis extends CI_Driver
 	 * @static
 	 * @var	array
 	 */
-	protected static $_default_config = array(
+	protected static $_default_config = [
 		'host' => '127.0.0.1',
 		'password' => NULL,
 		'port' => 6379,
 		'timeout' => 0,
 		'database' => 0
-	);
+	];
 
 	/**
 	 * Redis connection
@@ -136,7 +136,7 @@ class CI_Cache_redis extends CI_Driver
 	 */
 	public function get($key)
 	{
-		$data = $this->_redis->hMGet($key, array('__ci_type', '__ci_value'));
+		$data = $this->_redis->hMGet($key, ['__ci_type', '__ci_value']);
 
 		if ( ! isset($data['__ci_type'], $data['__ci_value']) OR $data['__ci_value'] === FALSE)
 		{
@@ -192,7 +192,7 @@ class CI_Cache_redis extends CI_Driver
 				return FALSE;
 		}
 
-		if ( ! $this->_redis->hMSet($id, array('__ci_type' => $data_type, '__ci_value' => $data)))
+		if ( ! $this->_redis->hMSet($id, ['__ci_type' => $data_type, '__ci_value' => $data]))
 		{
 			return FALSE;
 		}
@@ -288,10 +288,10 @@ class CI_Cache_redis extends CI_Driver
 
 		if ($value !== FALSE)
 		{
-			return array(
+			return [
 				'expire' => time() + $this->_redis->ttl($key),
 				'data' => $value
-			);
+			];
 		}
 
 		return FALSE;

--- a/system/libraries/Cache/drivers/Cache_wincache.php
+++ b/system/libraries/Cache/drivers/Cache_wincache.php
@@ -190,12 +190,12 @@ class CI_Cache_wincache extends CI_Driver {
 			$ttl = $stored['ucache_entries'][1]['ttl_seconds'];
 			$hitcount = $stored['ucache_entries'][1]['hitcount'];
 
-			return array(
+			return [
 				'expire'	=> $ttl - $age,
 				'hitcount'	=> $hitcount,
 				'age'		=> $age,
 				'ttl'		=> $ttl
-			);
+			];
 		}
 
 		return FALSE;

--- a/system/libraries/Calendar.php
+++ b/system/libraries/Calendar.php
@@ -62,7 +62,7 @@ class CI_Calendar {
 	 *
 	 * @var array
 	 */
-	public $replacements = array();
+	public $replacements = [];
 
 	/**
 	 * Day of the week to start the calendar on
@@ -127,7 +127,7 @@ class CI_Calendar {
 	 * @param	array	$config	Calendar options
 	 * @return	void
 	 */
-	public function __construct($config = array())
+	public function __construct($config = [])
 	{
 		$this->CI =& get_instance();
 		$this->CI->lang->load('calendar');
@@ -147,7 +147,7 @@ class CI_Calendar {
 	 * @param	array	config preferences
 	 * @return	CI_Calendar
 	 */
-	public function initialize($config = array())
+	public function initialize($config = [])
 	{
 		foreach ($config as $key => $val)
 		{
@@ -176,7 +176,7 @@ class CI_Calendar {
 	 * @param	array	the data to be shown in the calendar cells
 	 * @return	string
 	 */
-	public function generate($year = '', $month = '', $data = array())
+	public function generate($year = '', $month = '', $data = [])
 	{
 		$local_time = time();
 
@@ -212,7 +212,7 @@ class CI_Calendar {
 		$total_days = $this->get_total_days($month, $year);
 
 		// Set the starting day of the week
-		$start_days	= array('sunday' => 0, 'monday' => 1, 'tuesday' => 2, 'wednesday' => 3, 'thursday' => 4, 'friday' => 5, 'saturday' => 6);
+		$start_days	= ['sunday' => 0, 'monday' => 1, 'tuesday' => 2, 'wednesday' => 3, 'thursday' => 4, 'friday' => 5, 'saturday' => 6];
 		$start_day	= isset($start_days[$this->start_day]) ? $start_days[$this->start_day] : 0;
 
 		// Set the starting day number
@@ -293,7 +293,7 @@ class CI_Calendar {
 						// Cells with content
 						$temp = ($is_current_month === TRUE && $day == $cur_day) ?
 								$this->replacements['cal_cell_content_today'] : $this->replacements['cal_cell_content'];
-						$out .= str_replace(array('{content}', '{day}'), array($data[$day], $day), $temp);
+						$out .= str_replace(['{content}', '{day}'], [$data[$day], $day], $temp);
 					}
 					else
 					{
@@ -354,11 +354,11 @@ class CI_Calendar {
 	{
 		if ($this->month_type === 'short')
 		{
-			$month_names = array('01' => 'cal_jan', '02' => 'cal_feb', '03' => 'cal_mar', '04' => 'cal_apr', '05' => 'cal_may', '06' => 'cal_jun', '07' => 'cal_jul', '08' => 'cal_aug', '09' => 'cal_sep', '10' => 'cal_oct', '11' => 'cal_nov', '12' => 'cal_dec');
+			$month_names = ['01' => 'cal_jan', '02' => 'cal_feb', '03' => 'cal_mar', '04' => 'cal_apr', '05' => 'cal_may', '06' => 'cal_jun', '07' => 'cal_jul', '08' => 'cal_aug', '09' => 'cal_sep', '10' => 'cal_oct', '11' => 'cal_nov', '12' => 'cal_dec'];
 		}
 		else
 		{
-			$month_names = array('01' => 'cal_january', '02' => 'cal_february', '03' => 'cal_march', '04' => 'cal_april', '05' => 'cal_mayl', '06' => 'cal_june', '07' => 'cal_july', '08' => 'cal_august', '09' => 'cal_september', '10' => 'cal_october', '11' => 'cal_november', '12' => 'cal_december');
+			$month_names = ['01' => 'cal_january', '02' => 'cal_february', '03' => 'cal_march', '04' => 'cal_april', '05' => 'cal_mayl', '06' => 'cal_june', '07' => 'cal_july', '08' => 'cal_august', '09' => 'cal_september', '10' => 'cal_october', '11' => 'cal_november', '12' => 'cal_december'];
 		}
 
 		return ($this->CI->lang->line($month_names[$month]) === FALSE)
@@ -386,18 +386,18 @@ class CI_Calendar {
 
 		if ($this->day_type === 'long')
 		{
-			$day_names = array('sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday');
+			$day_names = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
 		}
 		elseif ($this->day_type === 'short')
 		{
-			$day_names = array('sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat');
+			$day_names = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'];
 		}
 		else
 		{
-			$day_names = array('su', 'mo', 'tu', 'we', 'th', 'fr', 'sa');
+			$day_names = ['su', 'mo', 'tu', 'we', 'th', 'fr', 'sa'];
 		}
 
-		$days = array();
+		$days = [];
 		for ($i = 0, $c = count($day_names); $i < $c; $i++)
 		{
 			$days[] = ($this->CI->lang->line('cal_'.$day_names[$i]) === FALSE) ? ucfirst($day_names[$i]) : $this->CI->lang->line('cal_'.$day_names[$i]);
@@ -421,7 +421,7 @@ class CI_Calendar {
 	 */
 	public function adjust_date($month, $year)
 	{
-		$date = array();
+		$date = [];
 
 		$date['month']	= $month;
 		$date['year']	= $year;
@@ -472,7 +472,7 @@ class CI_Calendar {
 	 */
 	public function default_template()
 	{
-		return array(
+		return [
 			'table_open'				=> '<table border="0" cellpadding="4" cellspacing="0">',
 			'heading_row_start'			=> '<tr>',
 			'heading_previous_cell'		=> '<th><a href="{previous_url}">&lt;&lt;</a></th>',
@@ -497,7 +497,7 @@ class CI_Calendar {
 			'cal_cell_end_other'		=> '</td>',
 			'cal_row_end'				=> '</tr>',
 			'table_close'				=> '</table>'
-		);
+		];
 	}
 
 	// --------------------------------------------------------------------
@@ -521,9 +521,9 @@ class CI_Calendar {
 
 		if (is_string($this->template))
 		{
-			$today = array('cal_cell_start_today', 'cal_cell_content_today', 'cal_cell_no_content_today', 'cal_cell_end_today');
+			$today = ['cal_cell_start_today', 'cal_cell_content_today', 'cal_cell_no_content_today', 'cal_cell_end_today'];
 
-			foreach (array('table_open', 'table_close', 'heading_row_start', 'heading_previous_cell', 'heading_title_cell', 'heading_next_cell', 'heading_row_end', 'week_row_start', 'week_day_cell', 'week_row_end', 'cal_row_start', 'cal_cell_start', 'cal_cell_content', 'cal_cell_no_content', 'cal_cell_blank', 'cal_cell_end', 'cal_row_end', 'cal_cell_start_today', 'cal_cell_content_today', 'cal_cell_no_content_today', 'cal_cell_end_today', 'cal_cell_start_other', 'cal_cell_other', 'cal_cell_end_other') as $val)
+			foreach (['table_open', 'table_close', 'heading_row_start', 'heading_previous_cell', 'heading_title_cell', 'heading_next_cell', 'heading_row_end', 'week_row_start', 'week_day_cell', 'week_row_end', 'cal_row_start', 'cal_cell_start', 'cal_cell_content', 'cal_cell_no_content', 'cal_cell_blank', 'cal_cell_end', 'cal_row_end', 'cal_cell_start_today', 'cal_cell_content_today', 'cal_cell_no_content_today', 'cal_cell_end_today', 'cal_cell_start_other', 'cal_cell_other', 'cal_cell_end_other'] as $val)
 			{
 				if (preg_match('/\{'.$val.'\}(.*?)\{\/'.$val.'\}/si', $this->template, $match))
 				{

--- a/system/libraries/Driver.php
+++ b/system/libraries/Driver.php
@@ -56,7 +56,7 @@ class CI_Driver_Library {
 	 *
 	 * @var array
 	 */
-	protected $valid_drivers = array();
+	protected $valid_drivers = [];
 
 	/**
 	 * Name of the current class - usually the driver class
@@ -96,7 +96,7 @@ class CI_Driver_Library {
 		if ( ! isset($this->lib_name))
 		{
 			// Get library name without any prefix
-			$this->lib_name = str_replace(array('CI_', $prefix), '', get_class($this));
+			$this->lib_name = str_replace(['CI_', $prefix], '', get_class($this));
 		}
 
 		// The child will be prefixed with the parent lib
@@ -219,14 +219,14 @@ class CI_Driver {
 	 *
 	 * @var array
 	 */
-	protected $_methods = array();
+	protected $_methods = [];
 
 	/**
 	 * List of properties in the parent class
 	 *
 	 * @var array
 	 */
-	protected $_properties = array();
+	protected $_properties = [];
 
 	/**
 	 * Array of methods and properties for the parent class(es)
@@ -234,7 +234,7 @@ class CI_Driver {
 	 * @static
 	 * @var	array
 	 */
-	protected static $_reflections = array();
+	protected static $_reflections = [];
 
 	/**
 	 * Decorate
@@ -273,7 +273,7 @@ class CI_Driver {
 				}
 			}
 
-			self::$_reflections[$class_name] = array($this->_methods, $this->_properties);
+			self::$_reflections[$class_name] = [$this->_methods, $this->_properties];
 		}
 		else
 		{
@@ -292,11 +292,11 @@ class CI_Driver {
 	 * @param	array
 	 * @return	mixed
 	 */
-	public function __call($method, $args = array())
+	public function __call($method, $args = [])
 	{
 		if (in_array($method, $this->_methods))
 		{
-			return call_user_func_array(array($this->_parent, $method), $args);
+			return call_user_func_array([$this->_parent, $method], $args);
 		}
 
 		throw new BadMethodCallException('No such method: '.$method.'()');

--- a/system/libraries/Email.php
+++ b/system/libraries/Email.php
@@ -287,42 +287,42 @@ class CI_Email {
 	 * @see	CI_Email::print_debugger()
 	 * @var	string
 	 */
-	protected $_debug_msg		= array();
+	protected $_debug_msg		= [];
 
 	/**
 	 * Recipients
 	 *
 	 * @var	string[]
 	 */
-	protected $_recipients		= array();
+	protected $_recipients		= [];
 
 	/**
 	 * CC Recipients
 	 *
 	 * @var	string[]
 	 */
-	protected $_cc_array		= array();
+	protected $_cc_array		= [];
 
 	/**
 	 * BCC Recipients
 	 *
 	 * @var	string[]
 	 */
-	protected $_bcc_array		= array();
+	protected $_bcc_array		= [];
 
 	/**
 	 * Message headers
 	 *
 	 * @var	string[]
 	 */
-	protected $_headers		= array();
+	protected $_headers		= [];
 
 	/**
 	 * Attachment data
 	 *
 	 * @var	array
 	 */
-	protected $_attachments		= array();
+	protected $_attachments		= [];
 
 	/**
 	 * Valid $protocol values
@@ -330,7 +330,7 @@ class CI_Email {
 	 * @see	CI_Email::$protocol
 	 * @var	string[]
 	 */
-	protected $_protocols		= array('mail', 'sendmail', 'smtp');
+	protected $_protocols		= ['mail', 'sendmail', 'smtp'];
 
 	/**
 	 * Base charsets
@@ -340,7 +340,7 @@ class CI_Email {
 	 *
 	 * @var	string[]
 	 */
-	protected $_base_charsets	= array('us-ascii', 'iso-2022-');
+	protected $_base_charsets	= ['us-ascii', 'iso-2022-'];
 
 	/**
 	 * Bit depths
@@ -350,7 +350,7 @@ class CI_Email {
 	 * @see	CI_Email::$_encoding
 	 * @var	string[]
 	 */
-	protected $_bit_depths		= array('7bit', '8bit');
+	protected $_bit_depths		= ['7bit', '8bit'];
 
 	/**
 	 * $priority translations
@@ -359,13 +359,13 @@ class CI_Email {
 	 *
 	 * @var	string[]
 	 */
-	protected $_priorities = array(
+	protected $_priorities = [
 		1 => '1 (Highest)',
 		2 => '2 (High)',
 		3 => '3 (Normal)',
 		4 => '4 (Low)',
 		5 => '5 (Lowest)'
-	);
+	];
 
 	/**
 	 * mbstring.func_overload flag
@@ -384,7 +384,7 @@ class CI_Email {
 	 * @param	array	$config = array()
 	 * @return	void
 	 */
-	public function __construct(array $config = array())
+	public function __construct(array $config = [])
 	{
 		$this->charset = config_item('charset');
 		$this->initialize($config);
@@ -402,7 +402,7 @@ class CI_Email {
 	 * @param	array	$config
 	 * @return	CI_Email
 	 */
-	public function initialize(array $config = array())
+	public function initialize(array $config = [])
 	{
 		$this->clear();
 
@@ -444,17 +444,17 @@ class CI_Email {
 		$this->_finalbody	= '';
 		$this->_header_str	= '';
 		$this->_replyto_flag	= FALSE;
-		$this->_recipients	= array();
-		$this->_cc_array	= array();
-		$this->_bcc_array	= array();
-		$this->_headers		= array();
-		$this->_debug_msg	= array();
+		$this->_recipients	= [];
+		$this->_cc_array	= [];
+		$this->_bcc_array	= [];
+		$this->_headers		= [];
+		$this->_debug_msg	= [];
 
 		$this->set_header('Date', $this->_set_date());
 
 		if ($clear_attachments !== FALSE)
 		{
-			$this->_attachments = array();
+			$this->_attachments = [];
 		}
 
 		return $this;
@@ -706,13 +706,13 @@ class CI_Email {
 			$file_content =& $file; // buffered file
 		}
 
-		$this->_attachments[] = array(
-			'name'		=> array($file, $newname),
+		$this->_attachments[] = [
+			'name'		=> [$file, $newname],
 			'disposition'	=> empty($disposition) ? 'attachment' : $disposition,  // Can also be 'inline'  Not sure if it matters
 			'type'		=> $mime,
 			'content'	=> chunk_split(base64_encode($file_content)),
 			'multipart'	=> 'mixed'
-		);
+		];
 
 		return $this;
 	}
@@ -753,7 +753,7 @@ class CI_Email {
 	 */
 	public function set_header($header, $value)
 	{
-		$this->_headers[$header] = str_replace(array("\n", "\r"), '', $value);
+		$this->_headers[$header] = str_replace(["\n", "\r"], '', $value);
 		return $this;
 	}
 
@@ -857,7 +857,7 @@ class CI_Email {
 	 */
 	public function set_newline($newline = "\n")
 	{
-		$this->newline = in_array($newline, array("\n", "\r\n", "\r")) ? $newline : "\n";
+		$this->newline = in_array($newline, ["\n", "\r\n", "\r"]) ? $newline : "\n";
 		return $this;
 	}
 
@@ -884,7 +884,7 @@ class CI_Email {
 	 */
 	protected function _get_message_id()
 	{
-		$from = str_replace(array('>', '<'), '', $this->_headers['Return-Path']);
+		$from = str_replace(['>', '<'], '', $this->_headers['Return-Path']);
 		return '<'.uniqid('').strstr($from, '@').'>';
 	}
 
@@ -1037,7 +1037,7 @@ class CI_Email {
 			return preg_match('/\<(.*)\>/', $email, $match) ? $match[1] : $email;
 		}
 
-		$clean_email = array();
+		$clean_email = [];
 
 		foreach ($email as $addy)
 		{
@@ -1104,7 +1104,7 @@ class CI_Email {
 		// Standardize newlines
 		if (strpos($str, "\r") !== FALSE)
 		{
-			$str = str_replace(array("\r\n", "\r"), "\n", $str);
+			$str = str_replace(["\r\n", "\r"], "\n", $str);
 		}
 
 		// Reduce multiple spaces at end of line
@@ -1112,7 +1112,7 @@ class CI_Email {
 
 		// If the current word is surrounded by {unwrap} tags we'll
 		// strip the entire chunk and replace it with a marker.
-		$unwrap = array();
+		$unwrap = [];
 		if (preg_match_all('|\{unwrap\}(.+?)\{/unwrap\}|s', $str, $matches))
 		{
 			for ($i = 0, $c = count($matches[0]); $i < $c; $i++)
@@ -1472,7 +1472,7 @@ class CI_Email {
 		// ASCII code numbers for "safe" characters that can always be
 		// used literally, without encoding, as described in RFC 2049.
 		// http://www.ietf.org/rfc/rfc2049.txt
-		static $ascii_safe_chars = array(
+		static $ascii_safe_chars = [
 			// ' (  )   +   ,   -   .   /   :   =   ?
 			39, 40, 41, 43, 44, 45, 46, 47, 58, 61, 63,
 			// numbers
@@ -1481,11 +1481,11 @@ class CI_Email {
 			65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90,
 			// lower-case letters
 			97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122
-		);
+		];
 
 		// We are intentionally wrapping so mail servers will encode characters
 		// properly and MUAs will behave, so {unwrap} must go!
-		$str = str_replace(array('{unwrap}', '{/unwrap}'), '', $str);
+		$str = str_replace(['{unwrap}', '{/unwrap}'], '', $str);
 
 		// RFC 2045 specifies CRLF as "\r\n".
 		// However, many developers choose to override that and violate
@@ -1497,12 +1497,12 @@ class CI_Email {
 		}
 
 		// Reduce multiple spaces & remove nulls
-		$str = preg_replace(array('| +|', '/\x00+/'), array(' ', ''), $str);
+		$str = preg_replace(['| +|', '/\x00+/'], [' ', ''], $str);
 
 		// Standardize newlines
 		if (strpos($str, "\r") !== FALSE)
 		{
-			$str = str_replace(array("\r\n", "\r"), "\n", $str);
+			$str = str_replace(["\r\n", "\r"], "\n", $str);
 		}
 
 		$escape = '=';
@@ -1577,7 +1577,7 @@ class CI_Email {
 	 */
 	protected function _prep_q_encoding($str)
 	{
-		$str = str_replace(array("\r", "\n"), '', $str);
+		$str = str_replace(["\r", "\n"], '', $str);
 
 		if ($this->charset === 'UTF-8')
 		{
@@ -1587,13 +1587,13 @@ class CI_Email {
 			if (ICONV_ENABLED === TRUE)
 			{
 				$output = @iconv_mime_encode('', $str,
-					array(
+					[
 						'scheme' => 'Q',
 						'line-length' => 76,
 						'input-charset' => $this->charset,
 						'output-charset' => $this->charset,
 						'line-break-chars' => $this->crlf
-					)
+					]
 				);
 
 				// There are reports that iconv_mime_encode() might fail and return FALSE
@@ -1707,7 +1707,7 @@ class CI_Email {
 	{
 		$float = $this->bcc_batch_size - 1;
 		$set = '';
-		$chunk = array();
+		$chunk = [];
 
 		for ($i = 0, $c = count($this->_bcc_array); $i < $c; $i++)
 		{
@@ -1758,7 +1758,7 @@ class CI_Email {
 	 */
 	protected function _unwrap_specials()
 	{
-		$this->_finalbody = preg_replace_callback('/\{unwrap\}(.*?)\{\/unwrap\}/si', array($this, '_remove_nl_callback'), $this->_finalbody);
+		$this->_finalbody = preg_replace_callback('/\{unwrap\}(.*?)\{\/unwrap\}/si', [$this, '_remove_nl_callback'], $this->_finalbody);
 	}
 
 	// --------------------------------------------------------------------
@@ -1773,7 +1773,7 @@ class CI_Email {
 	{
 		if (strpos($matches[1], "\r") !== FALSE OR strpos($matches[1], "\n") !== FALSE)
 		{
-			$matches[1] = str_replace(array("\r\n", "\r", "\n"), '', $matches[1]);
+			$matches[1] = str_replace(["\r\n", "\r", "\n"], '', $matches[1]);
 		}
 
 		return $matches[1];
@@ -2280,13 +2280,13 @@ class CI_Email {
 	 *					Valid options are: 'headers', 'subject', 'body'
 	 * @return	string
 	 */
-	public function print_debugger($include = array('headers', 'subject', 'body'))
+	public function print_debugger($include = ['headers', 'subject', 'body'])
 	{
 		$msg = implode('', $this->_debug_msg);
 
 		// Determine which parts of our raw data needs to be printed
 		$raw_data = '';
-		is_array($include) OR $include = array($include);
+		is_array($include) OR $include = [$include];
 
 		in_array('headers', $include, TRUE) && $raw_data  = htmlspecialchars($this->_header_str)."\n";
 		in_array('subject', $include, TRUE) && $raw_data .= htmlspecialchars($this->_subject)."\n";

--- a/system/libraries/Encryption.php
+++ b/system/libraries/Encryption.php
@@ -90,15 +90,15 @@ class CI_Encryption {
 	 *
 	 * @var	array
 	 */
-	protected $_drivers = array();
+	protected $_drivers = [];
 
 	/**
 	 * List of available modes
 	 *
 	 * @var	array
 	 */
-	protected $_modes = array(
-		'mcrypt' => array(
+	protected $_modes = [
+		'mcrypt' => [
 			'cbc' => 'cbc',
 			'ecb' => 'ecb',
 			'ofb' => 'nofb',
@@ -107,8 +107,8 @@ class CI_Encryption {
 			'cfb8' => 'cfb',
 			'ctr' => 'ctr',
 			'stream' => 'stream'
-		),
-		'openssl' => array(
+		],
+		'openssl' => [
 			'cbc' => 'cbc',
 			'ecb' => 'ecb',
 			'ofb' => 'ofb',
@@ -117,8 +117,8 @@ class CI_Encryption {
 			'ctr' => 'ctr',
 			'stream' => '',
 			'xts' => 'xts'
-		)
-	);
+		]
+	];
 
 	/**
 	 * List of supported HMAC algorithms
@@ -127,12 +127,12 @@ class CI_Encryption {
 	 *
 	 * @var	array
 	 */
-	protected $_digests = array(
+	protected $_digests = [
 		'sha224' => 28,
 		'sha256' => 32,
 		'sha384' => 48,
 		'sha512' => 64
-	);
+	];
 
 	/**
 	 * mbstring.func_overload flag
@@ -149,12 +149,12 @@ class CI_Encryption {
 	 * @param	array	$params	Configuration parameters
 	 * @return	void
 	 */
-	public function __construct(array $params = array())
+	public function __construct(array $params = [])
 	{
-		$this->_drivers = array(
+		$this->_drivers = [
 			'mcrypt'  => defined('MCRYPT_DEV_URANDOM'),
 			'openssl' => extension_loaded('openssl')
-		);
+		];
 
 		if ( ! $this->_drivers['mcrypt'] && ! $this->_drivers['openssl'])
 		{
@@ -427,7 +427,7 @@ class CI_Encryption {
 
 		// Use PKCS#7 padding in order to ensure compatibility with OpenSSL
 		// and other implementations outside of PHP.
-		if (in_array(strtolower(mcrypt_enc_get_modes_name($params['handle'])), array('cbc', 'ecb'), TRUE))
+		if (in_array(strtolower(mcrypt_enc_get_modes_name($params['handle'])), ['cbc', 'ecb'], TRUE))
 		{
 			$block_size = mcrypt_enc_get_block_size($params['handle']);
 			$pad = $block_size - (self::strlen($data) % $block_size);
@@ -600,7 +600,7 @@ class CI_Encryption {
 
 		$data = mdecrypt_generic($params['handle'], $data);
 		// Remove PKCS#7 padding, if necessary
-		if (in_array(strtolower(mcrypt_enc_get_modes_name($params['handle'])), array('cbc', 'ecb'), TRUE))
+		if (in_array(strtolower(mcrypt_enc_get_modes_name($params['handle'])), ['cbc', 'ecb'], TRUE))
 		{
 			$data = self::substr($data, 0, -ord($data[self::strlen($data)-1]));
 		}
@@ -659,7 +659,7 @@ class CI_Encryption {
 		if (empty($params))
 		{
 			return isset($this->_cipher, $this->_mode, $this->_key, $this->_handle)
-				? array(
+				? [
 					'handle' => $this->_handle,
 					'cipher' => $this->_cipher,
 					'mode' => $this->_mode,
@@ -667,7 +667,7 @@ class CI_Encryption {
 					'base64' => TRUE,
 					'hmac_digest' => 'sha512',
 					'hmac_key' => NULL
-				)
+				]
 				: FALSE;
 		}
 		elseif ( ! isset($params['cipher'], $params['mode'], $params['key']))
@@ -712,7 +712,7 @@ class CI_Encryption {
 			}
 		}
 
-		$params = array(
+		$params = [
 			'handle' => NULL,
 			'cipher' => $params['cipher'],
 			'mode' => $params['mode'],
@@ -720,7 +720,7 @@ class CI_Encryption {
 			'base64' => isset($params['raw_data']) ? ! $params['raw_data'] : FALSE,
 			'hmac_digest' => $params['hmac_digest'],
 			'hmac_key' => $params['hmac_key']
-		);
+		];
 
 		$this->_cipher_alias($params['cipher']);
 		$params['handle'] = ($params['cipher'] !== $this->_cipher OR $params['mode'] !== $this->_mode)
@@ -777,8 +777,8 @@ class CI_Encryption {
 
 		if (empty($dictionary))
 		{
-			$dictionary = array(
-				'mcrypt' => array(
+			$dictionary = [
+				'mcrypt' => [
 					'aes-128' => 'rijndael-128',
 					'aes-192' => 'rijndael-128',
 					'aes-256' => 'rijndael-128',
@@ -787,16 +787,16 @@ class CI_Encryption {
 					'cast5' => 'cast-128',
 					'rc4' => 'arcfour',
 					'rc4-40' => 'arcfour'
-				),
-				'openssl' => array(
+				],
+				'openssl' => [
 					'rijndael-128' => 'aes-128',
 					'tripledes' => 'des-ede3',
 					'blowfish' => 'bf',
 					'cast-128' => 'cast5',
 					'arcfour' => 'rc4-40',
 					'rc4' => 'rc4-40'
-				)
-			);
+				]
+			];
 
 			// Notes:
 			//
@@ -893,7 +893,7 @@ class CI_Encryption {
 		{
 			return array_search($this->_mode, $this->_modes[$this->_driver], TRUE);
 		}
-		elseif (in_array($key, array('cipher', 'driver', 'drivers', 'digests'), TRUE))
+		elseif (in_array($key, ['cipher', 'driver', 'drivers', 'digests'], TRUE))
 		{
 			return $this->{'_'.$key};
 		}

--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -60,28 +60,28 @@ class CI_Form_validation {
 	 *
 	 * @var array
 	 */
-	protected $_field_data		= array();
+	protected $_field_data		= [];
 
 	/**
 	 * Validation rules for the current form
 	 *
 	 * @var array
 	 */
-	protected $_config_rules	= array();
+	protected $_config_rules	= [];
 
 	/**
 	 * Array of validation errors
 	 *
 	 * @var array
 	 */
-	protected $_error_array		= array();
+	protected $_error_array		= [];
 
 	/**
 	 * Array of custom error messages
 	 *
 	 * @var array
 	 */
-	protected $_error_messages	= array();
+	protected $_error_messages	= [];
 
 	/**
 	 * Start tag for error wrapping
@@ -109,7 +109,7 @@ class CI_Form_validation {
 	 *
 	 * @var array
 	 */
-	public $validation_data	= array();
+	public $validation_data	= [];
 
 	/**
 	 * Initialize Form_Validation class
@@ -117,7 +117,7 @@ class CI_Form_validation {
 	 * @param	array	$rules
 	 * @return	void
 	 */
-	public function __construct($rules = array())
+	public function __construct($rules = [])
 	{
 		$this->CI =& get_instance();
 
@@ -157,7 +157,7 @@ class CI_Form_validation {
 	 * @param	array	$errors
 	 * @return	CI_Form_validation
 	 */
-	public function set_rules($field, $label = null, $rules = null, $errors = array())
+	public function set_rules($field, $label = null, $rules = null, $errors = [])
 	{
 		// No reason to set rules if we have no POST data
 		// or a validation array has not been specified
@@ -182,7 +182,7 @@ class CI_Form_validation {
 				$label = isset($row['label']) ? $row['label'] : $row['field'];
 
 				// Add the custom error message array
-				$errors = (isset($row['errors']) && is_array($row['errors'])) ? $row['errors'] : array();
+				$errors = (isset($row['errors']) && is_array($row['errors'])) ? $row['errors'] : [];
 
 				// Here we go!
 				$this->set_rules($row['field'], $label, $row['rules'], $errors);
@@ -214,7 +214,7 @@ class CI_Form_validation {
 		// If the field label wasn't passed we use the field name
 		$label = ($label === '') ? $field : $label;
 
-		$indexes = array();
+		$indexes = [];
 
 		// Is the field name an array? If it is an array, we break it apart
 		// into its components so that we can fetch the corresponding POST data later
@@ -232,7 +232,7 @@ class CI_Form_validation {
 		}
 
 		// Build our master array
-		$this->_field_data[$field] = array(
+		$this->_field_data[$field] = [
 			'field'		=> $field,
 			'label'		=> $label,
 			'rules'		=> $rules,
@@ -241,7 +241,7 @@ class CI_Form_validation {
 			'keys'		=> $indexes,
 			'postdata'	=> NULL,
 			'error'		=> ''
-		);
+		];
 
 		return $this;
 	}
@@ -287,7 +287,7 @@ class CI_Form_validation {
 	{
 		if ( ! is_array($lang))
 		{
-			$lang = array($lang => $val);
+			$lang = [$lang => $val];
 		}
 
 		$this->_error_messages = array_merge($this->_error_messages, $lang);
@@ -511,8 +511,8 @@ class CI_Form_validation {
 	 */
 	protected function _prepare_rules($rules)
 	{
-		$new_rules = array();
-		$callbacks = array();
+		$new_rules = [];
+		$callbacks = [];
 
 		foreach ($rules as &$rule)
 		{
@@ -705,7 +705,7 @@ class CI_Form_validation {
 				($postdata === NULL OR ($allow_arrays === FALSE && $postdata === ''))
 				&& $callback === FALSE
 				&& $callable === FALSE
-				&& ! in_array($rule, array('required', 'isset', 'matches'), TRUE)
+				&& ! in_array($rule, ['required', 'isset', 'matches'], TRUE)
 			)
 			{
 				continue;
@@ -896,7 +896,7 @@ class CI_Form_validation {
 			return sprintf($line, $field, $param);
 		}
 
-		return str_replace(array('{field}', '{param}'), array($field, $param), $line);
+		return str_replace(['{field}', '{param}'], [$field, $param], $line);
 	}
 
 	// --------------------------------------------------------------------
@@ -1123,7 +1123,7 @@ class CI_Form_validation {
 	{
 		sscanf($field, '%[^.].%[^.]', $table, $field);
 		return isset($this->CI->db)
-			? ($this->CI->db->limit(1)->get_where($table, array($field => $str))->num_rows() === 0)
+			? ($this->CI->db->limit(1)->get_where($table, [$field => $str])->num_rows() === 0)
 			: FALSE;
 	}
 
@@ -1204,7 +1204,7 @@ class CI_Form_validation {
 			{
 				return FALSE;
 			}
-			elseif ( ! in_array(strtolower($matches[1]), array('http', 'https'), TRUE))
+			elseif ( ! in_array(strtolower($matches[1]), ['http', 'https'], TRUE))
 			{
 				return FALSE;
 			}
@@ -1551,7 +1551,7 @@ class CI_Form_validation {
 	 */
 	public function encode_php_tags($str)
 	{
-		return str_replace(array('<?', '?>'), array('&lt;?', '?&gt;'), $str);
+		return str_replace(['<?', '?>'], ['&lt;?', '?&gt;'], $str);
 	}
 
 	// --------------------------------------------------------------------
@@ -1566,9 +1566,9 @@ class CI_Form_validation {
 	 */
 	public function reset_validation()
 	{
-		$this->_field_data = array();
-		$this->_error_array = array();
-		$this->_error_messages = array();
+		$this->_field_data = [];
+		$this->_error_array = [];
+		$this->_error_messages = [];
 		$this->error_string = '';
 		return $this;
 	}

--- a/system/libraries/Ftp.php
+++ b/system/libraries/Ftp.php
@@ -109,7 +109,7 @@ class CI_FTP {
 	 * @param	array	$config
 	 * @return	void
 	 */
-	public function __construct($config = array())
+	public function __construct($config = [])
 	{
 		empty($config) OR $this->initialize($config);
 		log_message('info', 'FTP Class Initialized');
@@ -123,7 +123,7 @@ class CI_FTP {
 	 * @param	array	$config
 	 * @return	void
 	 */
-	public function initialize($config = array())
+	public function initialize($config = [])
 	{
 		foreach ($config as $key => $val)
 		{
@@ -145,7 +145,7 @@ class CI_FTP {
 	 * @param	array	 $config	Connection values
 	 * @return	bool
 	 */
-	public function connect($config = array())
+	public function connect($config = [])
 	{
 		if (count($config) > 0)
 		{
@@ -630,7 +630,7 @@ class CI_FTP {
 	 */
 	protected function _settype($ext)
 	{
-		return in_array($ext, array('txt', 'text', 'php', 'phps', 'php4', 'js', 'css', 'htm', 'html', 'phtml', 'shtml', 'log', 'xml'), TRUE)
+		return in_array($ext, ['txt', 'text', 'php', 'phps', 'php4', 'js', 'css', 'htm', 'html', 'phtml', 'shtml', 'log', 'xml'], TRUE)
 			? 'ascii'
 			: 'binary';
 	}

--- a/system/libraries/Image_lib.php
+++ b/system/libraries/Image_lib.php
@@ -363,7 +363,7 @@ class CI_Image_lib {
 	 *
 	 * @var array
 	 */
-	public $error_msg		= array();
+	public $error_msg		= [];
 
 	/**
 	 * Whether to have a drop shadow on watermark
@@ -385,7 +385,7 @@ class CI_Image_lib {
 	 * @param	array	$props
 	 * @return	void
 	 */
-	public function __construct($props = array())
+	public function __construct($props = [])
 	{
 		if (count($props) > 0)
 		{
@@ -416,7 +416,7 @@ class CI_Image_lib {
 	 */
 	public function clear()
 	{
-		$props = array('thumb_marker', 'library_path', 'source_image', 'new_image', 'width', 'height', 'rotation_angle', 'x_axis', 'y_axis', 'wm_text', 'wm_overlay_path', 'wm_font_path', 'wm_shadow_color', 'source_folder', 'dest_folder', 'mime_type', 'orig_width', 'orig_height', 'image_type', 'size_str', 'full_src_path', 'full_dst_path');
+		$props = ['thumb_marker', 'library_path', 'source_image', 'new_image', 'width', 'height', 'rotation_angle', 'x_axis', 'y_axis', 'wm_text', 'wm_overlay_path', 'wm_font_path', 'wm_shadow_color', 'source_folder', 'dest_folder', 'mime_type', 'orig_width', 'orig_height', 'image_type', 'size_str', 'full_src_path', 'full_dst_path'];
 
 		foreach ($props as $val)
 		{
@@ -444,7 +444,7 @@ class CI_Image_lib {
 		$this->wm_opacity 			= 50;
 		$this->create_fnc 			= 'imagecreatetruecolor';
 		$this->copy_fnc 			= 'imagecopyresampled';
-		$this->error_msg 			= array();
+		$this->error_msg 			= [];
 		$this->wm_use_drop_shadow 	= FALSE;
 		$this->wm_use_truetype 		= FALSE;
 	}
@@ -457,7 +457,7 @@ class CI_Image_lib {
 	 * @param	array
 	 * @return	bool
 	 */
-	public function initialize($props = array())
+	public function initialize($props = [])
 	{
 		// Convert array elements into class variables
 		if (count($props) > 0)
@@ -466,7 +466,7 @@ class CI_Image_lib {
 			{
 				if (property_exists($this, $key))
 				{
-					if (in_array($key, array('wm_font_color', 'wm_shadow_color'), TRUE))
+					if (in_array($key, ['wm_font_color', 'wm_shadow_color'], TRUE))
 					{
 						if (preg_match('/^#?([0-9a-f]{3}|[0-9a-f]{6})$/i', $val, $matches))
 						{
@@ -488,7 +488,7 @@ class CI_Image_lib {
 							continue;
 						}
 					}
-					elseif (in_array($key, array('width', 'height'), TRUE) && ! ctype_digit((string) $val))
+					elseif (in_array($key, ['width', 'height'], TRUE) && ! ctype_digit((string) $val))
 					{
 						continue;
 					}
@@ -707,7 +707,7 @@ class CI_Image_lib {
 	public function rotate()
 	{
 		// Allowed rotation values
-		$degs = array(90, 180, 270, 'vrt', 'hor');
+		$degs = [90, 180, 270, 'vrt', 'hor'];
 
 		if ($this->rotation_angle === '' OR ! in_array($this->rotation_angle, $degs))
 		{
@@ -1448,7 +1448,7 @@ class CI_Image_lib {
 			case 1:
 				if ( ! function_exists('imagecreatefromgif'))
 				{
-					$this->set_error(array('imglib_unsupported_imagecreate', 'imglib_gif_not_supported'));
+					$this->set_error(['imglib_unsupported_imagecreate', 'imglib_gif_not_supported']);
 					return FALSE;
 				}
 
@@ -1456,7 +1456,7 @@ class CI_Image_lib {
 			case 2:
 				if ( ! function_exists('imagecreatefromjpeg'))
 				{
-					$this->set_error(array('imglib_unsupported_imagecreate', 'imglib_jpg_not_supported'));
+					$this->set_error(['imglib_unsupported_imagecreate', 'imglib_jpg_not_supported']);
 					return FALSE;
 				}
 
@@ -1464,13 +1464,13 @@ class CI_Image_lib {
 			case 3:
 				if ( ! function_exists('imagecreatefrompng'))
 				{
-					$this->set_error(array('imglib_unsupported_imagecreate', 'imglib_png_not_supported'));
+					$this->set_error(['imglib_unsupported_imagecreate', 'imglib_png_not_supported']);
 					return FALSE;
 				}
 
 				return imagecreatefrompng($path);
 			default:
-				$this->set_error(array('imglib_unsupported_imagecreate'));
+				$this->set_error(['imglib_unsupported_imagecreate']);
 				return FALSE;
 		}
 	}
@@ -1493,7 +1493,7 @@ class CI_Image_lib {
 			case 1:
 				if ( ! function_exists('imagegif'))
 				{
-					$this->set_error(array('imglib_unsupported_imagecreate', 'imglib_gif_not_supported'));
+					$this->set_error(['imglib_unsupported_imagecreate', 'imglib_gif_not_supported']);
 					return FALSE;
 				}
 
@@ -1506,7 +1506,7 @@ class CI_Image_lib {
 			case 2:
 				if ( ! function_exists('imagejpeg'))
 				{
-					$this->set_error(array('imglib_unsupported_imagecreate', 'imglib_jpg_not_supported'));
+					$this->set_error(['imglib_unsupported_imagecreate', 'imglib_jpg_not_supported']);
 					return FALSE;
 				}
 
@@ -1519,7 +1519,7 @@ class CI_Image_lib {
 			case 3:
 				if ( ! function_exists('imagepng'))
 				{
-					$this->set_error(array('imglib_unsupported_imagecreate', 'imglib_png_not_supported'));
+					$this->set_error(['imglib_unsupported_imagecreate', 'imglib_png_not_supported']);
 					return FALSE;
 				}
 
@@ -1530,7 +1530,7 @@ class CI_Image_lib {
 				}
 			break;
 			default:
-				$this->set_error(array('imglib_unsupported_imagecreate'));
+				$this->set_error(['imglib_unsupported_imagecreate']);
 				return FALSE;
 			break;
 		}
@@ -1655,18 +1655,18 @@ class CI_Image_lib {
 			return FALSE;
 		}
 
-		$types = array(1 => 'gif', 2 => 'jpeg', 3 => 'png');
+		$types = [1 => 'gif', 2 => 'jpeg', 3 => 'png'];
 		$mime = isset($types[$vals[2]]) ? 'image/'.$types[$vals[2]] : 'image/jpg';
 
 		if ($return === TRUE)
 		{
-			return array(
+			return [
 				'width'      => $vals[0],
 				'height'     => $vals[1],
 				'image_type' => $vals[2],
 				'size_str'   => $vals[3],
 				'mime_type'  => $mime
-			);
+			];
 		}
 
 		$this->orig_width  = $vals[0];
@@ -1704,7 +1704,7 @@ class CI_Image_lib {
 			return;
 		}
 
-		$allowed = array('new_width', 'new_height', 'width', 'height');
+		$allowed = ['new_width', 'new_height', 'width', 'height'];
 
 		foreach ($allowed as $item)
 		{
@@ -1751,7 +1751,7 @@ class CI_Image_lib {
 		$ext = strrchr($source_image, '.');
 		$name = ($ext === FALSE) ? $source_image : substr($source_image, 0, -strlen($ext));
 
-		return array('ext' => $ext, 'name' => $name);
+		return ['ext' => $ext, 'name' => $name];
 	}
 
 	// --------------------------------------------------------------------

--- a/system/libraries/Migration.php
+++ b/system/libraries/Migration.php
@@ -113,10 +113,10 @@ class CI_Migration {
 	 * @param	array	$config
 	 * @return	void
 	 */
-	public function __construct($config = array())
+	public function __construct($config = [])
 	{
 		// Only run this constructor on main library load
-		if ( ! in_array(get_class($this), array('CI_Migration', config_item('subclass_prefix').'Migration'), TRUE))
+		if ( ! in_array(get_class($this), ['CI_Migration', config_item('subclass_prefix').'Migration'], TRUE))
 		{
 			return;
 		}
@@ -158,7 +158,7 @@ class CI_Migration {
 			: '/^\d{3}_(\w+)$/';
 
 		// Make sure a valid migration numbering type was set.
-		if ( ! in_array($this->_migration_type, array('sequential', 'timestamp')))
+		if ( ! in_array($this->_migration_type, ['sequential', 'timestamp']))
 		{
 			show_error('An invalid migration numbering type was specified: '.$this->_migration_type);
 		}
@@ -166,13 +166,13 @@ class CI_Migration {
 		// If the migrations table is missing, make it
 		if ( ! $this->db->table_exists($this->_migration_table))
 		{
-			$this->dbforge->add_field(array(
-				'version' => array('type' => 'BIGINT', 'constraint' => 20),
-			));
+			$this->dbforge->add_field([
+				'version' => ['type' => 'BIGINT', 'constraint' => 20],
+			]);
 
 			$this->dbforge->create_table($this->_migration_table, TRUE);
 
-			$this->db->insert($this->_migration_table, array('version' => 0));
+			$this->db->insert($this->_migration_table, ['version' => 0]);
 		}
 
 		// Do we auto migrate to the latest migration?
@@ -237,7 +237,7 @@ class CI_Migration {
 		// in order to avoid leaving the procedure in a broken state.
 		//
 		// See https://github.com/bcit-ci/CodeIgniter/issues/4539
-		$pending = array();
+		$pending = [];
 		foreach ($migrations as $number => $file)
 		{
 			// Ignore versions out of our range.
@@ -288,13 +288,13 @@ class CI_Migration {
 				$this->_error_string = sprintf($this->lang->line('migration_class_doesnt_exist'), $class);
 				return FALSE;
 			}
-			elseif ( ! is_callable(array($class, $method)))
+			elseif ( ! is_callable([$class, $method]))
 			{
 				$this->_error_string = sprintf($this->lang->line('migration_missing_'.$method.'_method'), $class);
 				return FALSE;
 			}
 
-			$pending[$number] = array($class, $method);
+			$pending[$number] = [$class, $method];
 		}
 
 		// Now just run the necessary migrations
@@ -377,7 +377,7 @@ class CI_Migration {
 	 */
 	public function find_migrations()
 	{
-		$migrations = array();
+		$migrations = [];
 
 		// Load all *_*.php files in the migrations path
 		foreach (glob($this->_migration_path.'*_*.php') as $file)
@@ -456,9 +456,9 @@ class CI_Migration {
 	 */
 	protected function _update_version($migration)
 	{
-		$this->db->update($this->_migration_table, array(
+		$this->db->update($this->_migration_table, [
 			'version' => $migration
-		));
+		]);
 	}
 
 	// --------------------------------------------------------------------

--- a/system/libraries/Pagination.php
+++ b/system/libraries/Pagination.php
@@ -289,7 +289,7 @@ class CI_Pagination {
 	 * @see	CI_Pagination::_attr_rel()
 	 * @var	array
 	 */
-	protected $_link_types = array();
+	protected $_link_types = [];
 
 	/**
 	 * Reuse query string flag
@@ -327,11 +327,11 @@ class CI_Pagination {
 	 * @param	array	$params	Initialization parameters
 	 * @return	void
 	 */
-	public function __construct($params = array())
+	public function __construct($params = [])
 	{
 		$this->CI =& get_instance();
 		$this->CI->load->language('pagination');
-		foreach (array('first_link', 'next_link', 'prev_link', 'last_link') as $key)
+		foreach (['first_link', 'next_link', 'prev_link', 'last_link'] as $key)
 		{
 			if (($val = $this->CI->lang->line('pagination_'.$key)) !== FALSE)
 			{
@@ -351,9 +351,9 @@ class CI_Pagination {
 	 * @param	array	$params	Initialization parameters
 	 * @return	CI_Pagination
 	 */
-	public function initialize(array $params = array())
+	public function initialize(array $params = [])
 	{
-		isset($params['attributes']) OR $params['attributes'] = array();
+		isset($params['attributes']) OR $params['attributes'] = [];
 		if (is_array($params['attributes']))
 		{
 			$this->_parse_attributes($params['attributes']);
@@ -433,7 +433,7 @@ class CI_Pagination {
 		}
 		else
 		{
-			$get = array();
+			$get = [];
 		}
 
 		// Put together our base and first URLs.
@@ -462,7 +462,7 @@ class CI_Pagination {
 
 			// Add the page segment to the end of the query string, where the
 			// page number will be appended.
-			$base_url .= $query_string_sep.http_build_query(array_merge($get, array($this->query_string_segment => '')));
+			$base_url .= $query_string_sep.http_build_query(array_merge($get, [$this->query_string_segment => '']));
 		}
 		else
 		{
@@ -510,7 +510,7 @@ class CI_Pagination {
 			// Remove any specified prefix/suffix from the segment.
 			if ($this->prefix !== '' OR $this->suffix !== '')
 			{
-				$this->cur_page = str_replace(array($this->prefix, $this->suffix), '', $this->cur_page);
+				$this->cur_page = str_replace([$this->prefix, $this->suffix], '', $this->cur_page);
 			}
 		}
 		else
@@ -667,8 +667,8 @@ class CI_Pagination {
 	{
 		isset($attributes['rel']) OR $attributes['rel'] = TRUE;
 		$this->_link_types = ($attributes['rel'])
-			? array('start' => 'start', 'prev' => 'prev', 'next' => 'next')
-			: array();
+			? ['start' => 'start', 'prev' => 'prev', 'next' => 'next']
+			: [];
 		unset($attributes['rel']);
 
 		$this->_attributes = '';

--- a/system/libraries/Parser.php
+++ b/system/libraries/Parser.php
@@ -140,7 +140,7 @@ class CI_Parser {
 			return FALSE;
 		}
 
-		$replace = array();
+		$replace = [];
 		foreach ($data as $key => $val)
 		{
 			$replace = array_merge(
@@ -189,7 +189,7 @@ class CI_Parser {
 	 */
 	protected function _parse_single($key, $val, $string)
 	{
-		return array($this->l_delim.$key.$this->r_delim => (string) $val);
+		return [$this->l_delim.$key.$this->r_delim => (string) $val];
 	}
 
 	// --------------------------------------------------------------------
@@ -206,7 +206,7 @@ class CI_Parser {
 	 */
 	protected function _parse_pair($variable, $data, $string)
 	{
-		$replace = array();
+		$replace = [];
 		preg_match_all(
 			'#'.preg_quote($this->l_delim.$variable.$this->r_delim).'(.+?)'.preg_quote($this->l_delim.'/'.$variable.$this->r_delim).'#s',
 			$string,
@@ -219,7 +219,7 @@ class CI_Parser {
 			$str = '';
 			foreach ($data as $row)
 			{
-				$temp = array();
+				$temp = [];
 				foreach ($row as $key => $val)
 				{
 					if (is_array($val))

--- a/system/libraries/Profiler.php
+++ b/system/libraries/Profiler.php
@@ -59,7 +59,7 @@ class CI_Profiler {
 	 *
 	 * @var array
 	 */
-	protected $_available_sections = array(
+	protected $_available_sections = [
 		'benchmarks',
 		'get',
 		'memory_usage',
@@ -70,7 +70,7 @@ class CI_Profiler {
 		'http_headers',
 		'session_data',
 		'config'
-	);
+	];
 
 	/**
 	 * Number of queries to show before making the additional queries togglable
@@ -95,7 +95,7 @@ class CI_Profiler {
 	 *
 	 * @param	array	$config	Parameters
 	 */
-	public function __construct($config = array())
+	public function __construct($config = [])
 	{
 		$this->CI =& get_instance();
 		$this->CI->load->language('profiler');
@@ -154,7 +154,7 @@ class CI_Profiler {
 	 */
 	protected function _compile_benchmarks()
 	{
-		$profile = array();
+		$profile = [];
 		foreach ($this->CI->benchmark->marker as $key => $val)
 		{
 			// We match the "end" marker so that the list ends
@@ -178,7 +178,7 @@ class CI_Profiler {
 
 		foreach ($profile as $key => $val)
 		{
-			$key = ucwords(str_replace(array('_', '-'), ' ', $key));
+			$key = ucwords(str_replace(['_', '-'], ' ', $key));
 			$output .= '<tr><td style="padding:5px;width:50%;color:#000;font-weight:bold;background-color:#ddd;">'
 					.$key.'&nbsp;&nbsp;</td><td style="padding:5px;width:50%;color:#900;font-weight:normal;background-color:#ddd;">'
 					.$val."</td></tr>\n";
@@ -196,7 +196,7 @@ class CI_Profiler {
 	 */
 	protected function _compile_queries()
 	{
-		$dbs = array();
+		$dbs = [];
 
 		// Let's determine which databases are currently connected to
 		foreach (get_object_vars($this->CI) as $name => $cobject)
@@ -236,7 +236,7 @@ class CI_Profiler {
 		$this->CI->load->helper('text');
 
 		// Key words we want bolded
-		$highlight = array('SELECT', 'DISTINCT', 'FROM', 'WHERE', 'AND', 'LEFT&nbsp;JOIN', 'ORDER&nbsp;BY', 'GROUP&nbsp;BY', 'LIMIT', 'INSERT', 'INTO', 'VALUES', 'UPDATE', 'OR&nbsp;', 'HAVING', 'OFFSET', 'NOT&nbsp;IN', 'IN', 'LIKE', 'NOT&nbsp;LIKE', 'COUNT', 'MAX', 'MIN', 'ON', 'AS', 'AVG', 'SUM', '(', ')');
+		$highlight = ['SELECT', 'DISTINCT', 'FROM', 'WHERE', 'AND', 'LEFT&nbsp;JOIN', 'ORDER&nbsp;BY', 'GROUP&nbsp;BY', 'LIMIT', 'INSERT', 'INTO', 'VALUES', 'UPDATE', 'OR&nbsp;', 'HAVING', 'OFFSET', 'NOT&nbsp;IN', 'IN', 'LIKE', 'NOT&nbsp;LIKE', 'COUNT', 'MAX', 'MIN', 'ON', 'AS', 'AVG', 'SUM', '(', ')'];
 
 		$output  = "\n\n";
 		$count = 0;
@@ -455,7 +455,7 @@ class CI_Profiler {
 			.'&nbsp;&nbsp;(<span style="cursor: pointer;" onclick="var s=document.getElementById(\'ci_profiler_httpheaders_table\').style;s.display=s.display==\'none\'?\'\':\'none\';this.innerHTML=this.innerHTML==\''.$this->CI->lang->line('profiler_section_show').'\'?\''.$this->CI->lang->line('profiler_section_hide').'\':\''.$this->CI->lang->line('profiler_section_show').'\';">'.$this->CI->lang->line('profiler_section_show')."</span>)</legend>\n\n\n"
 			.'<table style="width:100%;display:none;" id="ci_profiler_httpheaders_table">'."\n";
 
-		foreach (array('HTTP_ACCEPT', 'HTTP_USER_AGENT', 'HTTP_CONNECTION', 'SERVER_PORT', 'SERVER_NAME', 'REMOTE_ADDR', 'SERVER_SOFTWARE', 'HTTP_ACCEPT_LANGUAGE', 'SCRIPT_NAME', 'REQUEST_METHOD',' HTTP_HOST', 'REMOTE_HOST', 'CONTENT_TYPE', 'SERVER_PROTOCOL', 'QUERY_STRING', 'HTTP_ACCEPT_ENCODING', 'HTTP_X_FORWARDED_FOR', 'HTTP_DNT') as $header)
+		foreach (['HTTP_ACCEPT', 'HTTP_USER_AGENT', 'HTTP_CONNECTION', 'SERVER_PORT', 'SERVER_NAME', 'REMOTE_ADDR', 'SERVER_SOFTWARE', 'HTTP_ACCEPT_LANGUAGE', 'SCRIPT_NAME', 'REQUEST_METHOD',' HTTP_HOST', 'REMOTE_HOST', 'CONTENT_TYPE', 'SERVER_PROTOCOL', 'QUERY_STRING', 'HTTP_ACCEPT_ENCODING', 'HTTP_X_FORWARDED_FOR', 'HTTP_DNT'] as $header)
 		{
 			$val = isset($_SERVER[$header]) ? htmlspecialchars($_SERVER[$header], ENT_QUOTES, config_item('charset')) : '';
 			$output .= '<tr><td style="vertical-align:top;width:50%;padding:5px;color:#900;background-color:#ddd;">'

--- a/system/libraries/Session/Session.php
+++ b/system/libraries/Session/Session.php
@@ -67,7 +67,7 @@ class CI_Session {
 	 * @param	array	$params	Configuration parameters
 	 * @return	void
 	 */
-	public function __construct(array $params = array())
+	public function __construct(array $params = [])
 	{
 		// No sessions under CLI
 		if (is_cli())
@@ -464,10 +464,10 @@ class CI_Session {
 	{
 		if ( ! isset($_SESSION['__ci_vars']))
 		{
-			return array();
+			return [];
 		}
 
-		$keys = array();
+		$keys = [];
 		foreach (array_keys($_SESSION['__ci_vars']) as $key)
 		{
 			is_int($_SESSION['__ci_vars'][$key]) OR $keys[] = $key;
@@ -491,7 +491,7 @@ class CI_Session {
 			return;
 		}
 
-		is_array($key) OR $key = array($key);
+		is_array($key) OR $key = [$key];
 
 		foreach ($key as $k)
 		{
@@ -522,7 +522,7 @@ class CI_Session {
 
 		if (is_array($key))
 		{
-			$temp = array();
+			$temp = [];
 
 			foreach ($key as $k => $v)
 			{
@@ -572,10 +572,10 @@ class CI_Session {
 	{
 		if ( ! isset($_SESSION['__ci_vars']))
 		{
-			return array();
+			return [];
 		}
 
-		$keys = array();
+		$keys = [];
 		foreach (array_keys($_SESSION['__ci_vars']) as $key)
 		{
 			is_int($_SESSION['__ci_vars'][$key]) && $keys[] = $key;
@@ -599,7 +599,7 @@ class CI_Session {
 			return;
 		}
 
-		is_array($key) OR $key = array($key);
+		is_array($key) OR $key = [$key];
 
 		foreach ($key as $k)
 		{
@@ -733,12 +733,12 @@ class CI_Session {
 		}
 		elseif (empty($_SESSION))
 		{
-			return array();
+			return [];
 		}
 
-		$userdata = array();
+		$userdata = [];
 		$_exclude = array_merge(
-			array('__ci_vars'),
+			['__ci_vars'],
 			$this->get_flash_keys(),
 			$this->get_temp_keys()
 		);
@@ -853,7 +853,7 @@ class CI_Session {
 				: NULL;
 		}
 
-		$flashdata = array();
+		$flashdata = [];
 
 		if ( ! empty($_SESSION['__ci_vars']))
 		{
@@ -917,7 +917,7 @@ class CI_Session {
 				: NULL;
 		}
 
-		$tempdata = array();
+		$tempdata = [];
 
 		if ( ! empty($_SESSION['__ci_vars']))
 		{

--- a/system/libraries/Session/drivers/Session_database_driver.php
+++ b/system/libraries/Session/drivers/Session_database_driver.php
@@ -103,7 +103,7 @@ class CI_Session_database_driver extends CI_Session_driver implements SessionHan
 		{
 			$this->_platform = 'mysql';
 		}
-		elseif (in_array($db_driver, array('postgre', 'pdo_pgsql'), TRUE))
+		elseif (in_array($db_driver, ['postgre', 'pdo_pgsql'], TRUE))
 		{
 			$this->_platform = 'postgre';
 		}
@@ -226,12 +226,12 @@ class CI_Session_database_driver extends CI_Session_driver implements SessionHan
 
 		if ($this->_row_exists === FALSE)
 		{
-			$insert_data = array(
+			$insert_data = [
 				'id' => $session_id,
 				'ip_address' => $_SERVER['REMOTE_ADDR'],
 				'timestamp' => time(),
 				'data' => ($this->_platform === 'postgre' ? base64_encode($session_data) : $session_data)
-			);
+			];
 
 			if ($this->_db->insert($this->_config['save_path'], $insert_data))
 			{
@@ -249,7 +249,7 @@ class CI_Session_database_driver extends CI_Session_driver implements SessionHan
 			$this->_db->where('ip_address', $_SERVER['REMOTE_ADDR']);
 		}
 
-		$update_data = array('timestamp' => time());
+		$update_data = ['timestamp' => time()];
 		if ($this->_fingerprint !== md5($session_data))
 		{
 			$update_data['data'] = ($this->_platform === 'postgre')

--- a/system/libraries/Session/drivers/Session_memcached_driver.php
+++ b/system/libraries/Session/drivers/Session_memcached_driver.php
@@ -107,7 +107,7 @@ class CI_Session_memcached_driver extends CI_Session_driver implements SessionHa
 	{
 		$this->_memcached = new Memcached();
 		$this->_memcached->setOption(Memcached::OPT_BINARY_PROTOCOL, TRUE); // required for touch() usage
-		$server_list = array();
+		$server_list = [];
 		foreach ($this->_memcached->getServerList() as $server)
 		{
 			$server_list[] = $server['host'].':'.$server['port'];

--- a/system/libraries/Session/drivers/Session_redis_driver.php
+++ b/system/libraries/Session/drivers/Session_redis_driver.php
@@ -94,15 +94,15 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 		}
 		elseif (preg_match('#^unix://([^\?]+)(?<options>\?.+)?$#', $this->_config['save_path'], $matches))
 		{
-			$save_path = array('path' => $matches[1]);
+			$save_path = ['path' => $matches[1]];
 		}
 		elseif (preg_match('#(?:tcp://)?([^:?]+)(?:\:(\d+))?(?<options>\?.+)?#', $this->_config['save_path'], $matches))
 		{
-			$save_path = array(
+			$save_path = [
 				'host'    => $matches[1],
 				'port'    => empty($matches[2]) ? NULL : $matches[2],
 				'timeout' => NULL // We always pass this to Redis::connect(), so it needs to exist
-			);
+			];
 		}
 		else
 		{
@@ -366,7 +366,7 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 			}
 
 			$result = ($ttl === -2)
-				? $this->_redis->set($lock_key, time(), array('nx', 'ex' => 300))
+				? $this->_redis->set($lock_key, time(), ['nx', 'ex' => 300])
 				: $this->_redis->setex($lock_key, 300, time());
 
 			if ( ! $result)

--- a/system/libraries/Table.php
+++ b/system/libraries/Table.php
@@ -55,14 +55,14 @@ class CI_Table {
 	 *
 	 * @var array
 	 */
-	public $rows		= array();
+	public $rows		= [];
 
 	/**
 	 * Data for table heading
 	 *
 	 * @var array
 	 */
-	public $heading		= array();
+	public $heading		= [];
 
 	/**
 	 * Whether or not to automatically create the table header
@@ -112,7 +112,7 @@ class CI_Table {
 	 * @param	array	$config	(default: array())
 	 * @return	void
 	 */
-	public function __construct($config = array())
+	public function __construct($config = [])
 	{
 		// initialize config
 		foreach ($config as $key => $val)
@@ -152,7 +152,7 @@ class CI_Table {
 	 * @param	mixed
 	 * @return	CI_Table
 	 */
-	public function set_heading($args = array())
+	public function set_heading($args = [])
 	{
 		$this->heading = $this->_prep_args(func_get_args());
 		return $this;
@@ -170,7 +170,7 @@ class CI_Table {
 	 * @param	int	$col_limit
 	 * @return	array
 	 */
-	public function make_columns($array = array(), $col_limit = 0)
+	public function make_columns($array = [], $col_limit = 0)
 	{
 		if ( ! is_array($array) OR count($array) === 0 OR ! is_int($col_limit))
 		{
@@ -186,7 +186,7 @@ class CI_Table {
 			return $array;
 		}
 
-		$new = array();
+		$new = [];
 		do
 		{
 			$temp = array_splice($array, 0, $col_limit);
@@ -232,7 +232,7 @@ class CI_Table {
 	 * @param	mixed
 	 * @return	CI_Table
 	 */
-	public function add_row($args = array())
+	public function add_row($args = [])
 	{
 		$this->rows[] = $this->_prep_args(func_get_args());
 		return $this;
@@ -260,7 +260,7 @@ class CI_Table {
 
 		foreach ($args as $key => $val)
 		{
-			is_array($val) OR $args[$key] = array('data' => $val);
+			is_array($val) OR $args[$key] = ['data' => $val];
 		}
 
 		return $args;
@@ -424,8 +424,8 @@ class CI_Table {
 	 */
 	public function clear()
 	{
-		$this->rows = array();
-		$this->heading = array();
+		$this->rows = [];
+		$this->heading = [];
 		$this->auto_heading = TRUE;
 		$this->caption = NULL;
 		return $this;
@@ -490,7 +490,7 @@ class CI_Table {
 		}
 
 		$this->temp = $this->_default_template();
-		foreach (array('table_open', 'thead_open', 'thead_close', 'heading_row_start', 'heading_row_end', 'heading_cell_start', 'heading_cell_end', 'tbody_open', 'tbody_close', 'row_start', 'row_end', 'cell_start', 'cell_end', 'row_alt_start', 'row_alt_end', 'cell_alt_start', 'cell_alt_end', 'table_close') as $val)
+		foreach (['table_open', 'thead_open', 'thead_close', 'heading_row_start', 'heading_row_end', 'heading_cell_start', 'heading_cell_end', 'tbody_open', 'tbody_close', 'row_start', 'row_end', 'cell_start', 'cell_end', 'row_alt_start', 'row_alt_end', 'cell_alt_start', 'cell_alt_end', 'table_close'] as $val)
 		{
 			if ( ! isset($this->template[$val]))
 			{
@@ -508,7 +508,7 @@ class CI_Table {
 	 */
 	protected function _default_template()
 	{
-		return array(
+		return [
 			'table_open'		=> '<table border="0" cellpadding="4" cellspacing="0">',
 
 			'thead_open'		=> '<thead>',
@@ -533,7 +533,7 @@ class CI_Table {
 			'cell_alt_end'		=> '</td>',
 
 			'table_close'		=> '</table>'
-		);
+		];
 	}
 
 }

--- a/system/libraries/Trackback.php
+++ b/system/libraries/Trackback.php
@@ -62,13 +62,13 @@ class CI_Trackback {
 	 *
 	 * @var	array
 	 */
-	public $data = array(
+	public $data = [
 		'url' => '',
 		'title' => '',
 		'excerpt' => '',
 		'blog_name' => '',
 		'charset' => ''
-	);
+	];
 
 	/**
 	 * Convert ASCII flag
@@ -92,7 +92,7 @@ class CI_Trackback {
 	 *
 	 * @var	string[]
 	 */
-	public $error_msg = array();
+	public $error_msg = [];
 
 	// --------------------------------------------------------------------
 
@@ -123,7 +123,7 @@ class CI_Trackback {
 		}
 
 		// Pre-process the Trackback Data
-		foreach (array('url', 'title', 'excerpt', 'blog_name', 'ping_url') as $item)
+		foreach (['url', 'title', 'excerpt', 'blog_name', 'ping_url'] as $item)
 		{
 			if ( ! isset($tb_data[$item]))
 			{
@@ -148,7 +148,7 @@ class CI_Trackback {
 			}
 
 			// Convert High ASCII Characters
-			if ($this->convert_ascii === TRUE && in_array($item, array('excerpt', 'title', 'blog_name'), TRUE))
+			if ($this->convert_ascii === TRUE && in_array($item, ['excerpt', 'title', 'blog_name'], TRUE))
 			{
 				$$item = $this->convert_ascii($$item);
 			}
@@ -190,7 +190,7 @@ class CI_Trackback {
 	 */
 	public function receive()
 	{
-		foreach (array('url', 'title', 'blog_name', 'excerpt') as $val)
+		foreach (['url', 'title', 'blog_name', 'excerpt'] as $val)
 		{
 			if (empty($_POST[$val]))
 			{
@@ -352,7 +352,7 @@ class CI_Trackback {
 		// Break into an array via commas and remove duplicates
 		$urls = array_unique(preg_split('/[,]/', rtrim($urls, ',')));
 
-		array_walk($urls, array($this, 'validate_url'));
+		array_walk($urls, [$this, 'validate_url']);
 		return $urls;
 	}
 
@@ -429,13 +429,13 @@ class CI_Trackback {
 	{
 		$temp = '__TEMP_AMPERSANDS__';
 
-		$str = preg_replace(array('/&#(\d+);/', '/&(\w+);/'), $temp.'\\1;', $str);
+		$str = preg_replace(['/&#(\d+);/', '/&(\w+);/'], $temp.'\\1;', $str);
 
-		$str = str_replace(array('&', '<', '>', '"', "'", '-'),
-					array('&amp;', '&lt;', '&gt;', '&quot;', '&#39;', '&#45;'),
+		$str = str_replace(['&', '<', '>', '"', "'", '-'],
+					['&amp;', '&lt;', '&gt;', '&quot;', '&#39;', '&#45;'],
 					$str);
 
-		return preg_replace(array('/'.$temp.'(\d+);/', '/'.$temp.'(\w+);/'), array('&#\\1;', '&\\1;'), $str);
+		return preg_replace(['/'.$temp.'(\d+);/', '/'.$temp.'(\w+);/'], ['&#\\1;', '&\\1;'], $str);
 	}
 
 	// --------------------------------------------------------------------
@@ -457,7 +457,7 @@ class CI_Trackback {
 			return $str;
 		}
 
-		$str = preg_replace('/\s+/', ' ', str_replace(array("\r\n", "\r", "\n"), ' ', $str));
+		$str = preg_replace('/\s+/', ' ', str_replace(["\r\n", "\r", "\n"], ' ', $str));
 
 		if (strlen($str) <= $n)
 		{
@@ -490,7 +490,7 @@ class CI_Trackback {
 	{
 		$count	= 1;
 		$out	= '';
-		$temp	= array();
+		$temp	= [];
 
 		for ($i = 0, $s = strlen($str); $i < $s; $i++)
 		{
@@ -517,7 +517,7 @@ class CI_Trackback {
 
 					$out .= '&#'.$number.';';
 					$count = 1;
-					$temp = array();
+					$temp = [];
 				}
 			}
 		}

--- a/system/libraries/Typography.php
+++ b/system/libraries/Typography.php
@@ -74,7 +74,7 @@ class CI_Typography {
 	 *
 	 * @var array
 	 */
-	public $inner_block_required = array('blockquote');
+	public $inner_block_required = ['blockquote'];
 
 	/**
 	 * the last block element parsed
@@ -115,7 +115,7 @@ class CI_Typography {
 		// Standardize Newlines to make matching easier
 		if (strpos($str, "\r") !== FALSE)
 		{
-			$str = str_replace(array("\r\n", "\r"), "\n", $str);
+			$str = str_replace(["\r\n", "\r"], "\n", $str);
 		}
 
 		// Reduce line breaks.  If there are more than two consecutive linebreaks
@@ -126,7 +126,7 @@ class CI_Typography {
 		}
 
 		// HTML comment tags don't conform to patterns of normal tags, so pull them out separately, only if needed
-		$html_comments = array();
+		$html_comments = [];
 		if (strpos($str, '<!--') !== FALSE && preg_match_all('#(<!\-\-.*?\-\->)#s', $str, $matches))
 		{
 			for ($i = 0, $total = count($matches[0]); $i < $total; $i++)
@@ -140,16 +140,16 @@ class CI_Typography {
 		// not contain <pre> tags, and it keeps the PCRE patterns below simpler and faster
 		if (strpos($str, '<pre') !== FALSE)
 		{
-			$str = preg_replace_callback('#<pre.*?>.*?</pre>#si', array($this, '_protect_characters'), $str);
+			$str = preg_replace_callback('#<pre.*?>.*?</pre>#si', [$this, '_protect_characters'], $str);
 		}
 
 		// Convert quotes within tags to temporary markers.
-		$str = preg_replace_callback('#<.+?>#si', array($this, '_protect_characters'), $str);
+		$str = preg_replace_callback('#<.+?>#si', [$this, '_protect_characters'], $str);
 
 		// Do the same with braces if necessary
 		if ($this->protect_braced_quotes === TRUE)
 		{
-			$str = preg_replace_callback('#\{.+?\}#si', array($this, '_protect_characters'), $str);
+			$str = preg_replace_callback('#\{.+?\}#si', [$this, '_protect_characters'], $str);
 		}
 
 		// Convert "ignore" tags to temporary marker.  The parser splits out the string at every tag
@@ -228,7 +228,7 @@ class CI_Typography {
 		}
 
 		// Final clean up
-		$table = array(
+		$table = [
 
 						// If the user submitted their own paragraph tags within the text
 						// we will retain them instead of using our tags.
@@ -260,7 +260,7 @@ class CI_Typography {
 						// Similarly, there might be cases where a closing </block> will follow
 						// a closing </p> tag, so we'll correct it by adding a newline in between
 						'#</p></#'			=> "</p>\n</"
-						);
+						];
 
 		// Do we need to reduce empty lines?
 		if ($reduce_linebreaks === TRUE)
@@ -296,7 +296,7 @@ class CI_Typography {
 
 		if ( ! isset($table))
 		{
-			$table = array(
+			$table = [
 							// nested smart quotes, opening and closing
 							// note that rules for grammar (English) allow only for two levels deep
 							// and that single quotes are _supposed_ to always be on the outside
@@ -337,7 +337,7 @@ class CI_Typography {
 
 							// ampersands, if not a character entity
 							'/&(?!#?[a-zA-Z0-9]{2,};)/'		=> '&amp;'
-						);
+						];
 		}
 
 		return preg_replace(array_keys($table), $table, $str);
@@ -395,7 +395,7 @@ class CI_Typography {
 	 */
 	protected function _protect_characters($match)
 	{
-		return str_replace(array("'",'"','--','  '), array('{@SQ}', '{@DQ}', '{@DD}', '{@NBS}'), $match[0]);
+		return str_replace(["'",'"','--','  '], ['{@SQ}', '{@DQ}', '{@DD}', '{@NBS}'], $match[0]);
 	}
 
 	// --------------------------------------------------------------------

--- a/system/libraries/Unit_test.php
+++ b/system/libraries/Unit_test.php
@@ -62,7 +62,7 @@ class CI_Unit_test {
 	 *
 	 * @var	array
 	 */
-	public $results = array();
+	public $results = [];
 
 	/**
 	 * Strict comparison flag
@@ -92,7 +92,7 @@ class CI_Unit_test {
 	 *
 	 * @var	array
 	 */
-	protected $_test_items_visible	= array(
+	protected $_test_items_visible	= [
 		'test_name',
 		'test_datatype',
 		'res_datatype',
@@ -100,7 +100,7 @@ class CI_Unit_test {
 		'file',
 		'line',
 		'notes'
-	);
+	];
 
 	// --------------------------------------------------------------------
 
@@ -152,10 +152,10 @@ class CI_Unit_test {
 			return FALSE;
 		}
 
-		if (in_array($expected, array('is_object', 'is_string', 'is_bool', 'is_true', 'is_false', 'is_int', 'is_numeric', 'is_float', 'is_double', 'is_array', 'is_null', 'is_resource'), TRUE))
+		if (in_array($expected, ['is_object', 'is_string', 'is_bool', 'is_true', 'is_false', 'is_int', 'is_numeric', 'is_float', 'is_double', 'is_array', 'is_null', 'is_resource'], TRUE))
 		{
 			$result = $expected($test);
-			$extype = str_replace(array('true', 'false'), 'bool', str_replace('is_', '', $expected));
+			$extype = str_replace(['true', 'false'], 'bool', str_replace('is_', '', $expected));
 		}
 		else
 		{
@@ -165,7 +165,7 @@ class CI_Unit_test {
 
 		$back = $this->_backtrace();
 
-		$report = array (
+		$report =  [
 			'test_name'     => $test_name,
 			'test_datatype' => gettype($test),
 			'res_datatype'  => $extype,
@@ -173,11 +173,11 @@ class CI_Unit_test {
 			'file'          => $back['file'],
 			'line'          => $back['line'],
 			'notes'         => $notes
-		);
+		];
 
 		$this->results[] = $report;
 
-		return $this->report($this->result(array($report)));
+		return $this->report($this->result([$report]));
 	}
 
 	// --------------------------------------------------------------------
@@ -190,7 +190,7 @@ class CI_Unit_test {
 	 * @param	array	 $result
 	 * @return	string
 	 */
-	public function report($result = array())
+	public function report($result = [])
 	{
 		if (count($result) === 0)
 		{
@@ -221,7 +221,7 @@ class CI_Unit_test {
 					}
 				}
 
-				$table .= str_replace(array('{item}', '{result}'), array($key, $val), $this->_template_rows);
+				$table .= str_replace(['{item}', '{result}'], [$key, $val], $this->_template_rows);
 			}
 
 			$r .= str_replace('{rows}', $table, $this->_template);
@@ -270,7 +270,7 @@ class CI_Unit_test {
 	 * @param	array	$results
 	 * @return	array
 	 */
-	public function result($results = array())
+	public function result($results = [])
 	{
 		$CI =& get_instance();
 		$CI->load->language('unit_test');
@@ -280,17 +280,17 @@ class CI_Unit_test {
 			$results = $this->results;
 		}
 
-		$retval = array();
+		$retval = [];
 		foreach ($results as $result)
 		{
-			$temp = array();
+			$temp = [];
 			foreach ($result as $key => $val)
 			{
 				if ( ! in_array($key, $this->_test_items_visible))
 				{
 					continue;
 				}
-				elseif (in_array($key, array('test_name', 'test_datatype', 'res_datatype', 'result'), TRUE))
+				elseif (in_array($key, ['test_name', 'test_datatype', 'res_datatype', 'result'], TRUE))
 				{
 					if (FALSE !== ($line = $CI->lang->line(strtolower('ut_'.$val), FALSE)))
 					{
@@ -334,10 +334,10 @@ class CI_Unit_test {
 	protected function _backtrace()
 	{
 		$back = debug_backtrace();
-		return array(
+		return [
 			'file' => (isset($back[1]['file']) ? $back[1]['file'] : ''),
 			'line' => (isset($back[1]['line']) ? $back[1]['line'] : '')
-		);
+		];
 	}
 
 	// --------------------------------------------------------------------

--- a/system/libraries/Upload.php
+++ b/system/libraries/Upload.php
@@ -214,7 +214,7 @@ class CI_Upload {
 	 *
 	 * @var	array
 	 */
-	public $error_msg = array();
+	public $error_msg = [];
 
 	/**
 	 * Remove spaces flag
@@ -272,7 +272,7 @@ class CI_Upload {
 	 *
 	 * @var	array
 	 */
-	protected $_mimes = array();
+	protected $_mimes = [];
 
 	/**
 	 * CI Singleton
@@ -289,7 +289,7 @@ class CI_Upload {
 	 * @param	array	$config
 	 * @return	void
 	 */
-	public function __construct($config = array())
+	public function __construct($config = [])
 	{
 		empty($config) OR $this->initialize($config, FALSE);
 
@@ -308,7 +308,7 @@ class CI_Upload {
 	 * @param	bool	$reset
 	 * @return	CI_Upload
 	 */
-	public function initialize(array $config = array(), $reset = TRUE)
+	public function initialize(array $config = [], $reset = TRUE)
 	{
 		$reflection = new ReflectionClass($this);
 
@@ -596,7 +596,7 @@ class CI_Upload {
 	 */
 	public function data($index = NULL)
 	{
-		$data = array(
+		$data = [
 				'file_name'		=> $this->file_name,
 				'file_type'		=> $this->file_type,
 				'file_path'		=> $this->upload_path,
@@ -611,7 +611,7 @@ class CI_Upload {
 				'image_height'		=> $this->image_height,
 				'image_type'		=> $this->image_type,
 				'image_size_str'	=> $this->image_size_str,
-			);
+			];
 
 		if ( ! empty($index))
 		{
@@ -816,7 +816,7 @@ class CI_Upload {
 		{
 			if (FALSE !== ($D = @getimagesize($path)))
 			{
-				$types = array(1 => 'gif', 2 => 'jpeg', 3 => 'png');
+				$types = [1 => 'gif', 2 => 'jpeg', 3 => 'png'];
 
 				$this->image_width	= $D[0];
 				$this->image_height	= $D[1];
@@ -857,8 +857,8 @@ class CI_Upload {
 		// IE will sometimes return odd mime-types during upload, so here we just standardize all
 		// jpegs or pngs to the same file type.
 
-		$png_mimes  = array('image/x-png');
-		$jpeg_mimes = array('image/jpg', 'image/jpe', 'image/jpeg', 'image/pjpeg');
+		$png_mimes  = ['image/x-png'];
+		$jpeg_mimes = ['image/jpg', 'image/jpe', 'image/jpeg', 'image/pjpeg'];
 
 		if (in_array($this->file_type, $png_mimes))
 		{
@@ -869,7 +869,7 @@ class CI_Upload {
 			$this->file_type = 'image/jpeg';
 		}
 
-		$img_mimes = array('image/gif',	'image/jpeg', 'image/png');
+		$img_mimes = ['image/gif',	'image/jpeg', 'image/png'];
 
 		return in_array($this->file_type, $img_mimes, TRUE);
 	}
@@ -903,7 +903,7 @@ class CI_Upload {
 		}
 
 		// Images get some additional checks
-		if (in_array($ext, array('gif', 'jpg', 'jpeg', 'jpe', 'png'), TRUE) && @getimagesize($this->file_temp) === FALSE)
+		if (in_array($ext, ['gif', 'jpg', 'jpeg', 'jpe', 'png'], TRUE) && @getimagesize($this->file_temp) === FALSE)
 		{
 			return FALSE;
 		}
@@ -1152,7 +1152,7 @@ class CI_Upload {
 	{
 		$this->_CI->lang->load('upload');
 
-		is_array($msg) OR $msg = array($msg);
+		is_array($msg) OR $msg = [$msg];
 		foreach ($msg as $val)
 		{
 			$msg = ($this->_CI->lang->line($val) === FALSE) ? $val : $this->_CI->lang->line($val);

--- a/system/libraries/User_agent.php
+++ b/system/libraries/User_agent.php
@@ -83,42 +83,42 @@ class CI_User_agent {
 	 *
 	 * @var array
 	 */
-	public $languages = array();
+	public $languages = [];
 
 	/**
 	 * Character sets accepted by the current user agent
 	 *
 	 * @var array
 	 */
-	public $charsets = array();
+	public $charsets = [];
 
 	/**
 	 * List of platforms to compare against current user agent
 	 *
 	 * @var array
 	 */
-	public $platforms = array();
+	public $platforms = [];
 
 	/**
 	 * List of browsers to compare against current user agent
 	 *
 	 * @var array
 	 */
-	public $browsers = array();
+	public $browsers = [];
 
 	/**
 	 * List of mobile browsers to compare against current user agent
 	 *
 	 * @var array
 	 */
-	public $mobiles = array();
+	public $mobiles = [];
 
 	/**
 	 * List of robots to compare against current user agent
 	 *
 	 * @var array
 	 */
-	public $robots = array();
+	public $robots = [];
 
 	/**
 	 * Current user-agent platform
@@ -253,7 +253,7 @@ class CI_User_agent {
 	{
 		$this->_set_platform();
 
-		foreach (array('_set_robot', '_set_browser', '_set_mobile') as $function)
+		foreach (['_set_robot', '_set_browser', '_set_mobile'] as $function)
 		{
 			if ($this->$function() === TRUE)
 			{
@@ -381,7 +381,7 @@ class CI_User_agent {
 
 		if (count($this->languages) === 0)
 		{
-			$this->languages = array('Undefined');
+			$this->languages = ['Undefined'];
 		}
 	}
 
@@ -401,7 +401,7 @@ class CI_User_agent {
 
 		if (count($this->charsets) === 0)
 		{
-			$this->charsets = array('Undefined');
+			$this->charsets = ['Undefined'];
 		}
 	}
 

--- a/system/libraries/Xmlrpc.php
+++ b/system/libraries/Xmlrpc.php
@@ -130,28 +130,28 @@ class CI_Xmlrpc {
 	 *
 	 * @var	array
 	 */
-	public $xmlrpcTypes	= array();
+	public $xmlrpcTypes	= [];
 
 	/**
 	 * Valid parents list
 	 *
 	 * @var	array
 	 */
-	public $valid_parents	= array();
+	public $valid_parents	= [];
 
 	/**
 	 * Response error numbers list
 	 *
 	 * @var	array
 	 */
-	public $xmlrpcerr		= array();
+	public $xmlrpcerr		= [];
 
 	/**
 	 * Response error messages list
 	 *
 	 * @var	string[]
 	 */
-	public $xmlrpcstr		= array();
+	public $xmlrpcstr		= [];
 
 	/**
 	 * Encoding charset
@@ -242,7 +242,7 @@ class CI_Xmlrpc {
 	 *
 	 * @var	array
 	 */
-	public $response		= array(); // Response from remote server
+	public $response		= []; // Response from remote server
 
 	/**
 	 * XSS Filter flag
@@ -261,12 +261,12 @@ class CI_Xmlrpc {
 	 * @param	array	$config
 	 * @return	void
 	 */
-	public function __construct($config = array())
+	public function __construct($config = [])
 	{
 		$this->xmlrpc_backslash = chr(92).chr(92);
 
 		// Types for info sent back and forth
-		$this->xmlrpcTypes = array(
+		$this->xmlrpcTypes = [
 			$this->xmlrpcI4	 		=> '1',
 			$this->xmlrpcInt		=> '1',
 			$this->xmlrpcBoolean	=> '1',
@@ -276,27 +276,27 @@ class CI_Xmlrpc {
 			$this->xmlrpcBase64		=> '1',
 			$this->xmlrpcArray		=> '2',
 			$this->xmlrpcStruct		=> '3'
-		);
+		];
 
 		// Array of Valid Parents for Various XML-RPC elements
-		$this->valid_parents = array('BOOLEAN' => array('VALUE'),
-			'I4'				=> array('VALUE'),
-			'INT'				=> array('VALUE'),
-			'STRING'			=> array('VALUE'),
-			'DOUBLE'			=> array('VALUE'),
-			'DATETIME.ISO8601'	=> array('VALUE'),
-			'BASE64'			=> array('VALUE'),
-			'ARRAY'			=> array('VALUE'),
-			'STRUCT'			=> array('VALUE'),
-			'PARAM'			=> array('PARAMS'),
-			'METHODNAME'		=> array('METHODCALL'),
-			'PARAMS'			=> array('METHODCALL', 'METHODRESPONSE'),
-			'MEMBER'			=> array('STRUCT'),
-			'NAME'				=> array('MEMBER'),
-			'DATA'				=> array('ARRAY'),
-			'FAULT'			=> array('METHODRESPONSE'),
-			'VALUE'			=> array('MEMBER', 'DATA', 'PARAM', 'FAULT')
-		);
+		$this->valid_parents = ['BOOLEAN' => ['VALUE'],
+			'I4'				=> ['VALUE'],
+			'INT'				=> ['VALUE'],
+			'STRING'			=> ['VALUE'],
+			'DOUBLE'			=> ['VALUE'],
+			'DATETIME.ISO8601'	=> ['VALUE'],
+			'BASE64'			=> ['VALUE'],
+			'ARRAY'			=> ['VALUE'],
+			'STRUCT'			=> ['VALUE'],
+			'PARAM'			=> ['PARAMS'],
+			'METHODNAME'		=> ['METHODCALL'],
+			'PARAMS'			=> ['METHODCALL', 'METHODRESPONSE'],
+			'MEMBER'			=> ['STRUCT'],
+			'NAME'				=> ['MEMBER'],
+			'DATA'				=> ['ARRAY'],
+			'FAULT'			=> ['METHODRESPONSE'],
+			'VALUE'			=> ['MEMBER', 'DATA', 'PARAM', 'FAULT']
+		];
 
 		// XML-RPC Responses
 		$this->xmlrpcerr['unknown_method'] = '1';
@@ -325,7 +325,7 @@ class CI_Xmlrpc {
 	 * @param	array	$config
 	 * @return	void
 	 */
-	public function initialize($config = array())
+	public function initialize($config = [])
 	{
 		if (count($config) > 0)
 		{
@@ -419,7 +419,7 @@ class CI_Xmlrpc {
 			return;
 		}
 
-		$this->data = array();
+		$this->data = [];
 
 		foreach ($incoming as $key => $value)
 		{
@@ -811,7 +811,7 @@ class XML_RPC_Response
 	 *
 	 * @var	array
 	 */
-	public $headers		= array();
+	public $headers		= [];
 
 	/**
 	 * XSS Filter flag
@@ -978,7 +978,7 @@ class XML_RPC_Response
 		{
 			reset($xmlrpc_val->me);
 			$b = current($xmlrpc_val->me);
-			$arr = array();
+			$arr = [];
 
 			for ($i = 0, $size = count($b); $i < $size; $i++)
 			{
@@ -989,7 +989,7 @@ class XML_RPC_Response
 		elseif ($kind === 'struct')
 		{
 			reset($xmlrpc_val->me['struct']);
-			$arr = array();
+			$arr = [];
 
 			foreach ($xmlrpc_val->me['struct'] as $key => &$value)
 			{
@@ -1052,14 +1052,14 @@ class XML_RPC_Message extends CI_Xmlrpc
 	 *
 	 * @var	array
 	 */
-	public $params		= array();
+	public $params		= [];
 
 	/**
 	 * XH?
 	 *
 	 * @var	array
 	 */
-	public $xh		= array();
+	public $xh		= [];
 
 	// --------------------------------------------------------------------
 
@@ -1151,14 +1151,14 @@ class XML_RPC_Message extends CI_Xmlrpc
 
 		$parser = xml_parser_create($this->xmlrpc_defencoding);
 		$pname = (string) $parser;
-		$this->xh[$pname] = array(
+		$this->xh[$pname] = [
 			'isf'		=> 0,
 			'ac'		=> '',
-			'headers'	=> array(),
-			'stack'		=> array(),
-			'valuestack'	=> array(),
+			'headers'	=> [],
+			'stack'		=> [],
+			'valuestack'	=> [],
 			'isf_reason'	=> 0
-		);
+		];
 
 		xml_set_object($parser, $this);
 		xml_parser_set_option($parser, XML_OPTION_CASE_FOLDING, TRUE);
@@ -1306,7 +1306,7 @@ class XML_RPC_Message extends CI_Xmlrpc
 			case 'STRUCT':
 			case 'ARRAY':
 				// Creates array for child elements
-				$cur_val = array('value' => array(), 'type' => $name);
+				$cur_val = ['value' => [], 'type' => $name];
 				array_unshift($this->xh[$the_parser]['valuestack'], $cur_val);
 				break;
 			case 'METHODNAME':
@@ -1395,7 +1395,7 @@ class XML_RPC_Message extends CI_Xmlrpc
 			case 'STRUCT':
 			case 'ARRAY':
 				$cur_val = array_shift($this->xh[$the_parser]['valuestack']);
-				$this->xh[$the_parser]['value'] = isset($cur_val['values']) ? $cur_val['values'] : array();
+				$this->xh[$the_parser]['value'] = isset($cur_val['values']) ? $cur_val['values'] : [];
 				$this->xh[$the_parser]['vt']	= strtolower($name);
 				break;
 			case 'NAME':
@@ -1555,7 +1555,7 @@ class XML_RPC_Message extends CI_Xmlrpc
 	 * @param	array	$array
 	 * @return	array
 	 */
-	public function output_parameters(array $array = array())
+	public function output_parameters(array $array = [])
 	{
 		$CI =& get_instance();
 
@@ -1578,7 +1578,7 @@ class XML_RPC_Message extends CI_Xmlrpc
 			return $array;
 		}
 
-		$parameters = array();
+		$parameters = [];
 
 		for ($i = 0, $c = count($this->params); $i < $c; $i++)
 		{
@@ -1617,7 +1617,7 @@ class XML_RPC_Message extends CI_Xmlrpc
 		{
 			reset($param->me);
 			$b = current($param->me);
-			$arr = array();
+			$arr = [];
 
 			for ($i = 0, $c = count($b); $i < $c; $i++)
 			{
@@ -1629,7 +1629,7 @@ class XML_RPC_Message extends CI_Xmlrpc
 		elseif ($kind === 'struct')
 		{
 			reset($param->me['struct']);
-			$arr = array();
+			$arr = [];
 
 			foreach ($param->me['struct'] as $key => &$value)
 			{
@@ -1656,7 +1656,7 @@ class XML_RPC_Values extends CI_Xmlrpc
 	 *
 	 * @var	array
 	 */
-	public $me	= array();
+	public $me	= [];
 
 	/**
 	 * Value type
@@ -1884,7 +1884,7 @@ class XML_RPC_Values extends CI_Xmlrpc
 	public function serializeval($o)
 	{
 		$array = $o->me;
-		list($value, $type) = array(reset($array), key($array));
+		list($value, $type) = [reset($array), key($array)];
 		return "<value>\n".$this->serializedata($type, $value)."</value>\n";
 	}
 

--- a/system/libraries/Xmlrpcs.php
+++ b/system/libraries/Xmlrpcs.php
@@ -65,7 +65,7 @@ class CI_Xmlrpcs extends CI_Xmlrpc {
 	 *
 	 * @var array
 	 */
-	public $methods = array();
+	public $methods = [];
 
 	/**
 	 * Debug Message
@@ -79,7 +79,7 @@ class CI_Xmlrpcs extends CI_Xmlrpc {
 	 *
 	 * @var array
 	 */
-	public $system_methods	= array();
+	public $system_methods	= [];
 
 	/**
 	 * Configuration object
@@ -94,7 +94,7 @@ class CI_Xmlrpcs extends CI_Xmlrpc {
 	 * @param	array	$config
 	 * @return	void
 	 */
-	public function __construct($config = array())
+	public function __construct($config = [])
 	{
 		parent::__construct();
 		$this->set_system_methods();
@@ -115,7 +115,7 @@ class CI_Xmlrpcs extends CI_Xmlrpc {
 	 * @param	mixed
 	 * @return	void
 	 */
-	public function initialize($config = array())
+	public function initialize($config = [])
 	{
 		if (isset($config['functions']) && is_array($config['functions']))
 		{
@@ -147,24 +147,24 @@ class CI_Xmlrpcs extends CI_Xmlrpc {
 	 */
 	public function set_system_methods()
 	{
-		$this->methods = array(
-					'system.listMethods'	 => array(
+		$this->methods = [
+					'system.listMethods'	 => [
 										'function' => 'this.listMethods',
-										'signature' => array(array($this->xmlrpcArray, $this->xmlrpcString), array($this->xmlrpcArray)),
-										'docstring' => 'Returns an array of available methods on this server'),
-					'system.methodHelp'	 => array(
+										'signature' => [[$this->xmlrpcArray, $this->xmlrpcString], [$this->xmlrpcArray]],
+										'docstring' => 'Returns an array of available methods on this server'],
+					'system.methodHelp'	 => [
 										'function' => 'this.methodHelp',
-										'signature' => array(array($this->xmlrpcString, $this->xmlrpcString)),
-										'docstring' => 'Returns a documentation string for the specified method'),
-					'system.methodSignature' => array(
+										'signature' => [[$this->xmlrpcString, $this->xmlrpcString]],
+										'docstring' => 'Returns a documentation string for the specified method'],
+					'system.methodSignature' => [
 										'function' => 'this.methodSignature',
-										'signature' => array(array($this->xmlrpcArray, $this->xmlrpcString)),
-										'docstring' => 'Returns an array describing the return type and required parameters of a method'),
-					'system.multicall'	 => array(
+										'signature' => [[$this->xmlrpcArray, $this->xmlrpcString]],
+										'docstring' => 'Returns an array describing the return type and required parameters of a method'],
+					'system.multicall'	 => [
 										'function' => 'this.multicall',
-										'signature' => array(array($this->xmlrpcArray, $this->xmlrpcArray)),
-										'docstring' => 'Combine multiple RPC calls in one request. See http://www.xmlrpc.com/discuss/msgReader$1208 for details')
-				);
+										'signature' => [[$this->xmlrpcArray, $this->xmlrpcArray]],
+										'docstring' => 'Combine multiple RPC calls in one request. See http://www.xmlrpc.com/discuss/msgReader$1208 for details']
+				];
 	}
 
 	// --------------------------------------------------------------------
@@ -197,11 +197,11 @@ class CI_Xmlrpcs extends CI_Xmlrpc {
 	 */
 	public function add_to_map($methodname, $function, $sig, $doc)
 	{
-		$this->methods[$methodname] = array(
+		$this->methods[$methodname] = [
 			'function'	=> $function,
 			'signature'	=> $sig,
 			'docstring'	=> $doc
-		);
+		];
 	}
 
 	// --------------------------------------------------------------------
@@ -235,14 +235,14 @@ class CI_Xmlrpcs extends CI_Xmlrpc {
 		$parser_object = new XML_RPC_Message('filler');
 		$pname = (string) $parser;
 
-		$parser_object->xh[$pname] = array(
+		$parser_object->xh[$pname] = [
 			'isf' => 0,
 			'isf_reason' => '',
-			'params' => array(),
-			'stack' => array(),
-			'valuestack' => array(),
+			'params' => [],
+			'stack' => [],
+			'valuestack' => [],
 			'method' => ''
-		);
+		];
 
 		xml_set_object($parser, $parser_object);
 		xml_parser_set_option($parser, XML_OPTION_CASE_FOLDING, TRUE);
@@ -343,12 +343,12 @@ class CI_Xmlrpcs extends CI_Xmlrpc {
 
 		if ($system_call === TRUE)
 		{
-			if ( ! is_callable(array($this, $method_parts[1])))
+			if ( ! is_callable([$this, $method_parts[1]]))
 			{
 				return new XML_RPC_Response(0, $this->xmlrpcerr['unknown_method'], $this->xmlrpcstr['unknown_method']);
 			}
 		}
-		elseif (($objectCall && ! is_callable(array($method_parts[0], $method_parts[1])))
+		elseif (($objectCall && ! is_callable([$method_parts[0], $method_parts[1]]))
 			OR ( ! $objectCall && ! is_callable($this->methods[$methName]['function']))
 		)
 		{
@@ -396,7 +396,7 @@ class CI_Xmlrpcs extends CI_Xmlrpc {
 		{
 			if ($method_parts[0] === 'this' && $system_call === TRUE)
 			{
-				return call_user_func(array($this, $method_parts[1]), $m);
+				return call_user_func([$this, $method_parts[1]], $m);
 			}
 			elseif ($this->object === FALSE)
 			{
@@ -424,7 +424,7 @@ class CI_Xmlrpcs extends CI_Xmlrpc {
 	public function listMethods($m)
 	{
 		$v = new XML_RPC_Values();
-		$output = array();
+		$output = [];
 
 		foreach ($this->methods as $key => $value)
 		{
@@ -457,12 +457,12 @@ class CI_Xmlrpcs extends CI_Xmlrpc {
 		{
 			if ($this->methods[$method_name]['signature'])
 			{
-				$sigs = array();
+				$sigs = [];
 				$signature = $this->methods[$method_name]['signature'];
 
 				for ($i = 0, $c = count($signature); $i < $c; $i++)
 				{
-					$cursig = array();
+					$cursig = [];
 					$inSig = $signature[$i];
 					for ($j = 0, $jc = count($inSig); $j < $jc; $j++)
 					{
@@ -521,7 +521,7 @@ class CI_Xmlrpcs extends CI_Xmlrpc {
 		$parameters = $m->output_parameters();
 		$calls = $parameters[0];
 
-		$result = array();
+		$result = [];
 
 		foreach ($calls as $value)
 		{
@@ -540,7 +540,7 @@ class CI_Xmlrpcs extends CI_Xmlrpc {
 				return $attempt;
 			}
 
-			$result[] = new XML_RPC_Values(array($attempt->value()), 'array');
+			$result[] = new XML_RPC_Values([$attempt->value()], 'array');
 		}
 
 		return new XML_RPC_Response(new XML_RPC_Values($result, 'array'));
@@ -584,7 +584,7 @@ class CI_Xmlrpcs extends CI_Xmlrpc {
 			return $this->multicall_error('nomethod');
 		}
 
-		list($scalar_value, $scalar_type) = array(reset($methName->me), key($methName->me));
+		list($scalar_value, $scalar_type) = [reset($methName->me), key($methName->me)];
 		$scalar_type = $scalar_type === $this->xmlrpcI4 ? $this->xmlrpcInt : $scalar_type;
 
 		if ($methName->kindOf() !== 'scalar' OR $scalar_type !== 'string')
@@ -604,7 +604,7 @@ class CI_Xmlrpcs extends CI_Xmlrpc {
 			return $this->multicall_error('notarray');
 		}
 
-		list($b, $a) = array(reset($params->me), key($params->me));
+		list($b, $a) = [reset($params->me), key($params->me)];
 
 		$msg = new XML_RPC_Message($scalar_value);
 		for ($i = 0, $numParams = count($b); $i < $numParams; $i++)
@@ -619,7 +619,7 @@ class CI_Xmlrpcs extends CI_Xmlrpc {
 			return $this->multicall_error($result);
 		}
 
-		return new XML_RPC_Values(array($result->value()), 'array');
+		return new XML_RPC_Values([$result->value()], 'array');
 	}
 
 }

--- a/system/libraries/Zip.php
+++ b/system/libraries/Zip.php
@@ -164,10 +164,10 @@ class CI_Zip {
 		// filemtime() may return false, but raises an error for non-existing files
 		$date = file_exists($dir) ? getdate(filemtime($dir)) : getdate($this->now);
 
-		return array(
+		return [
 			'file_mtime' => ($date['hours'] << 11) + ($date['minutes'] << 5) + $date['seconds'] / 2,
 			'file_mdate' => (($date['year'] - 1980) << 9) + ($date['mon'] << 5) + $date['mday']
-		);
+		];
 	}
 
 	// --------------------------------------------------------------------
@@ -361,7 +361,7 @@ class CI_Zip {
 		// Set the original directory root for child dir's to use as relative
 		if ($root_path === NULL)
 		{
-			$root_path = str_replace(array('\\', '/'), DIRECTORY_SEPARATOR, dirname($path)).DIRECTORY_SEPARATOR;
+			$root_path = str_replace(['\\', '/'], DIRECTORY_SEPARATOR, dirname($path)).DIRECTORY_SEPARATOR;
 		}
 
 		while (FALSE !== ($file = readdir($fp)))
@@ -377,7 +377,7 @@ class CI_Zip {
 			}
 			elseif (FALSE !== ($data = file_get_contents($path.$file)))
 			{
-				$name = str_replace(array('\\', '/'), DIRECTORY_SEPARATOR, $path);
+				$name = str_replace(['\\', '/'], DIRECTORY_SEPARATOR, $path);
 				if ($preserve_filepath === FALSE)
 				{
 					$name = str_replace($root_path, '', $name);

--- a/tests/codeigniter/core/Common_test.php
+++ b/tests/codeigniter/core/Common_test.php
@@ -12,7 +12,7 @@ class Common_test extends CI_TestCase {
 
 	public function test_stringify_attributes()
 	{
-		$this->assertEquals(' class="foo" id="bar"', _stringify_attributes(array('class' => 'foo', 'id' => 'bar')));
+		$this->assertEquals(' class="foo" id="bar"', _stringify_attributes(['class' => 'foo', 'id' => 'bar']));
 
 		$atts = new stdClass;
 		$atts->class = 'foo';
@@ -24,14 +24,14 @@ class Common_test extends CI_TestCase {
 
 		$this->assertEquals(' class="foo" id="bar"', _stringify_attributes('class="foo" id="bar"'));
 
-		$this->assertEquals('', _stringify_attributes(array()));
+		$this->assertEquals('', _stringify_attributes([]));
 	}
 
 	// ------------------------------------------------------------------------
 
 	public function test_stringify_js_attributes()
 	{
-		$this->assertEquals('width=800,height=600', _stringify_attributes(array('width' => '800', 'height' => '600'), TRUE));
+		$this->assertEquals('width=800,height=600', _stringify_attributes(['width' => '800', 'height' => '600'], TRUE));
 
 		$atts = new stdClass;
 		$atts->width = 800;
@@ -49,8 +49,8 @@ class Common_test extends CI_TestCase {
 		);
 
 		$this->assertEquals(
-			html_escape(array('associative' => 'and', array('multi' => 'dimentional'))),
-			array('associative' => 'and', array('multi' => 'dimentional'))
+			html_escape(['associative' => 'and', ['multi' => 'dimentional']]),
+			['associative' => 'and', ['multi' => 'dimentional']]
 		);
 	}
 

--- a/tests/codeigniter/core/Config_test.php
+++ b/tests/codeigniter/core/Config_test.php
@@ -7,11 +7,11 @@ class Config_test extends CI_TestCase {
 		$cls =& $this->ci_core_class('cfg');
 
 		// set predictable config values
-		$this->cfg = array(
+		$this->cfg = [
 			'index_page'		=> 'index.php',
 			'base_url'		=> 'http://example.com/',
 			'subclass_prefix'	=> 'MY_'
-		);
+		];
 		$this->ci_set_config($this->cfg);
 
 		$this->config = new $cls;
@@ -125,7 +125,7 @@ class Config_test extends CI_TestCase {
 		$uri = 'test';
 		$uri2 = '1';
 		$this->assertEquals($index_page.'/'.$uri, $this->config->site_url($uri));
-		$this->assertEquals($index_page.'/'.$uri.'/'.$uri2, $this->config->site_url(array($uri, $uri2)));
+		$this->assertEquals($index_page.'/'.$uri.'/'.$uri2, $this->config->site_url([$uri, $uri2]));
 
 		$this->assertEquals($index_page.'/test/', $this->config->site_url('test/'));
 
@@ -140,7 +140,7 @@ class Config_test extends CI_TestCase {
 		$this->config->set_item('enable_query_strings', TRUE);
 
 		$this->assertEquals($index_page.'?'.$uri, $this->config->site_url($uri));
-		$this->assertEquals($index_page.'?0='.$uri.'&1='.$uri2, $this->config->site_url(array($uri, $uri2)));
+		$this->assertEquals($index_page.'?0='.$uri.'&1='.$uri2, $this->config->site_url([$uri, $uri2]));
 
 		$this->config->set_item('base_url', $old_base);
 
@@ -158,42 +158,42 @@ class Config_test extends CI_TestCase {
 		$file = 'test.php';
 		$key = 'testconfig';
 		$val = 'my_value';
-		$cfg = array($key => $val);
+		$cfg = [$key => $val];
 		$this->ci_vfs_create($file, '<?php $config = '.var_export($cfg, TRUE).';', $this->ci_app_root, 'config');
 		$this->assertTrue($this->config->load($file));
 		$this->assertEquals($val, $this->config->item($key));
 
 		// Test reload - value should not change
 		$val2 = 'new_value';
-		$cfg = array($key => $val2);
+		$cfg = [$key => $val2];
 		$this->ci_vfs_create($file, '<?php $config = '.var_export($cfg, TRUE).';', $this->ci_app_root, 'config');
 		$this->assertTrue($this->config->load($file));
 		$this->assertEquals($val, $this->config->item($key));
 
 		// Test section load
 		$file = 'secttest';
-		$cfg = array(
+		$cfg = [
 			'one' => 'prime',
 			'two' => 2,
 			'three' => TRUE
-		);
+		];
 		$this->ci_vfs_create($file.'.php', '<?php $config = '.var_export($cfg, TRUE).';', $this->ci_app_root, 'config');
 		$this->assertTrue($this->config->load($file, TRUE));
 		$this->assertEquals($cfg, $this->config->item($file));
 
 		// Test section merge
-		$cfg2 = array(
+		$cfg2 = [
 			'three' => 'tres',
 			'number' => 42,
 			'letter' => 'Z'
-		);
+		];
 
 		$pkg_dir = 'package';
 		$this->ci_vfs_create(
 			$file.'.php',
 			'<?php $config = '.var_export($cfg2, TRUE).';',
 			$this->ci_app_root,
-			array($pkg_dir, 'config')
+			[$pkg_dir, 'config']
 		);
 		array_unshift($this->config->_config_paths, $this->ci_vfs_path($pkg_dir.'/', APPPATH));
 		$this->assertTrue($this->config->load($file, TRUE));

--- a/tests/codeigniter/core/Input_test.php
+++ b/tests/codeigniter/core/Input_test.php
@@ -20,7 +20,7 @@ class Input_test extends CI_TestCase {
 
 	public function test_get_not_exists()
 	{
-		$this->assertTrue($this->input->get() === array());
+		$this->assertTrue($this->input->get() === []);
 		$this->assertTrue($this->input->get('foo') === NULL);
 	}
 
@@ -51,7 +51,7 @@ class Input_test extends CI_TestCase {
 
 	public function test_post_not_exists()
 	{
-		$this->assertTrue($this->input->post() === array());
+		$this->assertTrue($this->input->post() === []);
 		$this->assertTrue($this->input->post('foo') === NULL);
 	}
 
@@ -121,10 +121,10 @@ class Input_test extends CI_TestCase {
 		$reflection = new ReflectionMethod($this->input, '_fetch_from_array');
 		$reflection->setAccessible(TRUE);
 
-		$data = array(
+		$data = [
 			'foo' => 'bar',
 			'harm' => 'Hello, i try to <script>alert(\'Hack\');</script> your site',
-		);
+		];
 
 		$foo      = $reflection->invokeArgs($this->input, [&$data, 'foo']);
 		$harm     = $reflection->invokeArgs($this->input, [&$data, 'harm']);
@@ -136,7 +136,7 @@ class Input_test extends CI_TestCase {
 
 		$_SERVER['REQUEST_METHOD'] = 'POST';
 		$_POST['foo']['bar'] = 'baz';
-		$barArray = array('bar' => 'baz');
+		$barArray = ['bar' => 'baz'];
 
 		$this->assertEquals('baz', $this->input->post('foo[bar]'));
 		$this->assertEquals($barArray, $this->input->post('foo[]'));
@@ -155,11 +155,11 @@ class Input_test extends CI_TestCase {
 		// v6 tests
 		$this->assertFalse($this->input->valid_ip('192.18.0.1', 'ipv6'));
 
-		$ip_v6 = array(
+		$ip_v6 = [
 			'2001:0db8:0000:85a3:0000:0000:ac1f:8001',
 			'2001:db8:0:85a3:0:0:ac1f:8001',
 			'2001:db8:0:85a3::ac1f:8001'
-		);
+		];
 
 		foreach ($ip_v6 as $ip)
 		{

--- a/tests/codeigniter/core/Lang_test.php
+++ b/tests/codeigniter/core/Lang_test.php
@@ -65,10 +65,10 @@ class Lang_test extends CI_TestCase {
 	{
 		// Multiple files
 		$this->ci_vfs_clone('system/language/english/profiler_lang.php');
-		$files = array(
+		$files = [
 			0 => 'profiler',
 			1 => 'nonexistent'
-		);
+		];
 		$this->setExpectedException(
 			'RuntimeException',
 			'CI Error: Unable to load the requested language file: language/english/nonexistent_lang.php'

--- a/tests/codeigniter/core/Loader_test.php
+++ b/tests/codeigniter/core/Loader_test.php
@@ -34,12 +34,12 @@ class Loader_test extends CI_TestCase {
 		$this->assertFalse($this->load->is_loaded(ucfirst($lib)));
 
 		// Test loading as an array.
-		$this->assertInstanceOf('CI_Loader', $this->load->library(array($lib)));
+		$this->assertInstanceOf('CI_Loader', $this->load->library([$lib]));
 		$this->assertTrue(class_exists($class), $class.' does not exist');
 		$this->assertAttributeInstanceOf($class, $lib, $this->ci_obj);
 
 		// Create library in VFS
-		$lib = array('unit_test_lib' => 'unit_test_lib');
+		$lib = ['unit_test_lib' => 'unit_test_lib'];
 
 		// Test loading as an array (int).
 		$this->assertInstanceOf('CI_Loader', $this->load->library($lib));
@@ -126,11 +126,11 @@ class Loader_test extends CI_TestCase {
 		$this->ci_vfs_create(ucfirst($lib), $content, $this->ci_base_root, 'libraries');
 
 		// Create config file
-		$cfg = array(
+		$cfg = [
 			'foo' => 'bar',
 			'bar' => 'baz',
 			'baz' => false
-		);
+		];
 		$this->ci_vfs_create($lib, '<?php $config = '.var_export($cfg, TRUE).';', $this->ci_app_root, 'config');
 
 		// Test object name and config
@@ -186,7 +186,7 @@ class Loader_test extends CI_TestCase {
 		$this->ci_vfs_create(ucfirst($driver), $content, $this->ci_base_root, 'libraries/'.$dir);
 
 		// Test loading as an array.
-		$this->assertInstanceOf('CI_Loader', $this->load->driver(array($driver)));
+		$this->assertInstanceOf('CI_Loader', $this->load->driver([$driver]));
 		$this->assertTrue(class_exists($class), $class.' does not exist');
 		$this->assertAttributeInstanceOf($class, $driver, $this->ci_obj);
 
@@ -233,7 +233,7 @@ class Loader_test extends CI_TestCase {
 		$base = 'CI_Model';
 		$subdir = 'cars';
 		$this->ci_vfs_create($model, '<?php class '.$model.' extends '.$base.' { }', $this->ci_app_root,
-			array('models', $subdir));
+			['models', $subdir]);
 
 		// Load model
 		$name = 'testors';
@@ -306,11 +306,11 @@ class Loader_test extends CI_TestCase {
 		$this->ci_vfs_create($view, $content.'<?php echo $'.$var.';', $this->ci_app_root, 'views');
 
 		// Test returning view
-		$out = $this->load->view($view, array($var => $value), TRUE);
+		$out = $this->load->view($view, [$var => $value], TRUE);
 		$this->assertEquals($content.$value, $out);
 
 		// Mock output class
-		$output = $this->getMockBuilder('CI_Output')->setMethods(array('append_output'))->getMock();
+		$output = $this->getMockBuilder('CI_Output')->setMethods(['append_output'])->getMock();
 		$output->expects($this->once())->method('append_output')->with($content.$value);
 		$this->ci_instance_var('output', $output);
 
@@ -329,7 +329,7 @@ class Loader_test extends CI_TestCase {
 			'CI Error: Unable to load the requested file: ci_test_nonexistent_view.php'
 		);
 
-		$this->load->view('ci_test_nonexistent_view', array('foo' => 'bar'));
+		$this->load->view('ci_test_nonexistent_view', ['foo' => 'bar']);
 	}
 
 	// --------------------------------------------------------------------
@@ -363,10 +363,10 @@ class Loader_test extends CI_TestCase {
 		$val1 = 'bar';
 		$key2 = 'boo';
 		$val2 = 'hoo';
-		$this->assertInstanceOf('CI_Loader', $this->load->vars(array($key1 => $val1)));
+		$this->assertInstanceOf('CI_Loader', $this->load->vars([$key1 => $val1]));
 		$this->assertInstanceOf('CI_Loader', $this->load->vars($key2, $val2));
 		$this->assertEquals($val1, $this->load->get_var($key1));
-		$this->assertEquals(array($key1 => $val1, $key2 => $val2), $this->load->get_vars());
+		$this->assertEquals([$key1 => $val1, $key2 => $val2], $this->load->get_vars());
 	}
 
 	// --------------------------------------------------------------------
@@ -377,10 +377,10 @@ class Loader_test extends CI_TestCase {
 		$val1 = 'bar';
 		$key2 = 'boo';
 		$val2 = 'hoo';
-		$this->assertInstanceOf('CI_Loader', $this->load->vars(array($key1 => $val1)));
+		$this->assertInstanceOf('CI_Loader', $this->load->vars([$key1 => $val1]));
 		$this->assertInstanceOf('CI_Loader', $this->load->vars($key2, $val2));
 		$this->assertEquals($val1, $this->load->get_var($key1));
-		$this->assertEquals(array($key1 => $val1, $key2 => $val2), $this->load->get_vars());
+		$this->assertEquals([$key1 => $val1, $key2 => $val2], $this->load->get_vars());
 
 		$this->assertInstanceOf('CI_Loader', $this->load->clear_vars());
 		$this->assertEquals('', $this->load->get_var($key1));
@@ -435,9 +435,9 @@ class Loader_test extends CI_TestCase {
 	public function test_loading_multiple_helpers()
 	{
 		// Create helpers in VFS
-		$helpers = array();
-		$funcs = array();
-		$files = array();
+		$helpers = [];
+		$funcs = [];
+		$files = [];
 		for ($i = 1; $i <= 3; ++$i) {
 			$helper = 'test'.$i;
 			$helpers[] = $helper;
@@ -462,7 +462,7 @@ class Loader_test extends CI_TestCase {
 	{
 		// Mock lang class and test load call
 		$file = 'test';
-		$lang = $this->getMockBuilder('CI_Lang')->setMethods(array('load'))->getMock();
+		$lang = $this->getMockBuilder('CI_Lang')->setMethods(['load'])->getMock();
 		$lang->expects($this->once())->method('load')->with($file);
 		$this->ci_instance_var('lang', $lang);
 		$this->assertInstanceOf('CI_Loader', $this->load->language($file));
@@ -476,7 +476,7 @@ class Loader_test extends CI_TestCase {
 		$dir = 'third-party';
 		$lib = 'unit_test_package';
 		$class = ucfirst($lib);
-		$this->ci_vfs_create(ucfirst($lib), '<?php class '.$class.' { }', $this->ci_app_root, array($dir, 'libraries'));
+		$this->ci_vfs_create(ucfirst($lib), '<?php class '.$class.' { }', $this->ci_app_root, [$dir, 'libraries']);
 
 		// Get paths
 		$paths = $this->load->get_package_paths(TRUE);
@@ -557,23 +557,23 @@ class Loader_test extends CI_TestCase {
 		$drv = 'autodrv';
 		$subdir = ucfirst($drv);
 		$drv_class = 'CI_'.$subdir;
-		$this->ci_vfs_create(ucfirst($drv), '<?php class '.$drv_class.' { }', $this->ci_base_root, array('libraries', $subdir));
+		$this->ci_vfs_create(ucfirst($drv), '<?php class '.$drv_class.' { }', $this->ci_base_root, ['libraries', $subdir]);
 
 		// Create model in VFS package path
 		$dir = 'testdir';
 		$path = APPPATH.$dir.'/';
 		$model = 'Automod';
-		$this->ci_vfs_create($model, '<?php class '.$model.' extends CI_Model { }', $this->ci_app_root, array($dir, 'models'));
+		$this->ci_vfs_create($model, '<?php class '.$model.' extends CI_Model { }', $this->ci_app_root, [$dir, 'models']);
 
 		// Create autoloader config
-		$cfg = array(
-			'packages' => array($path),
-			'helper' => array($helper),
-			'libraries' => array($lib),
-			'drivers' => array($drv),
-			'model' => array($model),
-			'config' => array('config1', 'config2')
-		);
+		$cfg = [
+			'packages' => [$path],
+			'helper' => [$helper],
+			'libraries' => [$lib],
+			'drivers' => [$drv],
+			'model' => [$model],
+			'config' => ['config1', 'config2']
+		];
 		$this->ci_vfs_create('autoload', '<?php $autoload = '.var_export($cfg, TRUE).';', $this->ci_app_root, 'config');
 
 		$this->load->initialize();

--- a/tests/codeigniter/core/Security_test.php
+++ b/tests/codeigniter/core/Security_test.php
@@ -76,11 +76,11 @@ class Security_test extends CI_TestCase {
 
 	public function test_xss_clean_string_array()
 	{
-		$harm_strings = array(
+		$harm_strings = [
 			"Hello, i try to <script>alert('Hack');</script> your site",
 			"Simple clean string",
 			"Hello, i try to <script>alert('Hack');</script> your site"
-		);
+		];
 
 		$harmless_strings = $this->security->xss_clean($harm_strings);
 
@@ -303,7 +303,7 @@ class Security_test extends CI_TestCase {
 
 	public function test_strip_image_tags()
 	{
-		$imgtags = array(
+		$imgtags = [
 			'<img src="smiley.gif" alt="Smiley face" height="42" width="42">',
 			'<img alt="Smiley face" height="42" width="42" src="smiley.gif">',
 			'<img src="http://www.w3schools.com/images/w3schools_green.jpg">',
@@ -313,9 +313,9 @@ class Security_test extends CI_TestCase {
 			'<img srqc="/img/sunset.gif" height="100%" width="100%">',
 			'<img srcq="/img/sunset.gif" height="100%" width="100%">',
 			'<img src=non-quoted.attribute foo="bar">'
-		);
+		];
 
-		$urls = array(
+		$urls = [
 			'smiley.gif',
 			'smiley.gif',
 			'http://www.w3schools.com/images/w3schools_green.jpg',
@@ -325,7 +325,7 @@ class Security_test extends CI_TestCase {
 			'<img srqc="/img/sunset.gif" height="100%" width="100%">',
 			'<img srcq="/img/sunset.gif" height="100%" width="100%">',
 			'non-quoted.attribute'
-		);
+		];
 
 		for ($i = 0; $i < count($imgtags); $i++)
 		{

--- a/tests/codeigniter/core/URI_test.php
+++ b/tests/codeigniter/core/URI_test.php
@@ -152,7 +152,7 @@ class URI_test extends CI_TestCase {
 
 	public function test_segment()
 	{
-		$this->uri->segments = array(1 => 'controller');
+		$this->uri->segments = [1 => 'controller'];
 		$this->assertEquals($this->uri->segment(1), 'controller');
 		$this->assertEquals($this->uri->segment(2, 'default'), 'default');
 	}
@@ -161,7 +161,7 @@ class URI_test extends CI_TestCase {
 
 	public function test_rsegment()
 	{
-		$this->uri->rsegments = array(1 => 'method');
+		$this->uri->rsegments = [1 => 'method'];
 		$this->assertEquals($this->uri->rsegment(1), 'method');
 		$this->assertEquals($this->uri->rsegment(2, 'default'), 'default');
 	}
@@ -170,33 +170,33 @@ class URI_test extends CI_TestCase {
 
 	public function test_uri_to_assoc()
 	{
-		$this->uri->segments = array('a', '1', 'b', '2', 'c', '3');
+		$this->uri->segments = ['a', '1', 'b', '2', 'c', '3'];
 
 		$this->assertEquals(
-			array('a' => '1', 'b' => '2', 'c' => '3'),
+			['a' => '1', 'b' => '2', 'c' => '3'],
 			$this->uri->uri_to_assoc(1)
 		);
 
 		$this->assertEquals(
-			array('b' => '2', 'c' => '3'),
+			['b' => '2', 'c' => '3'],
 			$this->uri->uri_to_assoc(3)
 		);
 
-		$this->uri->keyval = array(); // reset cache
-		$this->uri->segments = array('a', '1', 'b', '2', 'c');
+		$this->uri->keyval = []; // reset cache
+		$this->uri->segments = ['a', '1', 'b', '2', 'c'];
 
 		$this->assertEquals(
-			array('a' => '1', 'b' => '2', 'c' => FALSE),
+			['a' => '1', 'b' => '2', 'c' => FALSE],
 			$this->uri->uri_to_assoc(1)
 		);
 
-		$this->uri->keyval = array(); // reset cache
-		$this->uri->segments = array('a', '1');
+		$this->uri->keyval = []; // reset cache
+		$this->uri->segments = ['a', '1'];
 
 		// test default
 		$this->assertEquals(
-			array('a' => '1', 'b' => FALSE),
-			$this->uri->uri_to_assoc(1, array('a', 'b'))
+			['a' => '1', 'b' => FALSE],
+			$this->uri->uri_to_assoc(1, ['a', 'b'])
 		);
 	}
 
@@ -204,33 +204,33 @@ class URI_test extends CI_TestCase {
 
 	public function test_ruri_to_assoc()
 	{
-		$this->uri->rsegments = array('x', '1', 'y', '2', 'z', '3');
+		$this->uri->rsegments = ['x', '1', 'y', '2', 'z', '3'];
 
 		$this->assertEquals(
-			array('x' => '1', 'y' => '2', 'z' => '3'),
+			['x' => '1', 'y' => '2', 'z' => '3'],
 			$this->uri->ruri_to_assoc(1)
 		);
 
 		$this->assertEquals(
-			array('y' => '2', 'z' => '3'),
+			['y' => '2', 'z' => '3'],
 			$this->uri->ruri_to_assoc(3)
 		);
 
-		$this->uri->keyval = array(); // reset cache
-		$this->uri->rsegments = array('x', '1', 'y', '2', 'z');
+		$this->uri->keyval = []; // reset cache
+		$this->uri->rsegments = ['x', '1', 'y', '2', 'z'];
 
 		$this->assertEquals(
-			array('x' => '1', 'y' => '2', 'z' => FALSE),
+			['x' => '1', 'y' => '2', 'z' => FALSE],
 			$this->uri->ruri_to_assoc(1)
 		);
 
-		$this->uri->keyval = array(); // reset cache
-		$this->uri->rsegments = array('x', '1');
+		$this->uri->keyval = []; // reset cache
+		$this->uri->rsegments = ['x', '1'];
 
 		// test default
 		$this->assertEquals(
-			array('x' => '1', 'y' => FALSE),
-			$this->uri->ruri_to_assoc(1, array('x', 'y'))
+			['x' => '1', 'y' => FALSE],
+			$this->uri->ruri_to_assoc(1, ['x', 'y'])
 		);
 	}
 
@@ -239,7 +239,7 @@ class URI_test extends CI_TestCase {
 	public function test_assoc_to_uri()
 	{
 		$this->uri->config->set_item('uri_string_slashes', 'none');
-		$this->assertEquals('a/1/b/2', $this->uri->assoc_to_uri(array('a' => '1', 'b' => '2')));
+		$this->assertEquals('a/1/b/2', $this->uri->assoc_to_uri(['a' => '1', 'b' => '2']));
 	}
 
 	// --------------------------------------------------------------------

--- a/tests/codeigniter/core/Utf8_test.php
+++ b/tests/codeigniter/core/Utf8_test.php
@@ -59,7 +59,7 @@ class Utf8_test extends CI_TestCase {
 		elseif (ICONV_ENABLED)
 		{
 			// This is a known issue, iconv doesn't always work with //IGNORE
-			$this->assertTrue(in_array($utf8->clean_string($illegal_utf8), array('тест', ''), TRUE));
+			$this->assertTrue(in_array($utf8->clean_string($illegal_utf8), ['тест', ''], TRUE));
 		}
 		else
 		{

--- a/tests/codeigniter/core/compat/password_test.php
+++ b/tests/codeigniter/core/compat/password_test.php
@@ -41,11 +41,11 @@ class password_test extends CI_TestCase {
 	 */
 	public function test_password_get_info()
 	{
-		$expected = array(
+		$expected = [
 			'algo' => 1,
 			'algoName' => 'bcrypt',
-			'options' => array('cost' => 10)
-		);
+			'options' => ['cost' => 10]
+		];
 
 		// default
 		$this->assertEquals($expected, password_get_info('$2y$10$MTIzNDU2Nzg5MDEyMzQ1Nej0NmcAWSLR.oP7XOR9HD/vjUuOj100y'));
@@ -55,11 +55,11 @@ class password_test extends CI_TestCase {
 		// cost
 		$this->assertEquals($expected, password_get_info('$2y$11$MTIzNDU2Nzg5MDEyMzQ1Nej0NmcAWSLR.oP7XOR9HD/vjUuOj100y'));
 
-		$expected = array(
+		$expected = [
 			'algo' => 0,
 			'algoName' => 'unknown',
-			'options' => array()
-		);
+			'options' => []
+		];
 
 		// invalid length
 		$this->assertEquals($expected, password_get_info('$2y$11$MTIzNDU2Nzg5MDEyMzQ1Nej0NmcAWSLR.oP7XOR9HD/vjUuOj100'));
@@ -94,12 +94,12 @@ class password_test extends CI_TestCase {
 
 		$this->assertEquals(
 			'$2y$07$usesomesillystringfore2uDLvp1Ii2e./U9C8sBjqp8I90dH6hi',
-			password_hash('rasmuslerdorf', PASSWORD_BCRYPT, array('cost' => 7, 'salt' => 'usesomesillystringforsalt'))
+			password_hash('rasmuslerdorf', PASSWORD_BCRYPT, ['cost' => 7, 'salt' => 'usesomesillystringforsalt'])
 		);
 
 		$this->assertEquals(
 			'$2y$10$MTIzNDU2Nzg5MDEyMzQ1Nej0NmcAWSLR.oP7XOR9HD/vjUuOj100y',
-			password_hash('test', PASSWORD_BCRYPT, array('salt' => '123456789012345678901'.chr(0)))
+			password_hash('test', PASSWORD_BCRYPT, ['salt' => '123456789012345678901'.chr(0)])
 		);
 	}
 
@@ -121,22 +121,22 @@ class password_test extends CI_TestCase {
 		$this->assertFalse(password_needs_rehash('', 0));
 
 		// valid with same cost
-		$this->assertFalse(password_needs_rehash('$2y$10$MTIzNDU2Nzg5MDEyMzQ1Nej0NmcAWSLR.oP7XOR9HD/vjUuOj100y', PASSWORD_BCRYPT, array('cost' => 10)));
+		$this->assertFalse(password_needs_rehash('$2y$10$MTIzNDU2Nzg5MDEyMzQ1Nej0NmcAWSLR.oP7XOR9HD/vjUuOj100y', PASSWORD_BCRYPT, ['cost' => 10]));
 
 		// valid with same cost and additional parameters
-		$this->assertFalse(password_needs_rehash('$2y$10$MTIzNDU2Nzg5MDEyMzQ1Nej0NmcAWSLR.oP7XOR9HD/vjUuOj100y', PASSWORD_BCRYPT, array('cost' => 10, 'foo' => 3)));
+		$this->assertFalse(password_needs_rehash('$2y$10$MTIzNDU2Nzg5MDEyMzQ1Nej0NmcAWSLR.oP7XOR9HD/vjUuOj100y', PASSWORD_BCRYPT, ['cost' => 10, 'foo' => 3]));
 
 		// invalid: different (lower) cost
-		$this->assertTrue(password_needs_rehash('$2y$10$MTIzNDU2Nzg5MDEyMzQ1Nej0NmcAWSLR.oP7XOR9HD/vjUuOj100y', PASSWORD_BCRYPT, array('cost' => 9)));
+		$this->assertTrue(password_needs_rehash('$2y$10$MTIzNDU2Nzg5MDEyMzQ1Nej0NmcAWSLR.oP7XOR9HD/vjUuOj100y', PASSWORD_BCRYPT, ['cost' => 9]));
 
 		// invalid: different (higher) cost
-		$this->assertTrue(password_needs_rehash('$2y$10$MTIzNDU2Nzg5MDEyMzQ1Nej0NmcAWSLR.oP7XOR9HD/vjUuOj100y', PASSWORD_BCRYPT, array('cost' => 11)));
+		$this->assertTrue(password_needs_rehash('$2y$10$MTIzNDU2Nzg5MDEyMzQ1Nej0NmcAWSLR.oP7XOR9HD/vjUuOj100y', PASSWORD_BCRYPT, ['cost' => 11]));
 
 		// valid with default cost
 		$this->assertFalse(password_needs_rehash('$2y$'.str_pad(10, 2, '0', STR_PAD_LEFT).'$MTIzNDU2Nzg5MDEyMzQ1Nej0NmcAWSLR.oP7XOR9HD/vjUuOj100y', PASSWORD_BCRYPT));
 
 		// invalid: 'foo' is cast to 0
-		$this->assertTrue(password_needs_rehash('$2y$10$MTIzNDU2Nzg5MDEyMzQ1Nej0NmcAWSLR.oP7XOR9HD/vjUuOj100y', PASSWORD_BCRYPT, array('cost' => 'foo')));
+		$this->assertTrue(password_needs_rehash('$2y$10$MTIzNDU2Nzg5MDEyMzQ1Nej0NmcAWSLR.oP7XOR9HD/vjUuOj100y', PASSWORD_BCRYPT, ['cost' => 'foo']));
 	}
 
 	// ------------------------------------------------------------------------

--- a/tests/codeigniter/core/compat/standard_test.php
+++ b/tests/codeigniter/core/compat/standard_test.php
@@ -25,52 +25,52 @@ class standard_test extends CI_TestCase {
 	{
 		// Basic tests
 
-		$input = array(
-			array(
+		$input = [
+			[
 				'id' => 1,
 				'first_name' => 'John',
 				'last_name' => 'Doe'
-			),
-			array(
+			],
+			[
 				'id' => 2,
 				'first_name' => 'Sally',
 				'last_name' => 'Smith'
-			),
-			array(
+			],
+			[
 				'id' => 3,
 				'first_name' => 'Jane',
 				'last_name' => 'Jones'
-			)
-		);
+			]
+		];
 
 		// Ensure internal array position doesn't break it
 		next($input);
 
 		$this->assertEquals(
-			array('John', 'Sally', 'Jane'),
+			['John', 'Sally', 'Jane'],
 			array_column($input, 'first_name')
 		);
 
 		$this->assertEquals(
-			array(1, 2, 3),
+			[1, 2, 3],
 			array_column($input, 'id')
 		);
 
 		$this->assertEquals(
-			array(
+			[
 				1 => 'Doe',
 				2 => 'Smith',
 				3 => 'Jones'
-			),
+			],
 			array_column($input, 'last_name', 'id')
 		);
 
 		$this->assertEquals(
-			array(
+			[
 				'John' => 'Doe',
 				'Sally' => 'Smith',
 				'Jane' => 'Jones'
-			),
+			],
 			array_column($input, 'last_name', 'first_name')
 		);
 
@@ -80,79 +80,79 @@ class standard_test extends CI_TestCase {
 		$b = new Bar();
 
 		$this->assertEquals(
-			array('Doe', 'Smith', 'Jones'),
+			['Doe', 'Smith', 'Jones'],
 			array_column($input, $f)
 		);
 
 		$this->assertEquals(
-			array(
+			[
 				'John' => 'Doe',
 				'Sally' => 'Smith',
 				'Jane' => 'Jones'
-			),
+			],
 			array_column($input, $f, $b)
 		);
 
 		// NULL parameters
 
-		$input = array(
-			456 => array(
+		$input = [
+			456 => [
 				'id' => '3',
 				'title' => 'Foo',
 				'date' => '2013-03-25'
-			),
-			457 => array(
+			],
+			457 => [
 				'id' => '5',
 				'title' => 'Bar',
 				'date' => '2012-05-20'
-			)
-		);
+			]
+		];
 
 		$this->assertEquals(
-			array(
-				3 => array(
+			[
+				3 => [
 					'id' => '3',
 					'title' => 'Foo',
 					'date' => '2013-03-25'
-				),
-				5 => array(
+				],
+				5 => [
 					'id' => '5',
 					'title' => 'Bar',
 					'date' => '2012-05-20'
-				)
-			),
+				]
+			],
 			array_column($input, NULL, 'id')
 		);
 
 		$this->assertEquals(
-			array(
-				array(
+			[
+				[
 					'id' => '3',
 					'title' => 'Foo',
 					'date' => '2013-03-25'
-				),
-				array(
+				],
+				[
 					'id' => '5',
 					'title' => 'Bar',
 					'date' => '2012-05-20'
-				)
-			),
+				]
+			],
 			array_column($input, NULL, 'foo')
 		);
 
 		$this->assertEquals(
-			array(
-				array(
+			[
+				[
 					'id' => '3',
 					'title' => 'Foo',
 					'date' => '2013-03-25'
-				),
-				array(
+				],
+				[
 					'id' => '5',
 					'title' => 'Bar',
 					'date' => '2012-05-20'
-				)
-			),
+				]
+			],
 			array_column($input, NULL)
 		);
 
@@ -160,43 +160,43 @@ class standard_test extends CI_TestCase {
 
 		$fh = fopen(__FILE__, 'r', TRUE);
 		$stdClass = new stdClass();
-		$input = array(
-			array(
+		$input = [
+			[
 				'id' => 1,
 				'value' => $stdClass
-			),
-			array(
+			],
+			[
 				'id' => 2,
 				'value' => 34.2345
-			),
-			array(
+			],
+			[
 				'id' => 3,
 				'value' => TRUE
-			),
-			array(
+			],
+			[
 				'id' => 4,
 				'value' => FALSE
-			),
-			array(
+			],
+			[
 				'id' => 5,
 				'value' => NULL
-			),
-			array(
+			],
+			[
 				'id' => 6,
 				'value' => 1234
-			),
-			array(
+			],
+			[
 				'id' => 7,
 				'value' => 'Foo'
-			),
-			array(
+			],
+			[
 				'id' => 8,
 				'value' => $fh
-			)
-		);
+			]
+		];
 
 		$this->assertEquals(
-			array(
+			[
 				$stdClass,
 				34.2345,
 				TRUE,
@@ -205,12 +205,12 @@ class standard_test extends CI_TestCase {
 				1234,
 				'Foo',
 				$fh
-			),
+			],
 			array_column($input, 'value')
 		);
 
 		$this->assertEquals(
-			array(
+			[
 				1 => $stdClass,
 				2 => 34.2345,
 				3 => TRUE,
@@ -219,109 +219,109 @@ class standard_test extends CI_TestCase {
 				6 => 1234,
 				7 => 'Foo',
 				8 => $fh
-			),
+			],
 			array_column($input, 'value', 'id')
 		);
 
 		// Numeric column keys
 
-		$input = array(
-			array('aaa', '111'),
-			array('bbb', '222'),
-			array('ccc', '333', -1 => 'ddd')
-		);
+		$input = [
+			['aaa', '111'],
+			['bbb', '222'],
+			['ccc', '333', -1 => 'ddd']
+		];
 
 		$this->assertEquals(
-			array('111', '222', '333'),
+			['111', '222', '333'],
 			array_column($input, 1)
 		);
 
 		$this->assertEquals(
-			array(
+			[
 				'aaa' => '111',
 				'bbb' => '222',
 				'ccc' => '333'
-			),
+			],
 			array_column($input, 1, 0)
 		);
 
 		$this->assertEquals(
-			array(
+			[
 				'aaa' => '111',
 				'bbb' => '222',
 				'ccc' => '333'
-			),
+			],
 			array_column($input, 1, 0.123)
 		);
 
 		$this->assertEquals(
-			array(
+			[
 				0 => '111',
 				1 => '222',
 				'ddd' => '333'
-			),
+			],
 			array_column($input, 1, -1)
 		);
 
 		// Non-existing columns
 
-		$this->assertEquals(array(), array_column($input, 2));
-		$this->assertEquals(array(), array_column($input, 'foo'));
+		$this->assertEquals([], array_column($input, 2));
+		$this->assertEquals([], array_column($input, 'foo'));
 		$this->assertEquals(
-			array('aaa', 'bbb', 'ccc'),
+			['aaa', 'bbb', 'ccc'],
 			array_column($input, 0, 'foo')
 		);
-		$this->assertEquals(array(), array_column($input, 3.14));
+		$this->assertEquals([], array_column($input, 3.14));
 
 		// One-dimensional array
-		$this->assertEquals(array(), array_column(array('foo', 'bar', 'baz'), 1));
+		$this->assertEquals([], array_column(['foo', 'bar', 'baz'], 1));
 
 		// Columns not present in all rows
 
-		$input = array(
-			array('a' => 'foo', 'b' => 'bar', 'e' => 'bbb'),
-			array('a' => 'baz', 'c' => 'qux', 'd' => 'aaa'),
-			array('a' => 'eee', 'b' => 'fff', 'e' => 'ggg')
-		);
+		$input = [
+			['a' => 'foo', 'b' => 'bar', 'e' => 'bbb'],
+			['a' => 'baz', 'c' => 'qux', 'd' => 'aaa'],
+			['a' => 'eee', 'b' => 'fff', 'e' => 'ggg']
+		];
 
 		$this->assertEquals(
-			array('qux'),
+			['qux'],
 			array_column($input, 'c')
 		);
 
 		$this->assertEquals(
-			array('baz' => 'qux'),
+			['baz' => 'qux'],
 			array_column($input, 'c', 'a')
 		);
 
 		$this->assertEquals(
-			array(
+			[
 				0 => 'foo',
 				'aaa' => 'baz',
 				1 => 'eee'
-			),
+			],
 			array_column($input, 'a', 'd')
 		);
 
 		$this->assertEquals(
-			array(
+			[
 				'bbb' => 'foo',
 				0 => 'baz',
 				'ggg' => 'eee'
-			),
+			],
 			array_column($input, 'a', 'e')
 		);
 
 		$this->assertEquals(
-			array('bar', 'fff'),
+			['bar', 'fff'],
 			array_column($input, 'b')
 		);
 
 		$this->assertEquals(
-			array(
+			[
 				'foo' => 'bar',
 				'eee' => 'fff'
-			),
+			],
 			array_column($input, 'b', 'a')
 		);
 	}

--- a/tests/codeigniter/database/DB_test.php
+++ b/tests/codeigniter/database/DB_test.php
@@ -4,16 +4,16 @@ class DB_test extends CI_TestCase {
 
 	public function test_db_invalid()
 	{
-		$connection = new Mock_Database_DB(array(
-			'undefined' => array(
+		$connection = new Mock_Database_DB([
+			'undefined' => [
 				'dsn' => '',
 				'hostname' => 'undefined',
 				'username' => 'undefined',
 				'password' => 'undefined',
 				'database' => 'undefined',
 				'dbdriver' => 'undefined',
-			),
-		));
+			],
+		]);
 
 		$this->setExpectedException('RuntimeException', 'CI Error: Invalid DB driver');
 

--- a/tests/codeigniter/database/query_builder/delete_test.php
+++ b/tests/codeigniter/database/query_builder/delete_test.php
@@ -28,7 +28,7 @@ class Delete_test extends CI_TestCase {
 		$this->assertEquals('Developer', $job1->name);
 
 		// Do the delete
-		$this->db->delete('job', array('id' => 1));
+		$this->db->delete('job', ['id' => 1]);
 
 		// Check the record
 		$job1 = $this->db->where('id', 1)->get('job');
@@ -51,7 +51,7 @@ class Delete_test extends CI_TestCase {
 		$this->assertEquals('Chris Martin', $user4->name);
 
 		// Do the delete
-		$this->db->delete(array('job', 'user'), array('id' => 4));
+		$this->db->delete(['job', 'user'], ['id' => 4]);
 
 		// Check the record
 		$job4 = $this->db->where('id', 4)->get('job');

--- a/tests/codeigniter/database/query_builder/get_test.php
+++ b/tests/codeigniter/database/query_builder/get_test.php
@@ -41,7 +41,7 @@ class Get_test extends CI_TestCase {
 	 */
 	public function test_get_where()
 	{
-		$job1 = $this->db->get_where('job', array('id' => 1))->result_array();
+		$job1 = $this->db->get_where('job', ['id' => 1])->result_array();
 
 		// Dummy jobs contain 1 rows
 		$this->assertCount(1, $job1);

--- a/tests/codeigniter/database/query_builder/group_test.php
+++ b/tests/codeigniter/database/query_builder/group_test.php
@@ -58,7 +58,7 @@ class Group_test extends CI_TestCase {
 		$jobs = $this->db->select('name')
 			->from('job')
 			->group_by('name')
-			->having_in('SUM(id)', array(1, 2, 5))
+			->having_in('SUM(id)', [1, 2, 5])
 			->get()
 			->result_array();
 
@@ -75,8 +75,8 @@ class Group_test extends CI_TestCase {
 		$jobs = $this->db->select('name')
 			->from('job')
 			->group_by('name')
-			->or_having_in('SUM(id)', array(1, 5))
-			->or_having_in('SUM(id)', array(2, 6))
+			->or_having_in('SUM(id)', [1, 5])
+			->or_having_in('SUM(id)', [2, 6])
 			->get()
 			->result_array();
 
@@ -93,7 +93,7 @@ class Group_test extends CI_TestCase {
 		$jobs = $this->db->select('name')
 			->from('job')
 			->group_by('name')
-			->having_not_in('SUM(id)', array(3, 6))
+			->having_not_in('SUM(id)', [3, 6])
 			->get()
 			->result_array();
 
@@ -110,8 +110,8 @@ class Group_test extends CI_TestCase {
 		$jobs = $this->db->select('name')
 			->from('job')
 			->group_by('name')
-			->or_having_not_in('SUM(id)', array(1, 2, 3))
-			->or_having_not_in('SUM(id)', array(1, 3, 4))
+			->or_having_not_in('SUM(id)', [1, 2, 3])
+			->or_having_not_in('SUM(id)', [1, 3, 4])
 			->get()
 			->result_array();
 

--- a/tests/codeigniter/database/query_builder/insert_test.php
+++ b/tests/codeigniter/database/query_builder/insert_test.php
@@ -25,7 +25,7 @@ class Insert_test extends CI_TestCase {
 	 */
 	public function test_insert()
 	{
-		$job_data = array('id' => 1, 'name' => 'Grocery Sales', 'description' => 'Discount!');
+		$job_data = ['id' => 1, 'name' => 'Grocery Sales', 'description' => 'Discount!'];
 
 		// Do normal insert
 		$this->assertTrue($this->db->insert('job', $job_data));
@@ -44,10 +44,10 @@ class Insert_test extends CI_TestCase {
 	 */
 	public function test_insert_batch()
 	{
-		$job_datas = array(
-			array('id' => 2, 'name' => 'Commedian', 'description' => 'Theres something in your teeth'),
-			array('id' => 3, 'name' => 'Cab Driver', 'description' => 'Iam yellow'),
-		);
+		$job_datas = [
+			['id' => 2, 'name' => 'Commedian', 'description' => 'Theres something in your teeth'],
+			['id' => 3, 'name' => 'Cab Driver', 'description' => 'Iam yellow'],
+		];
 
 		// Do insert batch except for sqlite driver
 		if (strpos(DB_DRIVER, 'sqlite') === FALSE)

--- a/tests/codeigniter/database/query_builder/join_test.php
+++ b/tests/codeigniter/database/query_builder/join_test.php
@@ -63,7 +63,7 @@ class Join_test extends CI_TestCase {
 	public function test_join_escape_multiple_conditions()
 	{
 		// We just need a valid query produced, not one that makes sense
-		$fields = array($this->db->protect_identifiers('table1.field1'), $this->db->protect_identifiers('table2.field2'));
+		$fields = [$this->db->protect_identifiers('table1.field1'), $this->db->protect_identifiers('table2.field2')];
 
 		$expected = 'SELECT '.implode(', ', $fields)
 				."\nFROM ".$this->db->escape_identifiers('table1')
@@ -83,7 +83,7 @@ class Join_test extends CI_TestCase {
 	public function test_join_escape_multiple_conditions_with_parentheses()
 	{
 		// We just need a valid query produced, not one that makes sense
-		$fields = array($this->db->protect_identifiers('table1.field1'), $this->db->protect_identifiers('table2.field2'));
+		$fields = [$this->db->protect_identifiers('table1.field1'), $this->db->protect_identifiers('table2.field2')];
 
 		$expected = 'SELECT '.implode(', ', $fields)
 				."\nFROM ".$this->db->escape_identifiers('table1')

--- a/tests/codeigniter/database/query_builder/update_test.php
+++ b/tests/codeigniter/database/query_builder/update_test.php
@@ -27,7 +27,7 @@ class Update_test extends CI_TestCase {
 		$this->assertEquals('Developer', $job1->name);
 
 		// Do the update
-		$this->db->where('id', 1)->update('job', array('name' => 'Programmer'));
+		$this->db->where('id', 1)->update('job', ['name' => 'Programmer']);
 
 		// Check updated record
 		$job1 = $this->db->where('id', 1)->get('job')->row();

--- a/tests/codeigniter/database/query_builder/where_test.php
+++ b/tests/codeigniter/database/query_builder/where_test.php
@@ -46,7 +46,7 @@ class Where_test extends CI_TestCase {
 	 */
 	public function test_where_associative_array()
 	{
-		$where = array('id >' => 2, 'name !=' => 'Accountant');
+		$where = ['id >' => 2, 'name !=' => 'Accountant'];
 		$jobs = $this->db->where($where)->get('job')->result_array();
 
 		$this->assertEquals(1, count($jobs));
@@ -98,7 +98,7 @@ class Where_test extends CI_TestCase {
 	 */
 	public function test_where_in()
 	{
-		$jobs = $this->db->where_in('name', array('Politician', 'Accountant'))
+		$jobs = $this->db->where_in('name', ['Politician', 'Accountant'])
 							->get('job')
 							->result_array();
 
@@ -114,7 +114,7 @@ class Where_test extends CI_TestCase {
 	 */
 	public function test_where_not_in()
 	{
-		$jobs = $this->db->where_not_in('name', array('Politician', 'Accountant'))
+		$jobs = $this->db->where_not_in('name', ['Politician', 'Accountant'])
 							->get('job')
 							->result_array();
 

--- a/tests/codeigniter/helpers/array_helper_test.php
+++ b/tests/codeigniter/helpers/array_helper_test.php
@@ -2,12 +2,12 @@
 
 class Array_helper_test extends CI_TestCase {
 
-	public $my_array = array(
+	public $my_array = [
 		'foo'    => 'bar',
 		'sally'  => 'jim',
 		'maggie' => 'bessie',
 		'herb'   => 'cook'
-	);
+	];
 
 	public function set_up()
 	{

--- a/tests/codeigniter/helpers/date_helper_test.php
+++ b/tests/codeigniter/helpers/date_helper_test.php
@@ -147,7 +147,7 @@ class Date_helper_test extends CI_TestCase {
 
 	public function test_timezones()
 	{
-		$zones = array(
+		$zones = [
 			'UM12'		=> -12,
 			'UM11'		=> -11,
 			'UM10'		=> -10,
@@ -188,7 +188,7 @@ class Date_helper_test extends CI_TestCase {
 			'UP1275'	=> +12.75,
 			'UP13'		=> +13,
 			'UP14'		=> +14
-		);
+		];
 
 		foreach ($zones AS $test => $expected)
 		{
@@ -203,7 +203,7 @@ class Date_helper_test extends CI_TestCase {
 
 	public function test_date_range()
 	{
-		$dates = array(
+		$dates = [
 			'29-01-2012', '30-01-2012', '31-01-2012',
 			'01-02-2012', '02-02-2012', '03-02-2012',
 			'04-02-2012', '05-02-2012', '06-02-2012',
@@ -215,7 +215,7 @@ class Date_helper_test extends CI_TestCase {
 			'22-02-2012', '23-02-2012', '24-02-2012',
 			'25-02-2012', '26-02-2012', '27-02-2012',
 			'28-02-2012', '29-02-2012', '01-03-2012'
-		);
+		];
 
 		$this->assertEquals($dates, date_range(mktime(12, 0, 0, 1, 29, 2012), mktime(12, 0, 0, 3, 1, 2012), TRUE, 'd-m-Y'));
 		array_pop($dates);

--- a/tests/codeigniter/helpers/directory_helper_test.php
+++ b/tests/codeigniter/helpers/directory_helper_test.php
@@ -16,15 +16,15 @@ class Directory_helper_test extends CI_TestCase {
 	{
 		$ds = DIRECTORY_SEPARATOR;
 
-		$structure = array(
-			'libraries' => array(
+		$structure = [
+			'libraries' => [
 				'benchmark.html' => '',
-				'database' => array('active_record.html' => '', 'binds.html' => ''),
+				'database' => ['active_record.html' => '', 'binds.html' => ''],
 				'email.html' => '',
 				'0' => '',
 				'.hiddenfile.txt' => ''
-			)
-		);
+			]
+		];
 
 		vfsStream::create($structure, $this->_test_dir);
 
@@ -36,14 +36,14 @@ class Directory_helper_test extends CI_TestCase {
 		}
 
 		// test default recursive behavior
-		$expected = array(
-			'libraries'.$ds => array(
+		$expected = [
+			'libraries'.$ds => [
 				'benchmark.html',
-				'database'.$ds => array('active_record.html', 'binds.html'),
+				'database'.$ds => ['active_record.html', 'binds.html'],
 				'email.html',
 				'0'
-			)
-		);
+			]
+		];
 
 		$this->assertEquals($expected, directory_map(vfsStream::url('testDir')));
 
@@ -53,7 +53,7 @@ class Directory_helper_test extends CI_TestCase {
 		$this->assertEquals($expected, directory_map(vfsStream::url('testDir'), 0, TRUE));
 
 		// test recursion depth behavior
-		$this->assertEquals(array('libraries'.$ds), directory_map(vfsStream::url('testDir'), 1));
+		$this->assertEquals(['libraries'.$ds], directory_map(vfsStream::url('testDir'), 1));
 	}
 
 }

--- a/tests/codeigniter/helpers/file_helper_test.php
+++ b/tests/codeigniter/helpers/file_helper_test.php
@@ -77,10 +77,10 @@ class File_helper_Test extends CI_TestCase {
 		// Test the rest
 
 		// First pass in an array
-		$vals = array(
+		$vals = [
 			'name', 'server_path', 'size', 'date',
 			'readable', 'writable', 'executable', 'fileperms'
-		);
+		];
 
 		$this->_test_get_file_info($vals);
 
@@ -98,7 +98,7 @@ class File_helper_Test extends CI_TestCase {
 			->lastModified($last_modified)
 			->at($this->_test_dir);
 
-		$ret_values = array(
+		$ret_values = [
 			'name'        => 'my_file.txt',
 			'server_path' => 'vfs://my_file.txt',
 			'size'        => 57,
@@ -107,7 +107,7 @@ class File_helper_Test extends CI_TestCase {
 			'writable'    => TRUE,
 			'executable'  => TRUE,
 			'fileperms'   => 33279
-		);
+		];
 
 		$info = get_file_info(vfsStream::url('my_file.txt'), $vals);
 

--- a/tests/codeigniter/helpers/form_helper_test.php
+++ b/tests/codeigniter/helpers/form_helper_test.php
@@ -29,14 +29,14 @@ EOH;
 
 EOH;
 
-		$data = array(
+		$data = [
 			'name'        => 'username',
 			'id'          => 'username',
 			'value'       => 'johndoe',
 			'maxlength'   => '100',
 			'size'        => '50',
 			'style'       => 'width:50%',
-		);
+		];
 
 		$this->assertEquals($expected, form_input($data));
 	}
@@ -91,12 +91,12 @@ EOH;
 
 EOH;
 
-		$options = array(
+		$options = [
 			'small'		=> 'Small Shirt',
 			'med'		=> 'Medium Shirt',
 			'large'		=> 'Large Shirt',
 			'xlarge'	=> 'Extra Large Shirt',
-		);
+		];
 
 		$this->assertEquals($expected, form_dropdown('shirts', $options, 'large'));
 
@@ -110,20 +110,20 @@ EOH;
 
 EOH;
 
-		$shirts_on_sale = array('small', 'large');
+		$shirts_on_sale = ['small', 'large'];
 
 		$this->assertEquals($expected, form_dropdown('shirts', $options, $shirts_on_sale));
 
-		$options = array(
-			'Swedish Cars' => array(
+		$options = [
+			'Swedish Cars' => [
 				'volvo'	=> 'Volvo',
 				'saab'	=> 'Saab'
-			),
-			'German Cars' => array(
+			],
+			'German Cars' => [
 				'mercedes'	=> 'Mercedes',
 				'audi'		=> 'Audi'
-			)
-		);
+			]
+		];
 
 		$expected = <<<EOH
 <select name="cars" multiple="multiple">
@@ -139,7 +139,7 @@ EOH;
 
 EOH;
 
-		$this->assertEquals($expected, form_dropdown('cars', $options, array('volvo', 'audi')));
+		$this->assertEquals($expected, form_dropdown('cars', $options, ['volvo', 'audi']));
 	}
 
 	// ------------------------------------------------------------------------
@@ -156,14 +156,14 @@ EOH;
 
 EOH;
 
-		$options = array(
+		$options = [
 			'small'		=> 'Small Shirt',
 			'med'		=> 'Medium Shirt',
 			'large'		=> 'Large Shirt',
 			'xlarge'	=> 'Extra Large Shirt',
-		);
+		];
 
-		$this->assertEquals($expected, form_multiselect('shirts[]', $options, array('med', 'large')));
+		$this->assertEquals($expected, form_multiselect('shirts[]', $options, ['med', 'large']));
 	}
 
 	// ------------------------------------------------------------------------

--- a/tests/codeigniter/helpers/html_helper_test.php
+++ b/tests/codeigniter/helpers/html_helper_test.php
@@ -18,13 +18,13 @@ class Html_helper_test extends CI_TestCase {
 	public function test_heading_array_attributes()
 	{
 		// Test array of attributes
-		$this->assertEquals('<h2 class="bar" id="foo">foobar</h2>', heading('foobar', 2, array('class' => 'bar', 'id' => 'foo')));
+		$this->assertEquals('<h2 class="bar" id="foo">foobar</h2>', heading('foobar', 2, ['class' => 'bar', 'id' => 'foo']));
 	}
 
 	public function test_heading_object_attributes()
 	{
 		// Test array of attributes
-		$this->assertEquals('<h2 class="bar" id="foo">foobar</h2>', heading('foobar', 2, array('class' => 'bar', 'id' => 'foo')));
+		$this->assertEquals('<h2 class="bar" id="foo">foobar</h2>', heading('foobar', 2, ['class' => 'bar', 'id' => 'foo']));
 		$test = new stdClass;
 		$test->class = "bar";
 		$test->id = "foo";
@@ -58,7 +58,7 @@ class Html_helper_test extends CI_TestCase {
 EOH;
 
 		$expect = ltrim($expect);
-		$list = array('foo', 'bar');
+		$list = ['foo', 'bar'];
 
 		$this->assertEquals(ltrim($expect), ul($list));
 
@@ -74,7 +74,7 @@ EOH;
 
 		$this->assertEquals($expect, ul($list, 'class="test"'));
 
-		$this->assertEquals($expect, ul($list, array('class' => 'test')));
+		$this->assertEquals($expect, ul($list, ['class' => 'test']));
 	}
 
 	// ------------------------------------------------------------------------
@@ -88,17 +88,17 @@ EOH;
 
 		$this->assertEquals(
 			"<meta name=\"foo\" content=\"\" />\n",
-			meta(array('name' => 'foo'))
+			meta(['name' => 'foo'])
 		);
 
 		$this->assertEquals(
 			"<meta charset=\"foo\" />\n",
-			meta(array('name' => 'foo', 'type' => 'charset'))
+			meta(['name' => 'foo', 'type' => 'charset'])
 		);
 
 		$this->assertEquals(
 			"<meta charset=\"foo\" />\n",
-			meta(array('name' => 'foo', 'type' => 'charset'))
+			meta(['name' => 'foo', 'type' => 'charset'])
 		);
 	}
 }

--- a/tests/codeigniter/helpers/inflector_helper_test.php
+++ b/tests/codeigniter/helpers/inflector_helper_test.php
@@ -9,13 +9,13 @@ class Inflector_helper_test extends CI_TestCase {
 
 	public function test_singular()
 	{
-		$strs = array(
+		$strs = [
 			'tellies'      => 'telly',
 			'smellies'     => 'smelly',
 			'abjectnesses' => 'abjectness',
 			'smells'       => 'smell',
 			'equipment'    => 'equipment'
-		);
+		];
 
 		foreach ($strs as $str => $expect)
 		{
@@ -27,14 +27,14 @@ class Inflector_helper_test extends CI_TestCase {
 
 	public function test_plural()
 	{
-		$strs = array(
+		$strs = [
 			'telly'      => 'tellies',
 			'smelly'     => 'smellies',
 			'abjectness' => 'abjectnesses', // ref : http://en.wiktionary.org/wiki/abjectnesses
 			'smell'      => 'smells',
 			'witch'      => 'witches',
 			'equipment'  => 'equipment'
-		);
+		];
 
 		foreach ($strs as $str => $expect)
 		{
@@ -46,12 +46,12 @@ class Inflector_helper_test extends CI_TestCase {
 
 	public function test_camelize()
 	{
-		$strs = array(
+		$strs = [
 			'this is the string'	=> 'thisIsTheString',
 			'this is another one'   => 'thisIsAnotherOne',
 			'i-am-playing-a-trick'  => 'i-am-playing-a-trick',
 			'what_do_you_think-yo?' => 'whatDoYouThink-yo?',
-		);
+		];
 
 		foreach ($strs as $str => $expect)
 		{
@@ -63,12 +63,12 @@ class Inflector_helper_test extends CI_TestCase {
 
 	public function test_underscore()
 	{
-		$strs = array(
+		$strs = [
 			'this is the string'    => 'this_is_the_string',
 			'this is another one'   => 'this_is_another_one',
 			'i-am-playing-a-trick'  => 'i-am-playing-a-trick',
 			'what_do_you_think-yo?' => 'what_do_you_think-yo?',
-		);
+		];
 
 		foreach ($strs as $str => $expect)
 		{
@@ -80,12 +80,12 @@ class Inflector_helper_test extends CI_TestCase {
 
 	public function test_humanize()
 	{
-		$strs = array(
+		$strs = [
 			'this_is_the_string'    => 'This Is The String',
 			'this_is_another_one'   => 'This Is Another One',
 			'i-am-playing-a-trick'  => 'I-am-playing-a-trick',
 			'what_do_you_think-yo?' => 'What Do You Think-yo?',
-		);
+		];
 
 		foreach ($strs as $str => $expect)
 		{
@@ -97,7 +97,7 @@ class Inflector_helper_test extends CI_TestCase {
 
 	public function test_ordinal_format()
 	{
-		$strs = array(
+		$strs = [
 			1                => '1st',
 			2                => '2nd',
 			4                => '4th',
@@ -105,7 +105,7 @@ class Inflector_helper_test extends CI_TestCase {
 			12               => '12th',
 			13               => '13th',
 			'something else' => 'something else',
-		);
+		];
 
 		foreach ($strs as $str => $expect)
 		{

--- a/tests/codeigniter/helpers/language_helper_test.php
+++ b/tests/codeigniter/helpers/language_helper_test.php
@@ -5,12 +5,12 @@ class Language_helper_test extends CI_TestCase {
 	public function test_lang()
 	{
 		$this->helper('language');
-		$lang = $this->getMockBuilder('CI_Lang')->setMethods(array('line'))->getMock();
+		$lang = $this->getMockBuilder('CI_Lang')->setMethods(['line'])->getMock();
 		$lang->expects($this->any())->method('line')->will($this->returnValue(FALSE));
 		$this->ci_instance_var('lang', $lang);
 
 		$this->assertFalse(lang(1));
-		$this->assertEquals('<label for="foo" class="bar"></label>', lang(1, 'foo', array('class' => 'bar')));
+		$this->assertEquals('<label for="foo" class="bar"></label>', lang(1, 'foo', ['class' => 'bar']));
 	}
 
 }

--- a/tests/codeigniter/helpers/number_helper_test.php
+++ b/tests/codeigniter/helpers/number_helper_test.php
@@ -11,7 +11,7 @@ class Number_helper_test extends CI_TestCase {
 
 		// Mock away load, too much going on in there,
 		// we'll just check for the expected parameter
-		$lang = $this->getMockBuilder('CI_Lang')->setMethods(array('load'))->getMock();
+		$lang = $this->getMockBuilder('CI_Lang')->setMethods(['load'])->getMock();
 		$lang->expects($this->once())
 			 ->method('load')
 			 ->with($this->equalTo('number'));

--- a/tests/codeigniter/helpers/string_helper_test.php
+++ b/tests/codeigniter/helpers/string_helper_test.php
@@ -9,15 +9,15 @@ class String_helper_test extends CI_TestCase {
 
 	public function test_strip_slashes()
 	{
-		$expected = array(
+		$expected = [
 			"Is your name O'reilly?",
 			"No, my name is O'connor."
-		);
+		];
 
-		$str = array(
+		$str = [
 			"Is your name O\'reilly?",
 			"No, my name is O\'connor."
-		);
+		];
 
 		$this->assertEquals($expected, strip_slashes($str));
 	}
@@ -26,10 +26,10 @@ class String_helper_test extends CI_TestCase {
 
 	public function test_strip_quotes()
 	{
-		$strs = array(
+		$strs = [
 			'"me oh my!"'		=> 'me oh my!',
 			"it's a winner!"	=> 'its a winner!',
-		);
+		];
 
 		foreach ($strs as $str => $expect)
 		{
@@ -41,10 +41,10 @@ class String_helper_test extends CI_TestCase {
 
 	public function test_quotes_to_entities()
 	{
-		$strs = array(
+		$strs = [
 			'"me oh my!"'		=> '&quot;me oh my!&quot;',
 			"it's a winner!"	=> 'it&#39;s a winner!',
-		);
+		];
 
 		foreach ($strs as $str => $expect)
 		{
@@ -56,11 +56,11 @@ class String_helper_test extends CI_TestCase {
 
 	public function test_reduce_double_slashes()
 	{
-		$strs = array(
+		$strs = [
 			'http://codeigniter.com'		=> 'http://codeigniter.com',
 			'//var/www/html/example.com/'	=> '/var/www/html/example.com/',
 			'/var/www/html//index.php'		=> '/var/www/html/index.php'
-		);
+		];
 
 		foreach ($strs as $str => $expect)
 		{
@@ -72,20 +72,20 @@ class String_helper_test extends CI_TestCase {
 
 	public function test_reduce_multiples()
 	{
-		$strs = array(
+		$strs = [
 			'Fred, Bill,, Joe, Jimmy'	=> 'Fred, Bill, Joe, Jimmy',
 			'Ringo, John, Paul,,'		=> 'Ringo, John, Paul,'
-		);
+		];
 
 		foreach ($strs as $str => $expect)
 		{
 			$this->assertEquals($expect, reduce_multiples($str));
 		}
 
-		$strs = array(
+		$strs = [
 			'Fred, Bill,, Joe, Jimmy'	=> 'Fred, Bill, Joe, Jimmy',
 			'Ringo, John, Paul,,'		=> 'Ringo, John, Paul'
-		);
+		];
 
 		foreach ($strs as $str => $expect)
 		{

--- a/tests/codeigniter/helpers/text_helper_test.php
+++ b/tests/codeigniter/helpers/text_helper_test.php
@@ -34,10 +34,10 @@ class Text_helper_test extends CI_TestCase {
 
 	public function test_ascii_to_entities()
 	{
-		$strs = array(
+		$strs = [
 			'“‘ “test”'			=> '&#8220;&#8216; &#8220;test&#8221;',
 			'†¥¨ˆøåß∂ƒ©˙∆˚¬'	=> '&#8224;&#165;&#168;&#710;&#248;&#229;&#223;&#8706;&#402;&#169;&#729;&#8710;&#730;&#172;'
-		);
+		];
 
 		foreach ($strs as $str => $expect)
 		{
@@ -49,10 +49,10 @@ class Text_helper_test extends CI_TestCase {
 
 	public function test_entities_to_ascii()
 	{
-		$strs = array(
+		$strs = [
 			'&#8220;&#8216; &#8220;test&#8221;' => '“‘ “test”',
 			'&#8224;&#165;&#168;&#710;&#248;&#229;&#223;&#8706;&#402;&#169;&#729;&#8710;&#730;&#172;' => '†¥¨ˆøåß∂ƒ©˙∆˚¬'
-		);
+		];
 
 		foreach ($strs as $str => $expect)
 		{
@@ -73,15 +73,15 @@ class Text_helper_test extends CI_TestCase {
 
 	public function test_censored_words()
 	{
-		$censored = array('boob', 'nerd', 'ass', 'fart');
+		$censored = ['boob', 'nerd', 'ass', 'fart'];
 
-		$strs = array(
+		$strs = [
 			'Ted bobbled the ball' 			=> 'Ted bobbled the ball',
 			'Jake is a nerdo'				=> 'Jake is a nerdo',
 			'The borg will assimilate you'	=> 'The borg will assimilate you',
 			'Did Mary Fart?'				=> 'Did Mary $*#?',
 			'Jake is really a boob'			=> 'Jake is really a $*#'
-		);
+		];
 
 		foreach ($strs as $str => $expect)
 		{
@@ -110,13 +110,13 @@ class Text_helper_test extends CI_TestCase {
 	{
 		define('UTF8_ENABLED', FALSE);
 
-		$strs = array(
+		$strs = [
 			'this is a phrase'          => '<mark>this is</mark> a phrase',
 			'this is another'           => '<mark>this is</mark> another',
 			'Gimme a test, Sally'       => 'Gimme a test, Sally',
 			'Or tell me what this is'   => 'Or tell me what <mark>this is</mark>',
 			''                          => ''
-		);
+		];
 
 		foreach ($strs as $str => $expect)
 		{
@@ -130,26 +130,26 @@ class Text_helper_test extends CI_TestCase {
 
 	public function test_ellipsize()
 	{
-		$strs = array(
-			'0'		=> array(
+		$strs = [
+			'0'		=> [
 				'this is my string'				=> '&hellip; my string',
 				"here's another one"			=> '&hellip;nother one',
 				'this one is just a bit longer'	=> '&hellip;bit longer',
 				'short'							=> 'short'
-			),
-			'.5'	=> array(
+			],
+			'.5'	=> [
 				'this is my string'				=> 'this &hellip;tring',
 				"here's another one"			=> "here'&hellip;r one",
 				'this one is just a bit longer'	=> 'this &hellip;onger',
 				'short'							=> 'short'
-			),
-			'1'	=> array(
+			],
+			'1'	=> [
 				'this is my string'				=> 'this is my&hellip;',
 				"here's another one"			=> "here's ano&hellip;",
 				'this one is just a bit longer'	=> 'this one i&hellip;',
 				'short'							=> 'short'
-			),
-		);
+			],
+		];
 
 		foreach ($strs as $pos => $s)
 		{

--- a/tests/codeigniter/helpers/url_helper_test.php
+++ b/tests/codeigniter/helpers/url_helper_test.php
@@ -14,10 +14,10 @@ class Url_helper_test extends CI_TestCase {
 	{
 		define('UTF8_ENABLED', FALSE);
 
-		$words = array(
+		$words = [
 			'foo bar /' 	=> 'foo-bar',
 			'\  testing 12' => 'testing-12'
-		);
+		];
 
 		foreach ($words as $in => $out)
 		{
@@ -34,10 +34,10 @@ class Url_helper_test extends CI_TestCase {
 	{
 		define('UTF8_ENABLED', FALSE);
 
-		$words = array(
+		$words = [
 			'_foo bar_' 	=> 'foo_bar',
 			'_What\'s wrong with CSS?_' => 'Whats_wrong_with_CSS'
-		);
+		];
 
 		foreach ($words as $in => $out)
 		{
@@ -57,14 +57,14 @@ class Url_helper_test extends CI_TestCase {
 
 	public function test_auto_link_url()
 	{
-		$strings = array(
+		$strings = [
 			'www.codeigniter.com test' => '<a href="http://www.codeigniter.com">www.codeigniter.com</a> test',
 			'This is my noreply@codeigniter.com test' => 'This is my noreply@codeigniter.com test',
 			'<br />www.google.com' => '<br /><a href="http://www.google.com">www.google.com</a>',
 			'Download CodeIgniter at www.codeigniter.com. Period test.' => 'Download CodeIgniter at <a href="http://www.codeigniter.com">www.codeigniter.com</a>. Period test.',
 			'Download CodeIgniter at www.codeigniter.com, comma test' => 'Download CodeIgniter at <a href="http://www.codeigniter.com">www.codeigniter.com</a>, comma test',
 			'This one: ://codeigniter.com must not break this one: http://codeigniter.com' => 'This one: <a href="://codeigniter.com">://codeigniter.com</a> must not break this one: <a href="http://codeigniter.com">http://codeigniter.com</a>'
-		);
+		];
 
 		foreach ($strings as $in => $out)
 		{
@@ -76,9 +76,9 @@ class Url_helper_test extends CI_TestCase {
 
 	public function test_pull_675()
 	{
-		$strings = array(
+		$strings = [
 			'<br />www.google.com' => '<br /><a href="http://www.google.com">www.google.com</a>',
-		);
+		];
 
 		foreach ($strings as $in => $out)
 		{

--- a/tests/codeigniter/libraries/Calendar_test.php
+++ b/tests/codeigniter/libraries/Calendar_test.php
@@ -5,9 +5,9 @@ class Calendar_test extends CI_TestCase {
 	public function set_up()
 	{
 		// Required for get_total_days()
-		$this->ci_instance_var('load', $this->getMockBuilder('CI_Loader')->setMethods(array('helper'))->getMock());
+		$this->ci_instance_var('load', $this->getMockBuilder('CI_Loader')->setMethods(['helper'])->getMock());
 
-		$lang = $this->getMockBuilder('CI_Lang')->setMethods(array('load', 'line'))->getMock();
+		$lang = $this->getMockBuilder('CI_Lang')->setMethods(['load', 'line'])->getMock();
 		$lang->expects($this->any())->method('line')->will($this->returnValue(FALSE));
 		$this->ci_instance_var('lang', $lang);
 
@@ -18,10 +18,10 @@ class Calendar_test extends CI_TestCase {
 
 	public function test_initialize()
 	{
-		$this->calendar->initialize(array(
+		$this->calendar->initialize([
 			'month_type'	=>	'short',
 			'start_day'	=>	'monday'
-		));
+		]);
 		$this->assertEquals('short', $this->calendar->month_type);
 		$this->assertEquals('monday', $this->calendar->start_day);
 	}
@@ -65,12 +65,12 @@ class Calendar_test extends CI_TestCase {
 
 		$this->assertEquals($no_events, $this->calendar->generate(2011, 9));
 
-		$data = array(
+		$data = [
 			3  => 'http://example.com/news/article/2006/03/',
 			7  => 'http://example.com/news/article/2006/07/',
 			13 => 'http://example.com/news/article/2006/13/',
 			26 => 'http://example.com/news/article/2006/26/'
-		);
+		];
 
 		$events = '<table border="0" cellpadding="4" cellspacing="0">
 
@@ -123,7 +123,7 @@ class Calendar_test extends CI_TestCase {
 
 	public function test_get_day_names()
 	{
-		$this->assertEquals(array(
+		$this->assertEquals([
 			'Sunday',
 			'Monday',
 			'Tuesday',
@@ -131,9 +131,9 @@ class Calendar_test extends CI_TestCase {
 			'Thursday',
 			'Friday',
 			'Saturday'
-		), $this->calendar->get_day_names('long'));
+		], $this->calendar->get_day_names('long'));
 
-		$this->assertEquals(array(
+		$this->assertEquals([
 			'Sun',
 			'Mon',
 			'Tue',
@@ -141,11 +141,11 @@ class Calendar_test extends CI_TestCase {
 			'Thu',
 			'Fri',
 			'Sat'
-		), $this->calendar->get_day_names('short'));
+		], $this->calendar->get_day_names('short'));
 
 		$this->calendar->day_type = NULL;
 
-		$this->assertEquals(array(
+		$this->assertEquals([
 			'Su',
 			'Mo',
 			'Tu',
@@ -153,15 +153,15 @@ class Calendar_test extends CI_TestCase {
 			'Th',
 			'Fr',
 			'Sa'
-		), $this->calendar->get_day_names());
+		], $this->calendar->get_day_names());
 	}
 
 	// --------------------------------------------------------------------
 
 	public function test_adjust_date()
 	{
-		$this->assertEquals(array('month' => 8, 'year' => 2012), $this->calendar->adjust_date(8, 2012));
-		$this->assertEquals(array('month' => 1, 'year' => 2013), $this->calendar->adjust_date(13, 2012));
+		$this->assertEquals(['month' => 8, 'year' => 2012], $this->calendar->adjust_date(8, 2012));
+		$this->assertEquals(['month' => 1, 'year' => 2013], $this->calendar->adjust_date(13, 2012));
 	}
 
 	// --------------------------------------------------------------------
@@ -189,7 +189,7 @@ class Calendar_test extends CI_TestCase {
 
 	public function test_default_template()
 	{
-		$array = array(
+		$array = [
 			'table_open'			=> '<table border="0" cellpadding="4" cellspacing="0">',
 			'heading_row_start'		=> '<tr>',
 			'heading_previous_cell'		=> '<th><a href="{previous_url}">&lt;&lt;</a></th>',
@@ -214,7 +214,7 @@ class Calendar_test extends CI_TestCase {
 			'cal_cell_start_other'		=> '<td style="color: #666;">',
 			'cal_cell_other'		=> '{day}',
 			'cal_cell_end_other'		=> '</td>'
-		);
+		];
 
 		$this->assertEquals($array, $this->calendar->default_template());
 	}

--- a/tests/codeigniter/libraries/Driver_test.php
+++ b/tests/codeigniter/libraries/Driver_test.php
@@ -16,8 +16,8 @@ class Driver_test extends CI_TestCase {
 
 		// Mock Loader->get_package_paths
 		$paths = 'get_package_paths';
-		$ldr = $this->getMockBuilder('CI_Loader')->setMethods(array($paths))->getMock();
-		$ldr->expects($this->any())->method($paths)->will($this->returnValue(array(APPPATH, BASEPATH)));
+		$ldr = $this->getMockBuilder('CI_Loader')->setMethods([$paths])->getMock();
+		$ldr->expects($this->any())->method($paths)->will($this->returnValue([APPPATH, BASEPATH]));
 		$this->ci_instance_var('load', $ldr);
 
 		// Create mock driver library
@@ -37,7 +37,7 @@ class Driver_test extends CI_TestCase {
 		$prop = 'called';
 		$content = '<?php class '.$class.' extends CI_Driver { public $'.$prop.' = FALSE; '.
 			'public function decorate($parent) { $this->'.$prop.' = TRUE; } }';
-		$this->ci_vfs_create($file, $content, $this->ci_base_root, array('libraries', $this->name, 'drivers'));
+		$this->ci_vfs_create($file, $content, $this->ci_base_root, ['libraries', $this->name, 'drivers']);
 
 		// Make driver valid
 		$this->lib->driver_list($driver);
@@ -74,11 +74,11 @@ class Driver_test extends CI_TestCase {
 		$class = 'CI_'.$file;
 		$content = '<?php class '.$class.' extends CI_Driver {  }';
 		$this->ci_vfs_create($file, $content, $this->ci_app_root,
-			array('libraries', $this->name, 'drivers'));
+			['libraries', $this->name, 'drivers']);
 
 		// Make valid list
 		$nodriver = 'absent';
-		$this->lib->driver_list(array($driver, $nodriver));
+		$this->lib->driver_list([$driver, $nodriver]);
 
 		// Load driver
 		$this->assertNotNull($this->lib->load_driver($driver));
@@ -104,12 +104,12 @@ class Driver_test extends CI_TestCase {
 		$base = $this->name.'_'.$driver;
 		$baseclass = 'CI_'.$base;
 		$content = '<?php class '.$baseclass.' extends CI_Driver {  }';
-		$this->ci_vfs_create($base, $content, $this->ci_base_root, array('libraries', $this->name, 'drivers'));
+		$this->ci_vfs_create($base, $content, $this->ci_base_root, ['libraries', $this->name, 'drivers']);
 
 		// Create driver file
 		$class = $this->subclass.$base;
 		$content = '<?php class '.$class.' extends '.$baseclass.' {  }';
-		$this->ci_vfs_create($class, $content, $this->ci_app_root, array('libraries', $this->name, 'drivers'));
+		$this->ci_vfs_create($class, $content, $this->ci_app_root, ['libraries', $this->name, 'drivers']);
 
 		// Make valid list
 		$this->lib->driver_list($driver);
@@ -128,7 +128,7 @@ class Driver_test extends CI_TestCase {
 		$base = $this->name.'_'.$driver;
 		$class = $this->subclass.$base;
 		$content = '<?php class '.$class.' extends CI_Driver {  }';
-		$this->ci_vfs_create($class, $content, $this->ci_app_root, array('libraries', $this->name, 'drivers'));
+		$this->ci_vfs_create($class, $content, $this->ci_app_root, ['libraries', $this->name, 'drivers']);
 		$this->lib->driver_list($driver);
 
 		// Do we get an error when base class isn't found?

--- a/tests/codeigniter/libraries/Encryption_test.php
+++ b/tests/codeigniter/libraries/Encryption_test.php
@@ -46,9 +46,9 @@ class Encryption_test extends CI_TestCase {
 	 */
 	public function test_hkdf()
 	{
-		$vectors = array(
+		$vectors = [
 			// A.1: Basic test case with SHA-256
-			array(
+			[
 				'digest' => 'sha256',
 				'ikm' => "\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b",
 				'salt' => "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c",
@@ -56,9 +56,9 @@ class Encryption_test extends CI_TestCase {
 				'info' => "\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9",
 			//	'prk' => "\x07\x77\x09\x36\x2c\x2e\x32\xdf\x0d\xdc\x3f\x0d\xc4\x7b\xba\x63\x90\xb6\xc7\x3b\xb5\x0f\x9c\x31\x22\xec\x84\x4a\xd7\xc2\xb3\xe5",
 				'okm' => "\x3c\xb2\x5f\x25\xfa\xac\xd5\x7a\x90\x43\x4f\x64\xd0\x36\x2f\x2a\x2d\x2d\x0a\x90\xcf\x1a\x5a\x4c\x5d\xb0\x2d\x56\xec\xc4\xc5\xbf\x34\x00\x72\x08\xd5\xb8\x87\x18\x58\x65"
-			),
+			],
 			// A.2: Test with SHA-256 and longer inputs/outputs
-			array(
+			[
 				'digest' => 'sha256',
 				'ikm' => "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f\x20\x21\x22\x23\x24\x25\x26\x27\x28\x29\x2a\x2b\x2c\x2d\x2e\x2f\x30\x31\x32\x33\x34\x35\x36\x37\x38\x39\x3a\x3b\x3c\x3d\x3e\x3f\x40\x41\x42\x43\x44\x45\x46\x47\x48\x49\x4a\x4b\x4c\x4d\x4e\x4f",
 				'salt' => "\x60\x61\x62\x63\x64\x65\x66\x67\x68\x69\x6a\x6b\x6c\x6d\x6e\x6f\x70\x71\x72\x73\x74\x75\x76\x77\x78\x79\x7a\x7b\x7c\x7d\x7e\x7f\x80\x81\x82\x83\x84\x85\x86\x87\x88\x89\x8a\x8b\x8c\x8d\x8e\x8f\x90\x91\x92\x93\x94\x95\x96\x97\x98\x99\x9a\x9b\x9c\x9d\x9e\x9f\xa0\xa1\xa2\xa3\xa4\xa5\xa6\xa7\xa8\xa9\xaa\xab\xac\xad\xae\xaf",
@@ -66,9 +66,9 @@ class Encryption_test extends CI_TestCase {
 				'info' => "\xb0\xb1\xb2\xb3\xb4\xb5\xb6\xb7\xb8\xb9\xba\xbb\xbc\xbd\xbe\xbf\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf\xd0\xd1\xd2\xd3\xd4\xd5\xd6\xd7\xd8\xd9\xda\xdb\xdc\xdd\xde\xdf\xe0\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xeb\xec\xed\xee\xef\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xfa\xfb\xfc\xfd\xfe\xff",
 			//	'prk' => "\x06\xa6\xb8\x8c\x58\x53\x36\x1a\x06\x10\x4c\x9c\xeb\x35\xb4\x5c\xef\x76\x00\x14\x90\x46\x71\x01\x4a\x19\x3f\x40\xc1\x5f\xc2\x44",
 				'okm' => "\xb1\x1e\x39\x8d\xc8\x03\x27\xa1\xc8\xe7\xf7\x8c\x59\x6a\x49\x34\x4f\x01\x2e\xda\x2d\x4e\xfa\xd8\xa0\x50\xcc\x4c\x19\xaf\xa9\x7c\x59\x04\x5a\x99\xca\xc7\x82\x72\x71\xcb\x41\xc6\x5e\x59\x0e\x09\xda\x32\x75\x60\x0c\x2f\x09\xb8\x36\x77\x93\xa9\xac\xa3\xdb\x71\xcc\x30\xc5\x81\x79\xec\x3e\x87\xc1\x4c\x01\xd5\xc1\xf3\x43\x4f\x1d\x87",
-			),
+			],
 			// A.3: Test with SHA-256 and zero-length salt/info
-			array(
+			[
 				'digest' => 'sha256',
 				'ikm' => "\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b",
 				'salt' => '',
@@ -76,8 +76,8 @@ class Encryption_test extends CI_TestCase {
 				'info' => '',
 			//	'prk' => "\x19\xef\x24\xa3\x2c\x71\x7b\x16\x7f\x33\xa9\x1d\x6f\x64\x8b\xdf\x96\x59\x67\x76\xaf\xdb\x63\x77\xac\x43\x4c\x1c\x29\x3c\xcb\x04",
 				'okm' => "\x8d\xa4\xe7\x75\xa5\x63\xc1\x8f\x71\x5f\x80\x2a\x06\x3c\x5a\x31\xb8\xa1\x1f\x5c\x5e\xe1\x87\x9e\xc3\x45\x4e\x5f\x3c\x73\x8d\x2d\x9d\x20\x13\x95\xfa\xa4\xb6\x1a\x96\xc8",
-			)
-		);
+			]
+		];
 
 		foreach ($vectors as $test)
 		{
@@ -126,17 +126,17 @@ class Encryption_test extends CI_TestCase {
 		$key = str_repeat("\x0", 16);
 
 		// Invalid custom parameters
-		$params = array(
+		$params = [
 			// No cipher, mode or key
-			array('cipher' => 'aes-128', 'mode' => 'cbc'),
-			array('cipher' => 'aes-128', 'key' => $key),
-			array('mode' => 'cbc', 'key' => $key),
+			['cipher' => 'aes-128', 'mode' => 'cbc'],
+			['cipher' => 'aes-128', 'key' => $key],
+			['mode' => 'cbc', 'key' => $key],
 			// No HMAC key or not a valid digest
-			array('cipher' => 'aes-128', 'mode' => 'cbc', 'key' => $key),
-			array('cipher' => 'aes-128', 'mode' => 'cbc', 'key' => $key, 'hmac_digest' => 'sha1', 'hmac_key' => $key),
+			['cipher' => 'aes-128', 'mode' => 'cbc', 'key' => $key],
+			['cipher' => 'aes-128', 'mode' => 'cbc', 'key' => $key, 'hmac_digest' => 'sha1', 'hmac_key' => $key],
 			// Invalid mode
-			array('cipher' => 'aes-128', 'mode' => 'foo', 'key' => $key, 'hmac_digest' => 'sha256', 'hmac_key' => $key)
-		);
+			['cipher' => 'aes-128', 'mode' => 'foo', 'key' => $key, 'hmac_digest' => 'sha256', 'hmac_key' => $key]
+		];
 
 		for ($i = 0, $c = count($params); $i < $c; $i++)
 		{
@@ -144,12 +144,12 @@ class Encryption_test extends CI_TestCase {
 		}
 
 		// Valid parameters
-		$params = array(
+		$params = [
 			'cipher' => 'aes-128',
 			'mode' => 'cbc',
 			'key' => str_repeat("\x0", 16),
 			'hmac_key' => str_repeat("\x0", 16)
-		);
+		];
 
 		$this->assertTrue(is_array($this->encryption->__get_params($params)));
 
@@ -157,14 +157,14 @@ class Encryption_test extends CI_TestCase {
 		$params['hmac_digest'] = 'sha512';
 
 		// Including all parameters
-		$params = array(
+		$params = [
 			'cipher' => 'aes-128',
 			'mode' => 'cbc',
 			'key' => str_repeat("\x0", 16),
 			'raw_data' => TRUE,
 			'hmac_key' => str_repeat("\x0", 16),
 			'hmac_digest' => 'sha256'
-		);
+		];
 
 		$output = $this->encryption->__get_params($params);
 		unset($output['handle'], $output['cipher'], $params['raw_data'], $params['cipher']);
@@ -200,7 +200,7 @@ class Encryption_test extends CI_TestCase {
 		$key = "\xd0\xc9\x08\xc4\xde\x52\x12\x6e\xf8\xcc\xdb\x03\xea\xa0\x3a\x5c";
 
 		// Default state (AES-128/Rijndael-128 in CBC mode)
-		$this->encryption->initialize(array('key' => $key));
+		$this->encryption->initialize(['key' => $key]);
 
 		// Was the key properly set?
 		$this->assertEquals($key, $this->encryption->get_key());
@@ -208,7 +208,7 @@ class Encryption_test extends CI_TestCase {
 		$this->assertEquals($message, $this->encryption->decrypt($this->encryption->encrypt($message)));
 
 		// Try DES in ECB mode, just for the sake of changing stuff
-		$this->encryption->initialize(array('cipher' => 'des', 'mode' => 'ecb', 'key' => substr($key, 0, 8)));
+		$this->encryption->initialize(['cipher' => 'des', 'mode' => 'ecb', 'key' => substr($key, 0, 8)]);
 		$this->assertEquals($message, $this->encryption->decrypt($this->encryption->encrypt($message)));
 	}
 
@@ -224,17 +224,17 @@ class Encryption_test extends CI_TestCase {
 		$message = 'Another plain-text message.';
 
 		// A random invalid parameter
-		$this->assertFalse($this->encryption->encrypt($message, array('foo')));
-		$this->assertFalse($this->encryption->decrypt($message, array('foo')));
+		$this->assertFalse($this->encryption->encrypt($message, ['foo']));
+		$this->assertFalse($this->encryption->decrypt($message, ['foo']));
 
 		// No HMAC, binary output
-		$params = array(
+		$params = [
 			'cipher' => 'tripledes',
 			'mode' => 'cfb',
 			'key' => str_repeat("\x1", 16),
 			'base64' => FALSE,
 			'hmac' => FALSE
-		);
+		];
 
 		$ciphertext = $this->encryption->encrypt($message, $params);
 
@@ -298,78 +298,78 @@ class Encryption_test extends CI_TestCase {
 		$message = 'This is a message encrypted via MCrypt and decrypted via OpenSSL, or vice-versa.';
 
 		// Format is: <Cipher name>, <Cipher mode>, <Key size>
-		$portable = array(
-			array('aes-128', 'cbc', 16),
-			array('aes-128', 'cfb', 16),
-			array('aes-128', 'cfb8', 16),
-			array('aes-128', 'ofb', 16),
-			array('aes-128', 'ecb', 16),
-			array('aes-128', 'ctr', 16),
-			array('aes-192', 'cbc', 24),
-			array('aes-192', 'cfb', 24),
-			array('aes-192', 'cfb8', 24),
-			array('aes-192', 'ofb', 24),
-			array('aes-192', 'ecb', 24),
-			array('aes-192', 'ctr', 24),
-			array('aes-256', 'cbc', 32),
-			array('aes-256', 'cfb', 32),
-			array('aes-256', 'cfb8', 32),
-			array('aes-256', 'ofb', 32),
-			array('aes-256', 'ecb', 32),
-			array('aes-256', 'ctr', 32),
-			array('des', 'cbc', 7),
-			array('des', 'cfb', 7),
-			array('des', 'cfb8', 7),
-			array('des', 'ofb', 7),
-			array('des', 'ecb', 7),
-			array('tripledes', 'cbc', 7),
-			array('tripledes', 'cfb', 7),
-			array('tripledes', 'cfb8', 7),
-			array('tripledes', 'ofb', 7),
-			array('tripledes', 'cbc', 14),
-			array('tripledes', 'cfb', 14),
-			array('tripledes', 'cfb8', 14),
-			array('tripledes', 'ofb', 14),
-			array('tripledes', 'cbc', 21),
-			array('tripledes', 'cfb', 21),
-			array('tripledes', 'cfb8', 21),
-			array('tripledes', 'ofb', 21),
-			array('blowfish', 'cbc', 16),
-			array('blowfish', 'cfb', 16),
-			array('blowfish', 'ofb', 16),
-			array('blowfish', 'ecb', 16),
-			array('blowfish', 'cbc', 56),
-			array('blowfish', 'cfb', 56),
-			array('blowfish', 'ofb', 56),
-			array('blowfish', 'ecb', 56),
-			array('cast5', 'cbc', 11),
-			array('cast5', 'cfb', 11),
-			array('cast5', 'ofb', 11),
-			array('cast5', 'ecb', 11),
-			array('cast5', 'cbc', 16),
-			array('cast5', 'cfb', 16),
-			array('cast5', 'ofb', 16),
-			array('cast5', 'ecb', 16),
-			array('rc4', 'stream', 5),
-			array('rc4', 'stream', 8),
-			array('rc4', 'stream', 16),
-			array('rc4', 'stream', 32),
-			array('rc4', 'stream', 64),
-			array('rc4', 'stream', 128),
-			array('rc4', 'stream', 256)
-		);
-		$driver_index = array('mcrypt', 'openssl');
+		$portable = [
+			['aes-128', 'cbc', 16],
+			['aes-128', 'cfb', 16],
+			['aes-128', 'cfb8', 16],
+			['aes-128', 'ofb', 16],
+			['aes-128', 'ecb', 16],
+			['aes-128', 'ctr', 16],
+			['aes-192', 'cbc', 24],
+			['aes-192', 'cfb', 24],
+			['aes-192', 'cfb8', 24],
+			['aes-192', 'ofb', 24],
+			['aes-192', 'ecb', 24],
+			['aes-192', 'ctr', 24],
+			['aes-256', 'cbc', 32],
+			['aes-256', 'cfb', 32],
+			['aes-256', 'cfb8', 32],
+			['aes-256', 'ofb', 32],
+			['aes-256', 'ecb', 32],
+			['aes-256', 'ctr', 32],
+			['des', 'cbc', 7],
+			['des', 'cfb', 7],
+			['des', 'cfb8', 7],
+			['des', 'ofb', 7],
+			['des', 'ecb', 7],
+			['tripledes', 'cbc', 7],
+			['tripledes', 'cfb', 7],
+			['tripledes', 'cfb8', 7],
+			['tripledes', 'ofb', 7],
+			['tripledes', 'cbc', 14],
+			['tripledes', 'cfb', 14],
+			['tripledes', 'cfb8', 14],
+			['tripledes', 'ofb', 14],
+			['tripledes', 'cbc', 21],
+			['tripledes', 'cfb', 21],
+			['tripledes', 'cfb8', 21],
+			['tripledes', 'ofb', 21],
+			['blowfish', 'cbc', 16],
+			['blowfish', 'cfb', 16],
+			['blowfish', 'ofb', 16],
+			['blowfish', 'ecb', 16],
+			['blowfish', 'cbc', 56],
+			['blowfish', 'cfb', 56],
+			['blowfish', 'ofb', 56],
+			['blowfish', 'ecb', 56],
+			['cast5', 'cbc', 11],
+			['cast5', 'cfb', 11],
+			['cast5', 'ofb', 11],
+			['cast5', 'ecb', 11],
+			['cast5', 'cbc', 16],
+			['cast5', 'cfb', 16],
+			['cast5', 'ofb', 16],
+			['cast5', 'ecb', 16],
+			['rc4', 'stream', 5],
+			['rc4', 'stream', 8],
+			['rc4', 'stream', 16],
+			['rc4', 'stream', 32],
+			['rc4', 'stream', 64],
+			['rc4', 'stream', 128],
+			['rc4', 'stream', 256]
+		];
+		$driver_index = ['mcrypt', 'openssl'];
 
 		foreach ($portable as &$test)
 		{
 			// Add some randomness to the selected driver
 			$driver = mt_rand(0,1);
-			$params = array(
+			$params = [
 				'driver' => $driver_index[$driver],
 				'cipher' => $test[0],
 				'mode' => $test[1],
 				'key' => openssl_random_pseudo_bytes($test[2])
-			);
+			];
 
 			$this->encryption->initialize($params);
 			$ciphertext = $this->encryption->encrypt($message);
@@ -390,10 +390,10 @@ class Encryption_test extends CI_TestCase {
 	public function test_magic_get()
 	{
 		$this->assertNull($this->encryption->foo);
-		$this->assertEquals(array('mcrypt', 'openssl'), array_keys($this->encryption->drivers));
+		$this->assertEquals(['mcrypt', 'openssl'], array_keys($this->encryption->drivers));
 
 		// 'stream' mode is translated into an empty string for OpenSSL
-		$this->encryption->initialize(array('cipher' => 'rc4', 'mode' => 'stream'));
+		$this->encryption->initialize(['cipher' => 'rc4', 'mode' => 'stream']);
 		$this->assertEquals('stream', $this->encryption->mode);
 	}
 

--- a/tests/codeigniter/libraries/Form_validation_test.php
+++ b/tests/codeigniter/libraries/Form_validation_test.php
@@ -8,10 +8,10 @@ class Form_validation_test extends CI_TestCase {
 
 		// Create a mock loader since load->helper() looks in the wrong directories for unit tests,
 		// We'll use CI_TestCase->helper() instead
-		$loader = $this->getMockBuilder('CI_Loader')->setMethods(array('helper'))->getMock();
+		$loader = $this->getMockBuilder('CI_Loader')->setMethods(['helper'])->getMock();
 
 		// Same applies for lang
-		$lang = $this->getMockBuilder('CI_Lang')->setMethods(array('load'))->getMock();
+		$lang = $this->getMockBuilder('CI_Lang')->setMethods(['load'])->getMock();
 
 		$security = new Mock_Core_Security('UTF-8');
 		$input = new CI_Input($security);
@@ -30,66 +30,66 @@ class Form_validation_test extends CI_TestCase {
 	{
 		$this->assertFalse(
 			$this->run_rules(
-				array(array('field' => 'foo', 'label' => 'Foo Label', 'rules' => 'required')),
-				array('foo' => array())
+				[['field' => 'foo', 'label' => 'Foo Label', 'rules' => 'required']],
+				['foo' => []]
 			)
 		);
 	}
 
 	public function test_rule_required()
 	{
-		$rules = array(array('field' => 'foo', 'label' => 'Foo', 'rules' => 'is_numeric'));
+		$rules = [['field' => 'foo', 'label' => 'Foo', 'rules' => 'is_numeric']];
 
 		// Empty, not required
-		$this->assertTrue($this->run_rules($rules, array('foo' => '')));
+		$this->assertTrue($this->run_rules($rules, ['foo' => '']));
 
 		// Not required, but also not empty
-		$this->assertTrue($this->run_rules($rules, array('foo' => '123')));
-		$this->assertFalse($this->run_rules($rules, array('foo' => 'bar')));
+		$this->assertTrue($this->run_rules($rules, ['foo' => '123']));
+		$this->assertFalse($this->run_rules($rules, ['foo' => 'bar']));
 
 		// Required variations
 		$rules[0]['rules'] .= '|required';
-		$this->assertTrue($this->run_rules($rules, array('foo' => '123')));
-		$this->assertFalse($this->run_rules($rules, array('foo' => '')));
-		$this->assertFalse($this->run_rules($rules, array('foo' => ' ')));
-		$this->assertFalse($this->run_rules($rules, array('foo' => 'bar')));
+		$this->assertTrue($this->run_rules($rules, ['foo' => '123']));
+		$this->assertFalse($this->run_rules($rules, ['foo' => '']));
+		$this->assertFalse($this->run_rules($rules, ['foo' => ' ']));
+		$this->assertFalse($this->run_rules($rules, ['foo' => 'bar']));
 	}
 
 	public function test_rule_is_array()
 	{
-		$rules = array(array('field' => 'foo', 'label' => 'Foo', 'rules' => 'is_array'));
-		$this->assertTrue($this->run_rules($rules,  array('foo' => array('1', '2'))));
-		$this->assertFalse($this->run_rules($rules, array('foo' => '')));
+		$rules = [['field' => 'foo', 'label' => 'Foo', 'rules' => 'is_array']];
+		$this->assertTrue($this->run_rules($rules,  ['foo' => ['1', '2']]));
+		$this->assertFalse($this->run_rules($rules, ['foo' => '']));
 	}
 
 	public function test_rule_matches()
 	{
-		$rules = array(
-			array('field' => 'foo', 'label' => 'label', 'rules' => 'required'),
-			array('field' => 'bar', 'label' => 'label2', 'rules' => 'matches[foo]')
-		);
-		$values_base = array('foo' => 'sample');
+		$rules = [
+			['field' => 'foo', 'label' => 'label', 'rules' => 'required'],
+			['field' => 'bar', 'label' => 'label2', 'rules' => 'matches[foo]']
+		];
+		$values_base = ['foo' => 'sample'];
 
-		$this->assertTrue($this->run_rules($rules, array_merge($values_base, array('bar' => 'sample'))));
+		$this->assertTrue($this->run_rules($rules, array_merge($values_base, ['bar' => 'sample'])));
 
-		$this->assertFalse($this->run_rules($rules, array_merge($values_base, array('bar' => ''))));
-		$this->assertFalse($this->run_rules($rules, array_merge($values_base, array('bar' => 'Sample'))));
-		$this->assertFalse($this->run_rules($rules, array_merge($values_base, array('bar' => ' sample'))));
+		$this->assertFalse($this->run_rules($rules, array_merge($values_base, ['bar' => ''])));
+		$this->assertFalse($this->run_rules($rules, array_merge($values_base, ['bar' => 'Sample'])));
+		$this->assertFalse($this->run_rules($rules, array_merge($values_base, ['bar' => ' sample'])));
 	}
 
 	public function test_rule_differs()
 	{
-		$rules = array(
-			array('field' => 'foo', 'label' => 'label', 'rules' => 'required'),
-			array('field' => 'bar', 'label' => 'label2', 'rules' => 'differs[foo]')
-		);
-		$values_base = array('foo' => 'sample');
+		$rules = [
+			['field' => 'foo', 'label' => 'label', 'rules' => 'required'],
+			['field' => 'bar', 'label' => 'label2', 'rules' => 'differs[foo]']
+		];
+		$values_base = ['foo' => 'sample'];
 
-		$this->assertTrue($this->run_rules($rules, array_merge($values_base, array('bar' => 'does_not_match'))));
-		$this->assertTrue($this->run_rules($rules, array_merge($values_base, array('bar' => 'Sample'))));
-		$this->assertTrue($this->run_rules($rules, array_merge($values_base, array('bar' => ' sample'))));
+		$this->assertTrue($this->run_rules($rules, array_merge($values_base, ['bar' => 'does_not_match'])));
+		$this->assertTrue($this->run_rules($rules, array_merge($values_base, ['bar' => 'Sample'])));
+		$this->assertTrue($this->run_rules($rules, array_merge($values_base, ['bar' => ' sample'])));
 
-		$this->assertFalse($this->run_rules($rules, array_merge($values_base, array('bar' => 'sample'))));
+		$this->assertFalse($this->run_rules($rules, array_merge($values_base, ['bar' => 'sample'])));
 	}
 
 	public function test_rule_min_length()
@@ -322,20 +322,20 @@ class Form_validation_test extends CI_TestCase {
 	public function test_set_data()
 	{
 		// Reset test environment
-		$_POST = array();
+		$_POST = [];
 		$this->form_validation->reset_validation();
-		$data = array('field' => 'some_data');
+		$data = ['field' => 'some_data'];
 		$this->form_validation->set_data($data);
 		$this->form_validation->set_rules('field', 'label', 'required');
 		$this->assertTrue($this->form_validation->run());
 
 		// Test with empty array
-		$_POST = array();
+		$_POST = [];
 		$this->form_validation->reset_validation();
-		$data = array('field' => 'some_data');
+		$data = ['field' => 'some_data'];
 		$this->form_validation->set_data($data);
 		// This should do nothing. Old data will still be used
-		$this->form_validation->set_data(array());
+		$this->form_validation->set_data([]);
 		$this->form_validation->set_rules('field', 'label', 'required');
 		$this->assertTrue($this->form_validation->run());
 	}
@@ -343,18 +343,18 @@ class Form_validation_test extends CI_TestCase {
 	public function test_set_message()
 	{
 		// Reset test environment
-		$_POST = array();
+		$_POST = [];
 		$this->form_validation->reset_validation();
 		$err_message = 'What a terrible error!';
-		$rules = array(
-			array(
+		$rules = [
+			[
 				'field' => 'req_field',
 				'label' => 'label',
 				'rules' => 'required'
-			)
-		);
-		$errorless_data = array('req_field' => 'some text');
-		$erroneous_data = array('req_field' => '');
+			]
+		];
+		$errorless_data = ['req_field' => 'some text'];
+		$erroneous_data = ['req_field' => ''];
 
 		$this->form_validation->set_message('required', $err_message);
 		$this->form_validation->set_data($erroneous_data);
@@ -377,7 +377,7 @@ class Form_validation_test extends CI_TestCase {
 		$suffix = '</div>';
 		$this->form_validation->set_error_delimiters($prefix, $suffix);
 		$this->form_validation->set_rules('foo', 'label', 'required');
-		$_POST = array('foo' => '');
+		$_POST = ['foo' => ''];
 		$this->form_validation->run();
 		$error_msg = $this->form_validation->error('foo');
 
@@ -391,7 +391,7 @@ class Form_validation_test extends CI_TestCase {
 		$error_message = 'What a terrible error!';
 		$this->form_validation->set_message('required', $error_message);
 		$this->form_validation->set_rules('foo', 'label', 'required');
-		$_POST = array('foo' => '');
+		$_POST = ['foo' => ''];
 		$this->form_validation->run();
 		$error_array = $this->form_validation->error_array();
 		$this->assertEquals($error_message, $error_array['foo']);
@@ -408,7 +408,7 @@ class Form_validation_test extends CI_TestCase {
 		$this->form_validation->set_error_delimiters($prefix_default, $suffix_default);
 		$this->form_validation->set_message('required', $error_message);
 		$this->form_validation->set_rules('foo', 'label', 'required');
-		$_POST = array('foo' => '');
+		$_POST = ['foo' => ''];
 		$this->form_validation->run();
 
 		$this->assertEquals($prefix_default.$error_message.$suffix_default."\n", $this->form_validation->error_string());
@@ -418,7 +418,7 @@ class Form_validation_test extends CI_TestCase {
 
 		$this->form_validation->reset_validation();
 		$this->form_validation->set_rules('foo', 'label', 'required');
-		$_POST = array('foo' => 'bar');
+		$_POST = ['foo' => 'bar'];
 		$this->form_validation->run();
 		$this->assertEquals('', $this->form_validation->error_string());
 	}
@@ -427,23 +427,23 @@ class Form_validation_test extends CI_TestCase {
 	{
 		// form_validation->run() is tested in many of the other unit tests
 		// This test will only test run(group='') when group is not empty
-		$config = array(
-			'pass' => array(
-				array(
+		$config = [
+			'pass' => [
+				[
 					'field' => 'username',
 					'label' => 'user',
 					'rules' => 'alpha_numeric'
-				)
-			),
-			'fail' => array(
-				array(
+				]
+			],
+			'fail' => [
+				[
 					'field' => 'username',
 					'label' => 'user',
 					'rules' => 'alpha'
-				)
-			)
-		);
-		$_POST = array('username' => 'foo42');
+				]
+			]
+		];
+		$_POST = ['username' => 'foo42'];
 		$form_validation = new CI_Form_validation($config);
 		$this->assertTrue($form_validation->run('pass'));
 
@@ -475,7 +475,7 @@ class Form_validation_test extends CI_TestCase {
 
 		// No post data yet: should return the default value provided
 		$this->assertEquals($default, $this->form_validation->set_value('foo', $default));
-		$_POST = array('foo' => 'foo', 'bar' => array('bar1', 'bar2'));
+		$_POST = ['foo' => 'foo', 'bar' => ['bar1', 'bar2']];
 		$this->form_validation->run();
 		$this->assertEquals('foo', $this->form_validation->set_value('foo', $default));
 		$this->assertEquals('bar1', $this->form_validation->set_value('bar[]', $default));
@@ -486,7 +486,7 @@ class Form_validation_test extends CI_TestCase {
 	{
 		// Test 1: No options selected
 		$this->form_validation->reset_validation();
-		$_POST = array();
+		$_POST = [];
 		$this->form_validation->run();
 
 		$this->assertEquals('', $this->form_validation->set_select('select', 'foo'));
@@ -495,7 +495,7 @@ class Form_validation_test extends CI_TestCase {
 		// Test 2: 1 option selected
 		$this->form_validation->reset_validation();
 		$this->form_validation->set_rules('select', 'label', 'alpha_numeric');
-		$_POST = array('select' => 'foo');
+		$_POST = ['select' => 'foo'];
 		$this->form_validation->run();
 
 		$this->assertEquals(' selected="selected"', $this->form_validation->set_select('select', 'foo'));
@@ -506,7 +506,7 @@ class Form_validation_test extends CI_TestCase {
 		// Test 3: Multiple options selected
 		$this->form_validation->reset_validation();
 		$this->form_validation->set_rules('select[]', 'label', 'alpha_numeric');
-		$_POST = array('select' => array('foo', 'bar'));
+		$_POST = ['select' => ['foo', 'bar']];
 		$this->form_validation->run();
 
 		$this->assertEquals(' selected="selected"', $this->form_validation->set_select('select[]', 'foo'));
@@ -521,7 +521,7 @@ class Form_validation_test extends CI_TestCase {
 	{
 		// Test 1: No options selected
 		$this->form_validation->reset_validation();
-		$_POST = array();
+		$_POST = [];
 		$this->form_validation->run();
 
 		$this->assertEquals('', $this->form_validation->set_radio('select', 'foo'));
@@ -531,7 +531,7 @@ class Form_validation_test extends CI_TestCase {
 		// Test 2: 1 option selected
 		$this->form_validation->reset_validation();
 		$this->form_validation->set_rules('select', 'label', 'alpha_numeric');
-		$_POST = array('select' => 'foo');
+		$_POST = ['select' => 'foo'];
 		$this->form_validation->run();
 
 		$this->assertEquals(' checked="checked"', $this->form_validation->set_radio('select', 'foo'));
@@ -542,7 +542,7 @@ class Form_validation_test extends CI_TestCase {
 		// Test 3: Multiple options checked
 		$this->form_validation->reset_validation();
 		$this->form_validation->set_rules('select[]', 'label', 'alpha_numeric');
-		$_POST = array('select' => array('foo', 'bar'));
+		$_POST = ['select' => ['foo', 'bar']];
 		$this->form_validation->run();
 
 		$this->assertEquals(' checked="checked"', $this->form_validation->set_radio('select[]', 'foo'));
@@ -557,7 +557,7 @@ class Form_validation_test extends CI_TestCase {
 	{
 		// Test 1: No options selected
 		$this->form_validation->reset_validation();
-		$_POST = array();
+		$_POST = [];
 		$this->form_validation->run();
 
 		$this->assertEquals('', $this->form_validation->set_checkbox('select', 'foo'));
@@ -566,7 +566,7 @@ class Form_validation_test extends CI_TestCase {
 		// Test 2: 1 option selected
 		$this->form_validation->reset_validation();
 		$this->form_validation->set_rules('select', 'label', 'alpha_numeric');
-		$_POST = array('select' => 'foo');
+		$_POST = ['select' => 'foo'];
 		$this->form_validation->run();
 
 		$this->assertEquals(' checked="checked"', $this->form_validation->set_checkbox('select', 'foo'));
@@ -577,7 +577,7 @@ class Form_validation_test extends CI_TestCase {
 		// Test 3: Multiple options selected
 		$this->form_validation->reset_validation();
 		$this->form_validation->set_rules('select[]', 'label', 'alpha_numeric');
-		$_POST = array('select' => array('foo', 'bar'));
+		$_POST = ['select' => ['foo', 'bar']];
 		$this->form_validation->run();
 
 		$this->assertEquals(' checked="checked"', $this->form_validation->set_checkbox('select[]', 'foo'));
@@ -612,7 +612,7 @@ class Form_validation_test extends CI_TestCase {
 
 	public function test_validated_data_assignment()
 	{
-		$_POST = $post_original = array('foo' => ' bar ', 'bar' => 'baz');
+		$_POST = $post_original = ['foo' => ' bar ', 'bar' => 'baz'];
 
 		$this->form_validation->set_data($_POST);
 		$this->form_validation->set_rules('foo', 'Foo', 'required|trim');
@@ -622,10 +622,10 @@ class Form_validation_test extends CI_TestCase {
 
 		$this->assertTrue($validation_result);
 		$this->assertEquals($post_original, $_POST);
-		$this->assertEquals(array('foo' => 'bar', 'bar' => 'baz'), $data_processed);
+		$this->assertEquals(['foo' => 'bar', 'bar' => 'baz'], $data_processed);
 
 		$this->form_validation->reset_validation();
-		$_POST = array();
+		$_POST = [];
 	}
 
 	/**
@@ -637,7 +637,7 @@ class Form_validation_test extends CI_TestCase {
 	public function run_rules($rules, $values)
 	{
 		$this->form_validation->reset_validation();
-		$_POST = array();
+		$_POST = [];
 
 		$this->form_validation->set_rules($rules);
 		foreach ($values as $field => $value)

--- a/tests/codeigniter/libraries/Parser_test.php
+++ b/tests/codeigniter/libraries/Parser_test.php
@@ -35,10 +35,10 @@ class Parser_test extends CI_TestCase {
 
 	public function test_parse_string()
 	{
-		$data = array(
+		$data = [
 			'title' => 'Page Title',
 			'body' => 'Lorem ipsum dolor sit amet.'
-		);
+		];
 
 		$template = "{title}\n{body}";
 
@@ -67,10 +67,10 @@ class Parser_test extends CI_TestCase {
 
 	private function _parse_var_pair()
 	{
-		$data = array(
+		$data = [
 			'title'		=> 'Super Heroes',
-			'powers'	=> array(array('invisibility' => 'yes', 'flying' => 'no'))
-		);
+			'powers'	=> [['invisibility' => 'yes', 'flying' => 'no']]
+		];
 
 		$template = "{title}\n{powers}{invisibility}\n{flying}{/powers}\nsecond:{powers} {invisibility} {flying}{/powers}";
 
@@ -81,10 +81,10 @@ class Parser_test extends CI_TestCase {
 
 	private function _mismatched_var_pair()
 	{
-		$data = array(
+		$data = [
 			'title'		=> 'Super Heroes',
-			'powers'	=> array(array('invisibility' => 'yes', 'flying' => 'no'))
-		);
+			'powers'	=> [['invisibility' => 'yes', 'flying' => 'no']]
+		];
 
 		$template = "{title}\n{powers}{invisibility}\n{flying}";
 		$result = "Super Heroes\n{powers}{invisibility}\n{flying}";

--- a/tests/codeigniter/libraries/Session_test.php
+++ b/tests/codeigniter/libraries/Session_test.php
@@ -5,12 +5,12 @@
  */
 class Session_test extends CI_TestCase {
 
-	protected $settings = array(
+	protected $settings = [
 		'use_cookies' => 0,
 		'use_only_cookies' => 0,
 		'cache_limiter' => FALSE
-	);
-	protected $setting_vals = array();
+	];
+	protected $setting_vals = [];
 	protected $cookie_vals;
 	protected $session;
 
@@ -28,7 +28,7 @@ return;
 
 		// Start with clean environment
 		$this->cookie_vals = $_COOKIE;
-		$_COOKIE = array();
+		$_COOKIE = [];
 
 		// Set subclass prefix to match our mock
 		$this->ci_set_config('subclass_prefix', 'Mock_Libraries_');
@@ -44,7 +44,7 @@ return;
 		$this->ci_vfs_clone('system/helpers/string_helper.php');
 
 		// Attach session instance locally
-		$config = array(
+		$config = [
 			'sess_encrypt_cookie' => FALSE,
 			'sess_use_database' => FALSE,
 			'sess_table_name' => '',
@@ -61,7 +61,7 @@ return;
 			'time_reference' => 'local',
 			'cookie_prefix' => '',
 			'encryption_key' => 'foobar'
-		);
+		];
 		$this->session = new Mock_Libraries_Session($config);
 	}
 
@@ -73,7 +73,7 @@ return;
 return;
 		// Restore environment
 		if (session_id()) session_destroy();
-		$_SESSION = array();
+		$_SESSION = [];
 		$_COOKIE = $this->cookie_vals;
 
 		// Restore settings
@@ -144,20 +144,20 @@ return;
 	{
 return;
 		// Set a specific series of data for each driver
-		$cdata = array(
+		$cdata = [
 			'one' => 'first',
 			'two' => 'second',
 			'three' => 'third',
 			'foo' => 'bar',
 			'bar' => 'baz'
-		);
-		$ndata = array(
+		];
+		$ndata = [
 			'one' => 'gold',
 			'two' => 'silver',
 			'three' => 'bronze',
 			'foo' => 'baz',
 			'bar' => 'foo'
-		);
+		];
 		$this->session->cookie->set_userdata($cdata);
 		$this->session->native->set_userdata($ndata);
 
@@ -266,27 +266,27 @@ return;
 	{
 return;
 		// Set flashdata array for each driver
-		$cdata = array(
+		$cdata = [
 			'one' => 'first',
 			'two' => 'second',
 			'three' => 'third',
 			'foo' => 'bar',
 			'bar' => 'baz'
-		);
-		$ndata = array(
+		];
+		$ndata = [
 			'one' => 'gold',
 			'two' => 'silver',
 			'three' => 'bronze',
 			'foo' => 'baz',
 			'bar' => 'foo'
-		);
-		$kdata = array(
+		];
+		$kdata = [
 			'one',
 			'two',
 			'three',
 			'foo',
 			'bar'
-		);
+		];
 		$this->session->cookie->set_flashdata($cdata);
 		$this->session->native->set_flashdata($ndata);
 
@@ -320,20 +320,20 @@ return;
 	{
 return;
 		// Set a specific series of data for each driver
-		$cdata = array(
+		$cdata = [
 			'one' => 'first',
 			'two' => 'second',
 			'three' => 'third',
 			'foo' => 'bar',
 			'bar' => 'baz'
-		);
-		$ndata = array(
+		];
+		$ndata = [
 			'one' => 'gold',
 			'two' => 'silver',
 			'three' => 'bronze',
 			'foo' => 'baz',
 			'bar' => 'foo'
-		);
+		];
 		$this->session->cookie->set_flashdata($cdata);
 		$this->session->native->set_flashdata($ndata);
 

--- a/tests/codeigniter/libraries/Table_test.php
+++ b/tests/codeigniter/libraries/Table_test.php
@@ -15,7 +15,7 @@ class Table_test extends CI_TestCase {
 	{
 		$this->assertFalse($this->table->set_template('not an array'));
 
-		$template = array('a' => 'b');
+		$template = ['a' => 'b'];
 
 		$this->table->set_template($template);
 		$this->assertEquals($template, $this->table->template);
@@ -45,11 +45,11 @@ class Table_test extends CI_TestCase {
 		$this->table->set_heading('name', 'color', 'size');
 
 		$this->assertEquals(
-			array(
-				array('data' => 'name'),
-				array('data' => 'color'),
-				array('data' => 'size')
-			),
+			[
+				['data' => 'name'],
+				['data' => 'color'],
+				['data' => 'size']
+			],
 			$this->table->heading
 		);
 	}
@@ -70,11 +70,11 @@ class Table_test extends CI_TestCase {
 		$this->assertEquals(count($this->table->rows), 3);
 
 		$this->assertEquals(
-			array(
-				array('data' => 'your'),
-				array('data' => 'pony'),
-				array('data' => 'stinks')
-			),
+			[
+				['data' => 'your'],
+				['data' => 'pony'],
+				['data' => 'stinks']
+			],
 			$this->table->rows[1]
 		);
 	}
@@ -84,30 +84,30 @@ class Table_test extends CI_TestCase {
 
 	public function test_prep_args()
 	{
-		$expected = array(
-			array('data' => 'name'),
-			array('data' => 'color'),
-			array('data' => 'size')
-		);
+		$expected = [
+			['data' => 'name'],
+			['data' => 'color'],
+			['data' => 'size']
+		];
 
 		$this->assertEquals(
 			$expected,
-			$this->table->prep_args(array('name', 'color', 'size'))
+			$this->table->prep_args(['name', 'color', 'size'])
 		);
 
 		// with cell attributes
 		// need to add that new argument row to our expected outcome
-		$expected[] = array('data' => 'weight', 'class' => 'awesome');
+		$expected[] = ['data' => 'weight', 'class' => 'awesome'];
 
 		$this->assertEquals(
 			$expected,
-			$this->table->prep_args(array('name', 'color', 'size', array('data' => 'weight', 'class' => 'awesome')))
+			$this->table->prep_args(['name', 'color', 'size', ['data' => 'weight', 'class' => 'awesome']])
 		);
 	}
 
 	public function test_default_template_keys()
 	{
-		$keys = array(
+		$keys = [
 			'table_open',
 			'thead_open', 'thead_close',
 			'heading_row_start', 'heading_row_end', 'heading_cell_start', 'heading_cell_end',
@@ -115,7 +115,7 @@ class Table_test extends CI_TestCase {
 			'row_start', 'row_end', 'cell_start', 'cell_end',
 			'row_alt_start', 'row_alt_end', 'cell_alt_start', 'cell_alt_end',
 			'table_close'
-		);
+		];
 
 		foreach ($keys as $key)
 		{
@@ -128,14 +128,14 @@ class Table_test extends CI_TestCase {
 		$this->assertFalse($this->table->set_template('invalid_junk'));
 
 		// non default key
-		$this->table->set_template(array('nonsense' => 'foo'));
+		$this->table->set_template(['nonsense' => 'foo']);
 		$this->table->compile_template();
 
 		$this->assertArrayHasKey('nonsense', $this->table->template);
 		$this->assertEquals('foo', $this->table->template['nonsense']);
 
 		// override default
-		$this->table->set_template(array('table_close' => '</table junk>'));
+		$this->table->set_template(['table_close' => '</table junk>']);
 		$this->table->compile_template();
 
 		$this->assertArrayHasKey('table_close', $this->table->template);
@@ -146,15 +146,15 @@ class Table_test extends CI_TestCase {
 	{
 		// Test bogus parameters
 		$this->assertFalse($this->table->make_columns('invalid_junk'));
-		$this->assertFalse($this->table->make_columns(array()));
-		$this->assertFalse($this->table->make_columns(array('one', 'two'), '2.5'));
+		$this->assertFalse($this->table->make_columns([]));
+		$this->assertFalse($this->table->make_columns(['one', 'two'], '2.5'));
 
 		// Now on to the actual column creation
 
-		$five_values = array(
+		$five_values = [
 			'Laura', 'Red', '15',
 			'Katie', 'Blue'
-		);
+		];
 
 		// No column count - no changes to the array
 		$this->assertEquals(
@@ -164,10 +164,10 @@ class Table_test extends CI_TestCase {
 
 		// Column count of 3 leaves us with one &nbsp;
 		$this->assertEquals(
-			array(
-				array('Laura', 'Red', '15'),
-				array('Katie', 'Blue', '&nbsp;')
-			),
+			[
+				['Laura', 'Red', '15'],
+				['Katie', 'Blue', '&nbsp;']
+			],
 			$this->table->make_columns($five_values, 3)
 		);
 	}
@@ -177,10 +177,10 @@ class Table_test extends CI_TestCase {
 		$this->table->set_heading('Name', 'Color', 'Size');
 
 		// Make columns changes auto_heading
-		$rows = $this->table->make_columns(array(
+		$rows = $this->table->make_columns([
 			'Laura', 'Red', '15',
 			'Katie', 'Blue'
-		), 3);
+		], 3);
 
 		foreach ($rows as $row)
 		{
@@ -200,11 +200,11 @@ class Table_test extends CI_TestCase {
 
 	public function test_set_from_array()
 	{
-		$data = array(
-			array('name', 'color', 'number'),
-			array('Laura', 'Red', '22'),
-			array('Katie', 'Blue')
-		);
+		$data = [
+			['name', 'color', 'number'],
+			['Laura', 'Red', '22'],
+			['Katie', 'Blue']
+		];
 
 		$this->table->auto_heading = FALSE;
 		$this->table->set_from_array($data);
@@ -215,18 +215,18 @@ class Table_test extends CI_TestCase {
 		$this->table->set_from_array($data);
 		$this->assertEquals(count($this->table->rows), 2);
 
-		$expected = array(
-			array('data' => 'name'),
-			array('data' => 'color'),
-			array('data' => 'number')
-		);
+		$expected = [
+			['data' => 'name'],
+			['data' => 'color'],
+			['data' => 'number']
+		];
 
 		$this->assertEquals($expected, $this->table->heading);
 
-		$expected = array(
-			array('data' => 'Katie'),
-			array('data' => 'Blue'),
-		);
+		$expected = [
+			['data' => 'Katie'],
+			['data' => 'Blue'],
+		];
 
 		$this->assertEquals($expected, $this->table->rows[1]);
 	}
@@ -242,17 +242,17 @@ class Table_test extends CI_TestCase {
 
 		$this->table->set_from_db_result($db_result);
 
-		$expected = array(
-			array('data' => 'name'),
-			array('data' => 'email')
-		);
+		$expected = [
+			['data' => 'name'],
+			['data' => 'email']
+		];
 
 		$this->assertEquals($expected, $this->table->heading);
 
-		$expected = array(
-			'name' => array('data' => 'Foo Bar'),
-			'email' => array('data' => 'foo@bar.com'),
-		);
+		$expected = [
+			'name' => ['data' => 'Foo Bar'],
+			'email' => ['data' => 'foo@bar.com'],
+		];
 
 		$this->assertEquals($expected, $this->table->rows[1]);
 	}
@@ -260,12 +260,12 @@ class Table_test extends CI_TestCase {
 	public function test_generate()
 	{
 		// Prepare the data
-		$data = array(
-			array('Name', 'Color', 'Size'),
-			array('Fred', 'Blue', 'Small'),
-			array('Mary', 'Red', 'Large'),
-			array('John', 'Green', 'Medium')
-		);
+		$data = [
+			['Name', 'Color', 'Size'],
+			['Fred', 'Blue', 'Small'],
+			['Mary', 'Red', 'Large'],
+			['John', 'Green', 'Medium']
+		];
 
 		$table = $this->table->generate($data);
 
@@ -287,14 +287,14 @@ class DB_result_dummy extends CI_DB_result
 {
 	public function list_fields()
 	{
-		return array('name', 'email');
+		return ['name', 'email'];
 	}
 
 	public function result_array()
 	{
-		return array(
-			array('name' => 'John Doe', 'email' => 'john@doe.com'),
-			array('name' => 'Foo Bar', 'email' => 'foo@bar.com')
-		);
+		return [
+			['name' => 'John Doe', 'email' => 'john@doe.com'],
+			['name' => 'Foo Bar', 'email' => 'foo@bar.com']
+		];
 	}
 }

--- a/tests/codeigniter/libraries/Typography_test.php
+++ b/tests/codeigniter/libraries/Typography_test.php
@@ -17,7 +17,7 @@ class Typography_test extends CI_TestCase {
 	 */
 	public function test_format_characters()
 	{
-		$strs = array(
+		$strs = [
 			'"double quotes"' 				=> '&#8220;double quotes&#8221;',
 			'"testing" in "theory" that is' => '&#8220;testing&#8221; in &#8220;theory&#8221; that is',
 			"Here's what I'm" 				=> 'Here&#8217;s what I&#8217;m',
@@ -29,7 +29,7 @@ class Typography_test extends CI_TestCase {
 			'foo..'							=> 'foo..',
 			'foo...bar.'					=> 'foo&#8230;bar.',
 			'test.  new'					=> 'test.&nbsp; new',
-		);
+		];
 
 		foreach ($strs as $str => $expected)
 		{
@@ -109,10 +109,10 @@ EOH;
 
 	private function _standardize_new_lines()
 	{
-		$strs = array(
+		$strs = [
 			"My string\rhas return characters"	=> "<p>My string<br />\nhas return characters</p>",
 			'This one does not!' 				=> '<p>This one does not!</p>'
-		);
+		];
 
 		foreach ($strs as $str => $expect)
 		{

--- a/tests/codeigniter/libraries/Upload_test.php
+++ b/tests/codeigniter/libraries/Upload_test.php
@@ -7,7 +7,7 @@ class Upload_test extends CI_TestCase {
 		$ci = $this->ci_instance();
 		$ci->upload = new CI_Upload();
 		$ci->security = new Mock_Core_Security('UTF-8');
-		$ci->lang = $this->getMockBuilder('CI_Lang')->setMethods(array('load', 'line'))->getMock();
+		$ci->lang = $this->getMockBuilder('CI_Lang')->setMethods(['load', 'line'])->getMock();
 		$ci->lang->expects($this->any())->method('line')->will($this->returnValue(FALSE));
 		$this->upload = $ci->upload;
 	}
@@ -19,10 +19,10 @@ class Upload_test extends CI_TestCase {
 		// via __construct
 
 		$upload = new CI_Upload(
-			array(
+			[
 				'file_name' => 'foo',
 				'file_ext_tolower' => TRUE
-			)
+			]
 		);
 
 		$reflection = new ReflectionClass($upload);
@@ -34,13 +34,13 @@ class Upload_test extends CI_TestCase {
 
 		// reset (defaults to true)
 
-		$upload->initialize(array('file_name' => 'bar'));
+		$upload->initialize(['file_name' => 'bar']);
 		$this->assertEquals('bar', $upload->file_name);
 		$this->assertFalse($upload->file_ext_tolower);
 
 		// no reset
 
-		$upload->initialize(array('file_ext_tolower' => TRUE), FALSE);
+		$upload->initialize(['file_ext_tolower' => TRUE], FALSE);
 		$this->assertTrue($upload->file_ext_tolower);
 		$this->assertEquals('bar', $upload->file_name);
 	}
@@ -56,7 +56,7 @@ class Upload_test extends CI_TestCase {
 
 	function test_data()
 	{
-		$data = array(
+		$data = [
 				'file_name'		=> 'hello.txt',
 				'file_type'		=> 'text/plain',
 				'file_path'		=> '/tmp/',
@@ -71,7 +71,7 @@ class Upload_test extends CI_TestCase {
 				'image_height'		=> '',
 				'image_type'		=> '',
 				'image_size_str'	=> ''
-			);
+			];
 
 		$this->upload->set_upload_path('/tmp/');
 
@@ -136,7 +136,7 @@ class Upload_test extends CI_TestCase {
 		$this->assertEquals('*', $this->upload->allowed_types);
 
 		$this->upload->set_allowed_types('foo|bar');
-		$this->assertEquals(array('foo', 'bar'), $this->upload->allowed_types);
+		$this->assertEquals(['foo', 'bar'], $this->upload->allowed_types);
 	}
 
 	function test_set_image_properties()
@@ -144,12 +144,12 @@ class Upload_test extends CI_TestCase {
 		$this->upload->file_type = 'image/gif';
 		$this->upload->file_temp = realpath(PROJECT_BASE.'tests/mocks/uploads/ci_logo.gif');
 
-		$props = array(
+		$props = [
 			'image_width'	=>	170,
 			'image_height'	=>	73,
 			'image_type'	=>	'gif',
 			'image_size_str'	=>	'width="170" height="73"'
-		);
+		];
 
 		$this->upload->set_image_properties($this->upload->file_temp);
 
@@ -179,7 +179,7 @@ class Upload_test extends CI_TestCase {
 
 	function test_is_allowed_filetype()
 	{
-		$this->upload->allowed_types = array('html', 'gif');
+		$this->upload->allowed_types = ['html', 'gif'];
 
 		$this->upload->file_ext = '.txt';
 		$this->upload->file_type = 'text/plain';
@@ -276,9 +276,9 @@ class Upload_test extends CI_TestCase {
 
 	function test_set_error()
 	{
-		$errors = array(
+		$errors = [
 			'An error!'
-		);
+		];
 
 		$another = 'Another error!';
 

--- a/tests/codeigniter/libraries/Useragent_test.php
+++ b/tests/codeigniter/libraries/Useragent_test.php
@@ -83,19 +83,19 @@ class UserAgent_test extends CI_TestCase {
 	public function test_charsets()
 	{
 		$_SERVER['HTTP_ACCEPT_CHARSET'] = 'utf8';
-		$this->agent->charsets = array();
+		$this->agent->charsets = [];
 		$this->agent->charsets();
 		$this->assertTrue($this->agent->accept_charset('utf8'));
 		$this->assertFalse($this->agent->accept_charset('foo'));
 		$this->assertEquals('utf8', $this->agent->charsets[0]);
 
 		$_SERVER['HTTP_ACCEPT_CHARSET'] = '';
-		$this->agent->charsets = array();
+		$this->agent->charsets = [];
 		$this->assertFalse($this->agent->accept_charset());
 		$this->assertEquals('Undefined', $this->agent->charsets[0]);
 
 		$_SERVER['HTTP_ACCEPT_CHARSET'] = 'iso-8859-5, unicode-1-1; q=0.8';
-		$this->agent->charsets = array();
+		$this->agent->charsets = [];
 		$this->assertTrue($this->agent->accept_charset('iso-8859-5'));
 		$this->assertTrue($this->agent->accept_charset('unicode-1-1'));
 		$this->assertFalse($this->agent->accept_charset('foo'));

--- a/tests/mocks/autoloader.php
+++ b/tests/mocks/autoloader.php
@@ -13,7 +13,7 @@ function autoload($class)
 {
 	$dir = realpath(dirname(__FILE__)).DIRECTORY_SEPARATOR;
 
-	$ci_core = array(
+	$ci_core = [
 		'Benchmark',
 		'Config',
 		'Controller',
@@ -29,9 +29,9 @@ function autoload($class)
 		'Security',
 		'URI',
 		'Utf8'
-	);
+	];
 
-	$ci_libraries = array(
+	$ci_libraries = [
 		'Calendar',
 		'Driver_Library',
 		'Email',
@@ -53,13 +53,13 @@ function autoload($class)
 	   	'User_agent',
 		'Xmlrpc',
 		'Zip'
-	);
+	];
 
-	$ci_drivers = array('Session', 'Cache');
+	$ci_drivers = ['Session', 'Cache'];
 
 	if (strpos($class, 'Mock_') === 0)
 	{
-		$class = strtolower(str_replace(array('Mock_', '_'), array('', DIRECTORY_SEPARATOR), $class));
+		$class = strtolower(str_replace(['Mock_', '_'], ['', DIRECTORY_SEPARATOR], $class));
 	}
 	elseif (strpos($class, 'CI_') === 0)
 	{
@@ -99,7 +99,7 @@ function autoload($class)
 		elseif (strpos($class, 'CI_DB') === 0)
 		{
 			$dir = SYSTEM_PATH.'database'.DIRECTORY_SEPARATOR;
-			$file = $dir.str_replace(array('CI_DB','active_record'), array('DB', 'active_rec'), $subclass).'.php';
+			$file = $dir.str_replace(['CI_DB','active_record'], ['DB', 'active_rec'], $subclass).'.php';
 		}
 		else
 		{

--- a/tests/mocks/ci_testcase.php
+++ b/tests/mocks/ci_testcase.php
@@ -8,7 +8,7 @@ class CI_TestCase extends PHPUnit_Framework_TestCase {
 	protected $ci_instance;
 	protected static $ci_test_instance;
 
-	private $global_map = array(
+	private $global_map = [
 		'benchmark'	=> 'bm',
 		'config'	=> 'cfg',
 		'hooks'		=> 'ext',
@@ -20,7 +20,7 @@ class CI_TestCase extends PHPUnit_Framework_TestCase {
 		'lang'		=> 'lang',
 		'loader'	=> 'load',
 		'model'		=> 'model'
-	);
+	];
 
 	// --------------------------------------------------------------------
 
@@ -93,7 +93,7 @@ class CI_TestCase extends PHPUnit_Framework_TestCase {
 
 	public function ci_get_config()
 	{
-		return isset($this->ci_instance->config) ? $this->ci_instance->config->config : array();
+		return isset($this->ci_instance->config) ? $this->ci_instance->config->config : [];
 	}
 
 	// --------------------------------------------------------------------
@@ -217,10 +217,10 @@ class CI_TestCase extends PHPUnit_Framework_TestCase {
 		}
 
 		// Build content
-		$tree = array($file => $content);
+		$tree = [$file => $content];
 
 		// Check for path
-		$subs = array();
+		$subs = [];
 		if ($path)
 		{
 			// Explode if not array
@@ -258,7 +258,7 @@ class CI_TestCase extends PHPUnit_Framework_TestCase {
 			foreach (array_reverse($subs) as $dir)
 			{
 				// Wrap content in subdirectory for creation
-				$tree = array($dir => $tree);
+				$tree = [$dir => $tree];
 			}
 		}
 

--- a/tests/mocks/ci_testconfig.php
+++ b/tests/mocks/ci_testconfig.php
@@ -2,9 +2,9 @@
 
 class CI_TestConfig extends CI_Config {
 
-	public $config = array();
-	public $_config_paths = array(APPPATH);
-	public $loaded = array();
+	public $config = [];
+	public $_config_paths = [APPPATH];
+	public $loaded = [];
 
 	public function item($key, $index = '')
 	{

--- a/tests/mocks/core/common.php
+++ b/tests/mocks/core/common.php
@@ -48,7 +48,7 @@ if ( ! function_exists('get_mimes'))
 	 */
 	function &get_mimes()
 	{
-		static $_mimes = array();
+		static $_mimes = [];
 
 		if (empty($_mimes))
 		{
@@ -122,7 +122,7 @@ if ( ! function_exists('is_loaded'))
 {
 	function &is_loaded()
 	{
-		$loaded = array();
+		$loaded = [];
 		return $loaded;
 	}
 }

--- a/tests/mocks/core/security.php
+++ b/tests/mocks/core/security.php
@@ -24,9 +24,9 @@ class Mock_Core_Security extends CI_Security {
 	// Override inaccessible protected method
 	public function __call($method, $params)
 	{
-		if (is_callable(array($this, '_'.$method)))
+		if (is_callable([$this, '_'.$method]))
 		{
-			return call_user_func_array(array($this, '_'.$method), $params);
+			return call_user_func_array([$this, '_'.$method], $params);
 		}
 
 		throw new BadMethodCallException('Method '.$method.' was not found');

--- a/tests/mocks/core/uri.php
+++ b/tests/mocks/core/uri.php
@@ -8,13 +8,13 @@ class Mock_Core_URI extends CI_URI {
 		$cls =& $test->ci_core_class('cfg');
 
 		// set predictable config values
-		$test->ci_set_config(array(
+		$test->ci_set_config([
 			'index_page'		=> 'index.php',
 			'base_url'		=> 'http://example.com/',
 			'subclass_prefix'	=> 'MY_',
 			'enable_query_strings'	=> FALSE,
 			'permitted_uri_chars'	=> 'a-z 0-9~%.:_\-'
-		));
+		]);
 
 		$this->config = new $cls;
 

--- a/tests/mocks/database/config/mysql.php
+++ b/tests/mocks/database/config/mysql.php
@@ -1,34 +1,34 @@
 <?php
 
-return array(
+return [
 
 	// Typical Database configuration
-	'mysql' => array(
+	'mysql' => [
 		'dsn' => '',
 		'hostname' => 'localhost',
 		'username' => 'travis',
 		'password' => '',
 		'database' => 'ci_test',
 		'dbdriver' => 'mysql'
-	),
+	],
 
 	// Database configuration with failover
-	'mysql_failover' => array(
+	'mysql_failover' => [
 		'dsn' => '',
 		'hostname' => 'localhost',
 		'username' => 'not_travis',
 		'password' => 'wrong password',
 		'database' => 'not_ci_test',
 		'dbdriver' => 'mysql',
-		'failover' => array(
-			array(
+		'failover' => [
+			[
 				'dsn' => '',
 				'hostname' => 'localhost',
 				'username' => 'travis',
 				'password' => '',
 				'database' => 'ci_test',
 				'dbdriver' => 'mysql',
-			)
-		)
-	)
-);
+			]
+		]
+	]
+];

--- a/tests/mocks/database/config/mysqli.php
+++ b/tests/mocks/database/config/mysqli.php
@@ -1,34 +1,34 @@
 <?php
 
-return array(
+return [
 
 	// Typical Database configuration
-	'mysqli' => array(
+	'mysqli' => [
 		'dsn' => '',
 		'hostname' => 'localhost',
 		'username' => 'travis',
 		'password' => '',
 		'database' => 'ci_test',
 		'dbdriver' => 'mysqli'
-	),
+	],
 
 	// Database configuration with failover
-	'mysqli_failover' => array(
+	'mysqli_failover' => [
 		'dsn' => '',
 		'hostname' => 'localhost',
 		'username' => 'not_travis',
 		'password' => 'wrong password',
 		'database' => 'not_ci_test',
 		'dbdriver' => 'mysqli',
-		'failover' => array(
-			array(
+		'failover' => [
+			[
 				'dsn' => '',
 				'hostname' => 'localhost',
 				'username' => 'travis',
 				'password' => '',
 				'database' => 'ci_test',
 				'dbdriver' => 'mysqli',
-			)
-		)
-	)
-);
+			]
+		]
+	]
+];

--- a/tests/mocks/database/config/pdo/mysql.php
+++ b/tests/mocks/database/config/pdo/mysql.php
@@ -1,9 +1,9 @@
 <?php
 
-return array(
+return [
 
 	// Typical Database configuration
-	'pdo/mysql' => array(
+	'pdo/mysql' => [
 		'dsn' => 'mysql:host=localhost;dbname=ci_test',
 		'hostname' => 'localhost',
 		'username' => 'travis',
@@ -11,10 +11,10 @@ return array(
 		'database' => 'ci_test',
 		'dbdriver' => 'pdo',
 		'subdriver' => 'mysql'
-	),
+	],
 
 	// Database configuration with failover
-	'pdo/mysql_failover' => array(
+	'pdo/mysql_failover' => [
 		'dsn' => '',
 		'hostname' => 'localhost',
 		'username' => 'not_travis',
@@ -22,8 +22,8 @@ return array(
 		'database' => 'not_ci_test',
 		'dbdriver' => 'pdo',
 		'subdriver' => 'mysql',
-		'failover' => array(
-			array(
+		'failover' => [
+			[
 				'dsn' => 'mysql:host=localhost;dbname=ci_test',
 				'hostname' => 'localhost',
 				'username' => 'travis',
@@ -31,7 +31,7 @@ return array(
 				'database' => 'ci_test',
 				'dbdriver' => 'pdo',
 				'subdriver' => 'mysql'
-			)
-		)
-	)
-);
+			]
+		]
+	]
+];

--- a/tests/mocks/database/config/pdo/pgsql.php
+++ b/tests/mocks/database/config/pdo/pgsql.php
@@ -1,9 +1,9 @@
 <?php
 
-return array(
+return [
 
 	// Typical Database configuration
-	'pdo/pgsql' => array(
+	'pdo/pgsql' => [
 		'dsn' => 'pgsql:host=localhost;port=5432;dbname=ci_test;',
 		'hostname' => 'localhost',
 		'username' => 'postgres',
@@ -11,10 +11,10 @@ return array(
 		'database' => 'ci_test',
 		'dbdriver' => 'pdo',
 		'subdriver' => 'pgsql'
-	),
+	],
 
 	// Database configuration with failover
-	'pdo/pgsql_failover' => array(
+	'pdo/pgsql_failover' => [
 		'dsn' => '',
 		'hostname' => 'localhost',
 		'username' => 'not_travis',
@@ -22,8 +22,8 @@ return array(
 		'database' => 'not_ci_test',
 		'dbdriver' => 'pdo',
 		'subdriver' => 'pgsql',
-		'failover' => array(
-			array(
+		'failover' => [
+			[
 				'dsn' => 'pgsql:host=localhost;port=5432;dbname=ci_test;',
 				'hostname' => 'localhost',
 				'username' => 'postgres',
@@ -31,7 +31,7 @@ return array(
 				'database' => 'ci_test',
 				'dbdriver' => 'pdo',
 				'subdriver' => 'pgsql'
-			)
-		)
-	)
-);
+			]
+		]
+	]
+];

--- a/tests/mocks/database/config/pdo/sqlite.php
+++ b/tests/mocks/database/config/pdo/sqlite.php
@@ -1,9 +1,9 @@
 <?php
 
-return array(
+return [
 
 	// Typical Database configuration
-	'pdo/sqlite' => array(
+	'pdo/sqlite' => [
 		'dsn' => 'sqlite:/'.realpath(__DIR__.'/../..').'/ci_test.sqlite',
 		'hostname' => 'localhost',
 		'username' => 'sqlite',
@@ -11,10 +11,10 @@ return array(
 		'database' => 'sqlite',
 		'dbdriver' => 'pdo',
 		'subdriver' => 'sqlite'
-	),
+	],
 
 	// Database configuration with failover
-	'pdo/sqlite_failover' => array(
+	'pdo/sqlite_failover' => [
 		'dsn' => 'sqlite:not_exists.sqlite',
 		'hostname' => 'localhost',
 		'username' => 'sqlite',
@@ -22,8 +22,8 @@ return array(
 		'database' => 'sqlite',
 		'dbdriver' => 'pdo',
 		'subdriver' => 'sqlite',
-		'failover' => array(
-			array(
+		'failover' => [
+			[
 				'dsn' => 'sqlite:/'.realpath(__DIR__.'/../..').'/ci_test.sqlite',
 				'hostname' => 'localhost',
 				'username' => 'sqlite',
@@ -31,7 +31,7 @@ return array(
 				'database' => 'sqlite',
 				'dbdriver' => 'pdo',
 				'subdriver' => 'sqlite'
-			)
-		)
-	)
-);
+			]
+		]
+	]
+];

--- a/tests/mocks/database/config/pgsql.php
+++ b/tests/mocks/database/config/pgsql.php
@@ -1,34 +1,34 @@
 <?php
 
-return array(
+return [
 
 	// Typical Database configuration
-	'pgsql' => array(
+	'pgsql' => [
 		'dsn' => '',
 		'hostname' => 'localhost',
 		'username' => 'postgres',
 		'password' => '',
 		'database' => 'ci_test',
 		'dbdriver' => 'postgre'
-	),
+	],
 
 	// Database configuration with failover
-	'pgsql_failover' => array(
+	'pgsql_failover' => [
 		'dsn' => '',
 		'hostname' => 'localhost',
 		'username' => 'not_travis',
 		'password' => 'wrong password',
 		'database' => 'not_ci_test',
 		'dbdriver' => 'postgre',
-		'failover' => array(
-			array(
+		'failover' => [
+			[
 				'dsn' => '',
 				'hostname' => 'localhost',
 				'username' => 'postgres',
 				'password' => '',
 				'database' => 'ci_test',
 				'dbdriver' => 'postgre',
-			)
-		)
-	)
-);
+			]
+		]
+	]
+];

--- a/tests/mocks/database/config/sqlite.php
+++ b/tests/mocks/database/config/sqlite.php
@@ -1,34 +1,34 @@
 <?php
 
-return array(
+return [
 
 	// Typical Database configuration
-	'sqlite' => array(
+	'sqlite' => [
 		'dsn' => '',
 		'hostname' => 'localhost',
 		'username' => 'sqlite',
 		'password' => 'sqlite',
 		'database' => realpath(__DIR__.'/..').'/ci_test.sqlite',
 		'dbdriver' => 'sqlite3'
-	),
+	],
 
 	// Database configuration with failover
-	'sqlite_failover' => array(
+	'sqlite_failover' => [
 		'dsn' => '',
 		'hostname' => 'localhost',
 		'username' => 'sqlite',
 		'password' => 'sqlite',
 		'database' => '../not_exists.sqlite',
 		'dbdriver' => 'sqlite3',
-		'failover' => array(
-			array(
+		'failover' => [
+			[
 				'dsn' => '',
 				'hostname' => 'localhost',
 				'username' => 'sqlite',
 				'password' => 'sqlite',
 				'database' => realpath(__DIR__.'/..').'/ci_test.sqlite',
 				'dbdriver' => 'sqlite3'
-			)
-		)
-	)
-);
+			]
+		]
+	]
+];

--- a/tests/mocks/database/db.php
+++ b/tests/mocks/database/db.php
@@ -5,7 +5,7 @@ class Mock_Database_DB {
 	/**
 	 * @var array DB configuration
 	 */
-	private $config = array();
+	private $config = [];
 
 	/**
 	 * @var string DB driver name
@@ -23,7 +23,7 @@ class Mock_Database_DB {
 	 * @param  array 	DB configuration to set
 	 * @return void
 	 */
-	public function __construct($config = array())
+	public function __construct($config = [])
 	{
 		$this->config = $config;
 	}
@@ -47,7 +47,7 @@ class Mock_Database_DB {
 			self::$subdriver = $this->config[$group]['subdriver'];
 		}
 
-		$params = array(
+		$params = [
 			'dbprefix' => '',
 			'pconnect' => FALSE,
 			'db_debug' => FALSE,
@@ -57,7 +57,7 @@ class Mock_Database_DB {
 			'dbcollat' => 'utf8_general_ci',
 			'swap_pre' => '',
 			'stricton' => FALSE
-		);
+		];
 
 		$config = array_merge($this->config[$group], $params);
 		$dsnstring = empty($config['dsn']) ? FALSE : $config['dsn'];
@@ -103,26 +103,26 @@ class Mock_Database_DB {
 		$case = CI_TestCase::instance();
 		$driver = self::$dbdriver;
 		$subdriver = self::$subdriver;
-		$case->ci_vfs_create(array(
+		$case->ci_vfs_create([
 			'DB_driver.php' => '',
 			'DB_result.php' => '',
 			'DB_forge.php' => '',
 			'DB_query_builder.php' => ''
-		), '', $case->ci_base_root, 'database');
+		], '', $case->ci_base_root, 'database');
 		if (file_exists(SYSTEM_PATH.'database/drivers/'.$driver.'/'.$driver.'_driver.php'))
 		{
-			$case->ci_vfs_create(array(
+			$case->ci_vfs_create([
 				$driver.'_driver.php' => '',
 				$driver.'_result.php' => '',
 				$driver.'_forge.php' => ''
-			), '', $case->ci_base_root, 'database/drivers/'.$driver);
+			], '', $case->ci_base_root, 'database/drivers/'.$driver);
 		}
 		if ($subdriver)
 		{
-			$case->ci_vfs_create(array(
+			$case->ci_vfs_create([
 				$driver.'_'.$subdriver.'_driver.php' => '',
 				$driver.'_'.$subdriver.'_forge.php' => ''
-			), '', $case->ci_base_root, 'database/drivers/'.$driver.'/subdrivers');
+			], '', $case->ci_base_root, 'database/drivers/'.$driver.'/subdrivers');
 		}
 
 		include_once(SYSTEM_PATH.'database/DB.php');

--- a/tests/mocks/database/db/driver.php
+++ b/tests/mocks/database/db/driver.php
@@ -14,7 +14,7 @@ class Mock_Database_DB_Driver extends CI_DB_driver {
 	 * @param  array 	DB configuration to set
 	 * @return void
 	 */
-	public function __construct($driver_class, $config = array())
+	public function __construct($driver_class, $config = [])
 	{
 		if (is_string($driver_class))
 		{
@@ -27,12 +27,12 @@ class Mock_Database_DB_Driver extends CI_DB_driver {
 	 */
 	public function __call($method, $arguments)
 	{
-		if ( ! is_callable(array($this->ci_db_driver, $method)))
+		if ( ! is_callable([$this->ci_db_driver, $method]))
 		{
 			throw new BadMethodCallException($method. ' not exists or not implemented');
 		}
 
-		return call_user_func_array(array($this->ci_db_driver, $method), $arguments);
+		return call_user_func_array([$this->ci_db_driver, $method], $arguments);
 	}
 
 }

--- a/tests/mocks/database/drivers/mysql.php
+++ b/tests/mocks/database/drivers/mysql.php
@@ -8,7 +8,7 @@ class Mock_Database_Drivers_Mysql extends Mock_Database_DB_Driver {
 	 * @param	array	DB configuration to set
 	 * @return	void
 	 */
-	public function __construct($config = array())
+	public function __construct($config = [])
 	{
 		parent::__construct('CI_DB_mysql_driver', $config);
 	}

--- a/tests/mocks/database/drivers/mysqli.php
+++ b/tests/mocks/database/drivers/mysqli.php
@@ -8,7 +8,7 @@ class Mock_Database_Drivers_Mysqli extends Mock_Database_DB_Driver {
 	 * @param	array	DB configuration to set
 	 * @return	void
 	 */
-	public function __construct($config = array())
+	public function __construct($config = [])
 	{
 		parent::__construct('CI_DB_mysqli_driver', $config);
 	}

--- a/tests/mocks/database/drivers/pdo.php
+++ b/tests/mocks/database/drivers/pdo.php
@@ -8,7 +8,7 @@ class Mock_Database_Drivers_PDO extends Mock_Database_DB_Driver {
 	 * @param	array	DB configuration to set
 	 * @return	void
 	 */
-	public function __construct($config = array())
+	public function __construct($config = [])
 	{
 		parent::__construct('CI_DB_pdo_driver', $config);
 	}

--- a/tests/mocks/database/drivers/postgre.php
+++ b/tests/mocks/database/drivers/postgre.php
@@ -8,7 +8,7 @@ class Mock_Database_Drivers_Postgre extends Mock_Database_DB_Driver {
 	 * @param	array	DB configuration to set
 	 * @return	void
 	 */
-	public function __construct($config = array())
+	public function __construct($config = [])
 	{
 		parent::__construct('CI_DB_postgre_driver', $config);
 	}

--- a/tests/mocks/database/drivers/sqlite.php
+++ b/tests/mocks/database/drivers/sqlite.php
@@ -8,7 +8,7 @@ class Mock_Database_Drivers_Sqlite extends Mock_Database_DB_Driver {
 	 * @param	array	DB configuration to set
 	 * @return	void
 	 */
-	public function __construct($config = array())
+	public function __construct($config = [])
 	{
 		parent::__construct('CI_DB_sqlite3_driver', $config);
 	}

--- a/tests/mocks/database/schema/skeleton.php
+++ b/tests/mocks/database/schema/skeleton.php
@@ -57,58 +57,58 @@ class Mock_Database_Schema_Skeleton {
 	public static function create_tables()
 	{
 		// User Table
-		self::$forge->add_field(array(
-			'id' => array(
+		self::$forge->add_field([
+			'id' => [
 				'type' => 'INTEGER',
 				'constraint' => 3
-			),
-			'name' => array(
+			],
+			'name' => [
 				'type' => 'VARCHAR',
 				'constraint' => 40
-			),
-			'email' => array(
+			],
+			'email' => [
 				'type' => 'VARCHAR',
 				'constraint' => 100
-			),
-			'country' => array(
+			],
+			'country' => [
 				'type' => 'VARCHAR',
 				'constraint' => 40
-			)
-		));
+			]
+		]);
 		self::$forge->add_key('id', TRUE);
 		self::$forge->create_table('user', TRUE);
 
 		// Job Table
-		self::$forge->add_field(array(
-			'id' => array(
+		self::$forge->add_field([
+			'id' => [
 				'type' => 'INTEGER',
 				'constraint' => 3
-			),
-			'name' => array(
+			],
+			'name' => [
 				'type' => 'VARCHAR',
 				'constraint' => 40
-			),
-			'description' => array(
+			],
+			'description' => [
 				'type' => 'TEXT'
-			)
-		));
+			]
+		]);
 		self::$forge->add_key('id', TRUE);
 		self::$forge->create_table('job', TRUE);
 
 		// Misc Table
-		self::$forge->add_field(array(
-			'id' => array(
+		self::$forge->add_field([
+			'id' => [
 				'type' => 'INTEGER',
 				'constraint' => 3
-			),
-			'key' => array(
+			],
+			'key' => [
 				'type' => 'VARCHAR',
 				'constraint' => 40
-			),
-			'value' => array(
+			],
+			'value' => [
 				'type' => 'TEXT'
-			)
-		));
+			]
+		]);
 		self::$forge->add_key('id', TRUE);
 		self::$forge->create_table('misc', TRUE);
 	}
@@ -121,25 +121,25 @@ class Mock_Database_Schema_Skeleton {
 	public static function create_data()
 	{
 		// Job Data
-		$data = array(
-			'user' => array(
-				array('id' => 1, 'name' => 'Derek Jones', 'email' => 'derek@world.com', 'country' => 'US'),
-				array('id' => 2, 'name' => 'Ahmadinejad', 'email' => 'ahmadinejad@world.com', 'country' => 'Iran'),
-				array('id' => 3, 'name' => 'Richard A Causey', 'email' => 'richard@world.com', 'country' => 'US'),
-				array('id' => 4, 'name' => 'Chris Martin', 'email' => 'chris@world.com', 'country' => 'UK')
-			),
-			'job' => array(
-				array('id' => 1, 'name' => 'Developer', 'description' => 'Awesome job, but sometimes makes you bored'),
-				array('id' => 2, 'name' => 'Politician', 'description' => 'This is not really a job'),
-				array('id' => 3, 'name' => 'Accountant', 'description' => 'Boring job, but you will get free snack at lunch'),
-				array('id' => 4, 'name' => 'Musician', 'description' => 'Only Coldplay can actually called Musician')
-			),
-			'misc' => array(
-				array('id' => 1, 'key' => '\\xxxfoo456', 'value' => 'Entry with \\xxx'),
-				array('id' => 2, 'key' => '\\%foo456', 'value' => 'Entry with \\%'),
-				array('id' => 3, 'key' => 'spaces and tabs', 'value' => ' One  two   three	tab')
-			)
-		);
+		$data = [
+			'user' => [
+				['id' => 1, 'name' => 'Derek Jones', 'email' => 'derek@world.com', 'country' => 'US'],
+				['id' => 2, 'name' => 'Ahmadinejad', 'email' => 'ahmadinejad@world.com', 'country' => 'Iran'],
+				['id' => 3, 'name' => 'Richard A Causey', 'email' => 'richard@world.com', 'country' => 'US'],
+				['id' => 4, 'name' => 'Chris Martin', 'email' => 'chris@world.com', 'country' => 'UK']
+			],
+			'job' => [
+				['id' => 1, 'name' => 'Developer', 'description' => 'Awesome job, but sometimes makes you bored'],
+				['id' => 2, 'name' => 'Politician', 'description' => 'This is not really a job'],
+				['id' => 3, 'name' => 'Accountant', 'description' => 'Boring job, but you will get free snack at lunch'],
+				['id' => 4, 'name' => 'Musician', 'description' => 'Only Coldplay can actually called Musician']
+			],
+			'misc' => [
+				['id' => 1, 'key' => '\\xxxfoo456', 'value' => 'Entry with \\xxx'],
+				['id' => 2, 'key' => '\\%foo456', 'value' => 'Entry with \\%'],
+				['id' => 3, 'key' => 'spaces and tabs', 'value' => ' One  two   three	tab']
+			]
+		];
 
 		foreach ($data as $table => $dummy_data)
 		{

--- a/tests/mocks/libraries/encrypt.php
+++ b/tests/mocks/libraries/encrypt.php
@@ -5,9 +5,9 @@ class Mock_Libraries_Encrypt extends CI_Encrypt {
 	// Override inaccessible protected method
 	public function __call($method, $params)
 	{
-		if (is_callable(array($this, '_'.$method)))
+		if (is_callable([$this, '_'.$method]))
 		{
-			return call_user_func_array(array($this, '_'.$method), $params);
+			return call_user_func_array([$this, '_'.$method], $params);
 		}
 
 		throw new BadMethodCallException('Method '.$method.' was not found');

--- a/tests/mocks/libraries/table.php
+++ b/tests/mocks/libraries/table.php
@@ -5,9 +5,9 @@ class Mock_Libraries_Table extends CI_Table {
 	// Override inaccessible protected method
 	public function __call($method, $params)
 	{
-		if (is_callable(array($this, '_'.$method)))
+		if (is_callable([$this, '_'.$method]))
 		{
-			return call_user_func_array(array($this, '_'.$method), $params);
+			return call_user_func_array([$this, '_'.$method], $params);
 		}
 
 		throw new BadMethodCallException('Method '.$method.' was not found');


### PR DESCRIPTION
In case you don't have some reason for keeping old array, since PHP 5.4 is min version short array can be used.

