### PR TITLE
Bugfix: DB_query_builder order_by / count_all_results 

### DIFF
--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -1405,7 +1405,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 		// for selecting COUNT(*) ...
 		$qb_orderby       = $this->qb_orderby;
 		$qb_cache_orderby = $this->qb_cache_orderby;
-		$this->qb_orderby = $this->qb_cache_orderby = NULL;
+		$this->qb_orderby = $this->qb_cache_orderby = array();
 
 		$result = ($this->qb_distinct === TRUE OR ! empty($this->qb_groupby) OR ! empty($this->qb_cache_groupby) OR $this->qb_limit OR $this->qb_offset)
 			? $this->query($this->_count_string.$this->protect_identifiers('numrows')."\nFROM (\n".$this->_compile_select()."\n) CI_count_all_results")


### PR DESCRIPTION
The default type for $this->qb_orderby and $this->qb_cache_orderby is an empty array. 
Setting it to NULL in method 'count_all_results' causes an error on line 1238 when trying to merge it with newly added values.
The other option to prevent this would be to check before merging or to typecast.