### PR TITLE
Core/Codeigniter : fix too few args for php >= 7.1

### DIFF
--- a/system/core/CodeIgniter.php
+++ b/system/core/CodeIgniter.php
@@ -339,6 +339,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  *	2) a query string which doesn't go through a
  *	   file_exists() check
  *	3) a regular request for a non-existing page
+ * 	4) Arguments count test
  *
  *  We handle all of these as a 404 error.
  *
@@ -387,6 +388,21 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 		{
 			$reflection = new ReflectionMethod($class, $method);
 			if ( ! $reflection->isPublic() OR $reflection->isConstructor())
+			{
+				$e404 = TRUE;
+			}
+		}
+		else
+		{
+			/**
+			 * Throw on passing too few function arguments
+			 * http://php.net/manual/en/migration71.incompatible.php
+			 */
+			$reflection = new ReflectionMethod($class, $method);
+			$args_min = $reflection->getNumberOfRequiredParameters();
+			$args_max = $reflection->getNumberOfParameters();
+			$args_count = count(array_slice($URI->rsegments, 2));
+			if ($args_count < $args_min || $args_count > $args_max)
 			{
 				$e404 = TRUE;
 			}


### PR DESCRIPTION
After 7.1 migration we can't send too few arguments on uri without error : 

http://php.net/manual/en/migration71.incompatible.php
Fatal error: Uncaught ArgumentCountError: Too few arguments to function  ....

On this fix i try to count needed args and i compare with function proto

