### PR TITLE
Fix ORDER BY clauses being reset by count_all_results()

### DIFF
--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -1405,7 +1405,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 		// for selecting COUNT(*) ...
 		$qb_orderby       = $this->qb_orderby;
 		$qb_cache_orderby = $this->qb_cache_orderby;
-		$this->qb_orderby = $this->qb_cache_orderby = NULL;
+		$this->qb_orderby = $this->qb_cache_orderby = array();
 
 		$result = ($this->qb_distinct === TRUE OR ! empty($this->qb_groupby) OR ! empty($this->qb_cache_groupby) OR $this->qb_limit OR $this->qb_offset)
 			? $this->query($this->_count_string.$this->protect_identifiers('numrows')."\nFROM (\n".$this->_compile_select()."\n) CI_count_all_results")


### PR DESCRIPTION
recent changes broke query ordering giving a warning in line 1238 = '$this->qb_cache_orderby = array_merge($this->qb_cache_orderby, $qb_orderby);'
the warning message was about array_merge not working with a NULL object.

this was because on subsequent re-queries, the qb_cache_orderby was set to NULL not Array() as it is should have been.  See the initial instantiation of the $this->qb_cache_orderby 
This PR should fix it.