### PR TITLE
fix CI_Hooks object method call

### DIFF
--- a/system/core/Hooks.php
+++ b/system/core/Hooks.php
@@ -139,6 +139,11 @@ class CI_Hooks {
 
 		if (is_array($this->hooks[$which]) && ! isset($this->hooks[$which]['function']))
 		{
+			if (is_callable($this->hooks[$which]))
+			{
+				$this->_run_hook($this->hooks[$which]);
+				return TRUE;
+			}
 			foreach ($this->hooks[$which] as $val)
 			{
 				$this->_run_hook($val);


### PR DESCRIPTION
```php
$hooks = load_class('Hooks', 'core');
$hooks->enabled = true;
$hooks->hooks['test'] = [new Foo(), 'test'];
$hooks->call_hook('test');// not run
class Foo
{
    public function test()
    {
        echo 'hello,world';
    }
}
```