### PR TITLE
check if $class is actually a property of $CI before deeming it to be a duplicate request

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -1039,7 +1039,7 @@ class CI_Loader {
 			$filepath = $path.'libraries/'.$subdir.$class.'.php';
 
 			// Safety: Was the class already loaded by a previous call?
-			if (class_exists($class, FALSE))
+			if (class_exists($class, FALSE) && isset($CI->{strtolower($class)}))
 			{
 				// Before we deem this to be a duplicate request, let's see
 				// if a custom object name is being supplied. If so, we'll


### PR DESCRIPTION
We sometimes load libraries using require_once, for example say that I have

```
class My_library extends My_other_library
```

if we then load My_library using CI, we then load My_other_library using require_once at the top of the file, so now the class My_other_library exists

but somewhere else in the code, we may want to load My_other_library directly, but now it won't load, because the class already exists. With this PR, it will actually add the class to $CI super object

We are migrating from CI2 to CI3, and this is one of the issue we have, would be great if something like this could land in CI3.