### PR TITLE
Clean up form validation tests

### DIFF
--- a/tests/codeigniter/libraries/Form_validation_test.php
+++ b/tests/codeigniter/libraries/Form_validation_test.php
@@ -321,9 +321,6 @@ class Form_validation_test extends CI_TestCase {
 
 	public function test_set_data()
 	{
-		// Reset test environment
-		$_POST = array();
-		$this->form_validation->reset_validation();
 		$data = array('field' => 'some_data');
 		$this->form_validation->set_data($data);
 		$this->form_validation->set_rules('field', 'label', 'required');
@@ -342,9 +339,6 @@ class Form_validation_test extends CI_TestCase {
 
 	public function test_set_message()
 	{
-		// Reset test environment
-		$_POST = array();
-		$this->form_validation->reset_validation();
 		$err_message = 'What a terrible error!';
 		$rules = array(
 			array(
@@ -372,7 +366,6 @@ class Form_validation_test extends CI_TestCase {
 
 	public function test_set_error_delimiters()
 	{
-		$this->form_validation->reset_validation();
 		$prefix = '<div class="error">';
 		$suffix = '</div>';
 		$this->form_validation->set_error_delimiters($prefix, $suffix);
@@ -383,11 +376,12 @@ class Form_validation_test extends CI_TestCase {
 
 		$this->assertTrue(strrpos($error_msg, $prefix) === 0);
 		$this->assertTrue(strrpos($error_msg, $suffix, -strlen($suffix)) === (strlen($error_msg) - strlen($suffix)));
+
+		$_POST = array();
 	}
 
 	public function test_error_array()
 	{
-		$this->form_validation->reset_validation();
 		$error_message = 'What a terrible error!';
 		$this->form_validation->set_message('required', $error_message);
 		$this->form_validation->set_rules('foo', 'label', 'required');
@@ -395,11 +389,12 @@ class Form_validation_test extends CI_TestCase {
 		$this->form_validation->run();
 		$error_array = $this->form_validation->error_array();
 		$this->assertEquals($error_message, $error_array['foo']);
+
+		$_POST = array();
 	}
 
 	public function test_error_string()
 	{
-		$this->form_validation->reset_validation();
 		$error_message = 'What a terrible error!';
 		$prefix_default = '<foo>';
 		$suffix_default = '</foo>';
@@ -421,6 +416,8 @@ class Form_validation_test extends CI_TestCase {
 		$_POST = array('foo' => 'bar');
 		$this->form_validation->run();
 		$this->assertEquals('', $this->form_validation->error_string());
+
+		$_POST = array();
 	}
 
 	public function test_run()
@@ -449,6 +446,8 @@ class Form_validation_test extends CI_TestCase {
 
 		$form_validation = new CI_Form_validation($config);
 		$this->assertFalse($form_validation->run('fail'));
+
+		$_POST = array();
 	}
 
 	public function test_set_rules_exception()
@@ -459,7 +458,6 @@ class Form_validation_test extends CI_TestCase {
 
 	public function test_has_rule()
 	{
-		$this->form_validation->reset_validation();
 		$this->form_validation->set_rules('foo', 'label', 'required');
 
 		$this->assertTrue($this->form_validation->has_rule('foo'));
@@ -468,7 +466,6 @@ class Form_validation_test extends CI_TestCase {
 
 	public function test_set_value()
 	{
-		$this->form_validation->reset_validation();
 		$default = 'default';
 		$this->form_validation->set_rules('foo', 'label', 'required');
 		$this->form_validation->set_rules('bar[]', 'label', 'required');
@@ -480,12 +477,13 @@ class Form_validation_test extends CI_TestCase {
 		$this->assertEquals('foo', $this->form_validation->set_value('foo', $default));
 		$this->assertEquals('bar1', $this->form_validation->set_value('bar[]', $default));
 		$this->assertEquals('bar2', $this->form_validation->set_value('bar[]', $default));
+
+		$_POST = array();
 	}
 
 	public function test_issue_5202()
 	{
 		$data = array('person' => array('firstname' => 'Dick', 'lastname' => 'Tracy '));
-		$this->form_validation->reset_validation();
 		$this->form_validation->set_rules('person[firstname]', 'First Name', 'required|trim');
 		$this->form_validation->set_rules('person[lastname]', 'Last Name', 'required|trim');
 		$this->form_validation->set_data($data);
@@ -499,8 +497,6 @@ class Form_validation_test extends CI_TestCase {
 	public function test_set_select()
 	{
 		// Test 1: No options selected
-		$this->form_validation->reset_validation();
-		$_POST = array();
 		$this->form_validation->run();
 
 		$this->assertEquals('', $this->form_validation->set_select('select', 'foo'));
@@ -529,13 +525,13 @@ class Form_validation_test extends CI_TestCase {
 		$this->assertEquals(' selected="selected"', $this->form_validation->set_select('select[]', 'bar', TRUE));
 		$this->assertEquals('', $this->form_validation->set_select('select[]', 'foobar'));
 		$this->assertEquals('', $this->form_validation->set_select('select[]', 'foobar', TRUE));
+
+		$_POST = array();
 	}
 
 	public function test_set_radio()
 	{
 		// Test 1: No options selected
-		$this->form_validation->reset_validation();
-		$_POST = array();
 		$this->form_validation->run();
 
 		$this->assertEquals('', $this->form_validation->set_radio('select', 'foo'));
@@ -565,13 +561,13 @@ class Form_validation_test extends CI_TestCase {
 		$this->assertEquals(' checked="checked"', $this->form_validation->set_radio('select[]', 'bar', TRUE));
 		$this->assertEquals('', $this->form_validation->set_radio('select[]', 'foobar'));
 		$this->assertEquals('', $this->form_validation->set_radio('select[]', 'foobar', TRUE));
+
+		$_POST = array();
 	}
 
 	public function test_set_checkbox()
 	{
 		// Test 1: No options selected
-		$this->form_validation->reset_validation();
-		$_POST = array();
 		$this->form_validation->run();
 
 		$this->assertEquals('', $this->form_validation->set_checkbox('select', 'foo'));
@@ -600,6 +596,8 @@ class Form_validation_test extends CI_TestCase {
 		$this->assertEquals(' checked="checked"', $this->form_validation->set_checkbox('select[]', 'bar', TRUE));
 		$this->assertEquals('', $this->form_validation->set_checkbox('select[]', 'foobar'));
 		$this->assertEquals('', $this->form_validation->set_checkbox('select[]', 'foobar', TRUE));
+
+		$_POST = array();
 	}
 
 	public function test_regex_match()
@@ -638,7 +636,6 @@ class Form_validation_test extends CI_TestCase {
 		$this->assertEquals($post_original, $_POST);
 		$this->assertEquals(array('foo' => 'bar', 'bar' => 'baz'), $data_processed);
 
-		$this->form_validation->reset_validation();
 		$_POST = array();
 	}
 
@@ -652,13 +649,16 @@ class Form_validation_test extends CI_TestCase {
 	{
 		$this->form_validation->reset_validation();
 		$_POST = array();
-
 		$this->form_validation->set_rules($rules);
+
 		foreach ($values as $field => $value)
 		{
 			$_POST[$field] = $value;
 		}
 
-		return $this->form_validation->run();
+		$valid = $this->form_validation->run();
+		$_POST = array();
+
+		return $valid;
 	}
 }


### PR DESCRIPTION
There are a number of places where `$_POST` is modified and not
reset back to its previous state. This could lead to side effects
impacting other tests. There are also a number unnecessary calls to
`reset_validation()`. A new form_validation object is already
initialized for every test in `set_up()`, so these lines do nothing
unless they are cleaning up from earlier in the same test.

To remedy this, we make the following changes:

Set `$_POST = array()` in `set_up()`, resetting to a default state for
every test run. Add a `tear_down()` method that does the same and is
called by PHPUnit's `tearDown()` after each test.

Remove now-redundant lines where tests set `$_POST = array()` at the
beginning or end of the test.

Remove unnecessary calls to `reset_validation()` intended as setup
or teardown.