### PR TITLE
Made changes to get() and post() methods

### DIFF
--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -180,11 +180,19 @@ class CI_Input {
 	 *
 	 * @param	mixed	$index		Index for item to be fetched from $_GET
 	 * @param	bool	$xss_clean	Whether to apply XSS filtering
+	 * @param	bool 	$clean_get	unset GET Data
 	 * @return	mixed
 	 */
-	public function get($index = NULL, $xss_clean = FALSE)
+	public function get($index = NULL, $xss_clean = FALSE, $clean_get = FALSE)
 	{
-		return $this->_fetch_from_array($_GET, $index, $xss_clean);
+		$get = $this->_fetch_from_array($_GET, $index, $xss_clean);
+		
+		if($clean_post === TRUE){
+			
+			$_POST = array();
+		}
+		
+		return $get;
 	}
 
 	// --------------------------------------------------------------------
@@ -194,11 +202,19 @@ class CI_Input {
 	 *
 	 * @param	mixed	$index		Index for item to be fetched from $_POST
 	 * @param	bool	$xss_clean	Whether to apply XSS filtering
+	 * @param	bool 	$clean_post	unset Post Data
 	 * @return	mixed
 	 */
-	public function post($index = NULL, $xss_clean = FALSE)
-	{
-		return $this->_fetch_from_array($_POST, $index, $xss_clean);
+	public function post($index = NULL, $xss_clean = FALSE, $clean_post = FALSE)
+	{	
+		$post = $this->_fetch_from_array($_POST, $index, $xss_clean);
+		
+		if($clean_post === TRUE){
+			
+			$_POST = array();
+		}
+		
+		return $post;
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
Function calls have the access to read POST and GET data, so, I am giving the option to clean to have enough security.
For example run below code, methos: _callMeViaGet() has been called via function call still it has access to POST data, Which shouldnt so, i made this commit.
```

<?php

if (!defined('BASEPATH'))
    exit('No direct script access allowed');

class Test extends CI_Controller {

    public function index() {
        
    }

    function callMeViaPost(){
    	error_reporting(E_ALL); ini_set('display_errors', 1);
    	$data = $this->input->post(array("id", 'key3'));

    	echo "POST Data:<br>";
    	print_r($data);

    	$this->_callMeViaGet($data['id'], "yes");
    }

    function _callMeViaGet($id, $option){
    	echo "GET Data:<br>";

    	echo "Param 1 Data: ";
    	print_r($id);
    	echo "Param 2 Data: ";
    	print_r($option);

    	if(!empty($this->input->post())){
    		echo "Voila! How i came here, This function should have only access to my get params i guess<br>";
    		print_r($this->input->post());
    	}
    	else{
    		echo "Hmm";
    		print_r($this->input->post());
    	}
    }
}
```