### PR TITLE
Migration has been changed so that all the remaining migrations will …

### DIFF
--- a/system/libraries/Migration.php
+++ b/system/libraries/Migration.php
@@ -153,12 +153,15 @@ class CI_Migration {
 		}
 
 		// Migration basename regex
-		$this->_migration_regex = ($this->_migration_type === 'timestamp')
-			? '/^\d{10}_(\w+)$/'
-			: '/^\d{3}_(\w+)$/';
+    switch($this->_migration_type)
+    {
+      case 'timestamp': $this->_migration_regex = '/^\d{10}_(\w+)$/'; break;
+      case 'sequential': $this->_migration_regex = '/^\d{3}_(\w+)$/'; break;
+      case 'datetime': $this->_migration_regex = '/^\d{14}_(\w+)$/'; break;
+    }
 
 		// Make sure a valid migration numbering type was set.
-		if ( ! in_array($this->_migration_type, array('sequential', 'timestamp')))
+		if ( ! in_array($this->_migration_type, array('sequential', 'timestamp', 'datetime')))
 		{
 			show_error('An invalid migration numbering type was specified: '.$this->_migration_type);
 		}

--- a/system/libraries/Migration.php
+++ b/system/libraries/Migration.php
@@ -154,7 +154,7 @@ class CI_Migration {
 
 		// Migration basename regex
 		$this->_migration_regex = ($this->_migration_type === 'timestamp')
-			? '/^\d{14}_(\w+)$/'
+			? '/^\d{10}_(\w+)$/'
 			: '/^\d{3}_(\w+)$/';
 
 		// Make sure a valid migration numbering type was set.
@@ -181,143 +181,212 @@ class CI_Migration {
 			show_error($this->error_string());
 		}
 	}
-
 	// --------------------------------------------------------------------
 
 	/**
-	 * Migrate to a schema version
+	 * Migrate UP method to a schema version
 	 *
-	 * Calls each migration step required to get to the schema version of
-	 * choice
+	 * Calls each migration step and run it if not already ran
 	 *
-	 * @param	string	$target_version	Target schema version
-	 * @return	mixed	TRUE if no migrations are found, current version string on success, FALSE on failure
+	 * @param	string	$version	Optional Target schema version
+	 * @return	array having status of each migration
 	 */
-	public function version($target_version)
+	public function migrateup($version = '')
 	{
 		// Note: We use strings, so that timestamp versions work on 32-bit systems
 		$current_version = $this->_get_version();
 
-		if ($this->_migration_type === 'sequential')
-		{
-			$target_version = sprintf('%03d', $target_version);
-		}
-		else
-		{
-			$target_version = (string) $target_version;
-		}
+		$migrations = $this->find_migrations();
+    if ($version != '')
+    {
+      $this->db->where("version",$version);
+    }
+    $query = $this->db->get($this->_migration_table);
+    $old_migrations = array();
+    foreach ($query->result() as $row)
+    {
+      $old_migrations[] = $row->version;
+    }
+    
+    //$this->db->insert($this->_migration_table, array('version' => 0));
+    $method = 'up';
+		$pending = array();
+		$output_array = array();
+    if ($version == "")
+    {
+      foreach ($migrations as $number => $file)
+      {
+        if (!in_array($number,$old_migrations))
+        {
+          include_once($file);
+          $class = 'Migration_'.ucfirst(strtolower($this->_get_migration_name(basename($file, '.php'))));
+
+          // Validate the migration file structure
+          if ( ! class_exists($class, FALSE))
+          {
+            $output_array[] = sprintf($this->lang->line('migration_class_doesnt_exist'), $class);
+          }
+          elseif ( ! is_callable(array($class, $method)))
+          {
+            $output_array[] = sprintf($this->lang->line('migration_missing_'.$method.'_method'), $class);
+          }
+          else
+          {
+            $pending[$number] = array($class, $method);
+          }
+        }
+      }
+    }
+    else
+    {
+      if (array_key_exists($version,$migrations))
+      {
+        $number = $version;
+        $file = $migrations[$number];
+        if (!in_array($number,$old_migrations))
+        {
+          include_once($file);
+          $class = 'Migration_'.ucfirst(strtolower($this->_get_migration_name(basename($file, '.php'))));
+
+          // Validate the migration file structure
+          if ( ! class_exists($class, FALSE))
+          {
+            $output_array[] = sprintf($this->lang->line('migration_class_doesnt_exist'), $class);
+            //return FALSE;
+          }
+          elseif ( ! is_callable(array($class, $method)))
+          {
+            $output_array[] = sprintf($this->lang->line('migration_missing_'.$method.'_method'), $class);
+          }
+          else
+          {
+            $pending[$number] = array($class, $method);
+          }
+        }
+      }
+      else
+      {
+        $output_array[] =  sprintf($this->lang->line('migration_not_found'), $version);
+      }
+    }
+    // Now just run the necessary migrations
+    foreach ($pending as $number => $migration)
+    {
+      log_message('debug', 'Migrating '.$method.' from version '.$current_version.' to version '.$number);
+
+      $migration[0] = new $migration[0];
+      call_user_func($migration);
+      $current_version = $number;
+      $this->_add_version($current_version);
+      $output_array[] =  'Version '.$number.' ran successfully!';
+    }
+
+		return $output_array;
+	}
+
+	// --------------------------------------------------------------------
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Migrate DOWN method to a schema version
+	 *
+	 * Calls each migration step and run it if not already ran
+	 *
+	 * @param	string	$version	Optional Target schema version
+	 * @return	array having status of each migration
+	 */
+	public function migratedown($version = '')
+	{
+		// Note: We use strings, so that timestamp versions work on 32-bit systems
+		$current_version = $this->_get_version();
 
 		$migrations = $this->find_migrations();
-
-		if ($target_version > 0 && ! isset($migrations[$target_version]))
-		{
-			$this->_error_string = sprintf($this->lang->line('migration_not_found'), $target_version);
-			return FALSE;
-		}
-
-		if ($target_version > $current_version)
-		{
-			$method = 'up';
-		}
-		elseif ($target_version < $current_version)
-		{
-			$method = 'down';
-			// We need this so that migrations are applied in reverse order
-			krsort($migrations);
-		}
-		else
-		{
-			// Well, there's nothing to migrate then ...
-			return TRUE;
-		}
-
-		// Validate all available migrations within our target range.
-		//
-		// Unfortunately, we'll have to use another loop to run them
-		// in order to avoid leaving the procedure in a broken state.
-		//
-		// See https://github.com/bcit-ci/CodeIgniter/issues/4539
+    if ($version != '')
+    {
+      $this->db->where("version",$version);
+    }
+    $query = $this->db->get($this->_migration_table);
+    $old_migrations = array();
+    foreach ($query->result() as $row)
+    {
+      $old_migrations[] = $row->version;
+    }
+    
+    //$this->db->insert($this->_migration_table, array('version' => 0));
+    $method = 'down';
 		$pending = array();
-		foreach ($migrations as $number => $file)
-		{
-			// Ignore versions out of our range.
-			//
-			// Because we've previously sorted the $migrations array depending on the direction,
-			// we can safely break the loop once we reach $target_version ...
-			if ($method === 'up')
-			{
-				if ($number <= $current_version)
-				{
-					continue;
-				}
-				elseif ($number > $target_version)
-				{
-					break;
-				}
-			}
-			else
-			{
-				if ($number > $current_version)
-				{
-					continue;
-				}
-				elseif ($number <= $target_version)
-				{
-					break;
-				}
-			}
+		$output_array = array();
+    if ($version == "")
+    {
+      foreach ($migrations as $number => $file)
+      {
+        if (in_array($number,$old_migrations))
+        {
+          include_once($file);
+          $class = 'Migration_'.ucfirst(strtolower($this->_get_migration_name(basename($file, '.php'))));
 
-			// Check for sequence gaps
-			if ($this->_migration_type === 'sequential')
-			{
-				if (isset($previous) && abs($number - $previous) > 1)
-				{
-					$this->_error_string = sprintf($this->lang->line('migration_sequence_gap'), $number);
-					return FALSE;
-				}
+          // Validate the migration file structure
+          if ( ! class_exists($class, FALSE))
+          {
+            $output_array[] = sprintf($this->lang->line('migration_class_doesnt_exist'), $class);
+          }
+          elseif ( ! is_callable(array($class, $method)))
+          {
+            $output_array[] = sprintf($this->lang->line('migration_missing_'.$method.'_method'), $class);
+          }
+          else
+          {
+            $pending[$number] = array($class, $method);
+          }
+        }
+      }
+    }
+    else
+    {
+      if (array_key_exists($version,$migrations))
+      {
+        $number = $version;
+        $file = $migrations[$number];
+        if (!in_array($number,$old_migrations))
+        {
+          include_once($file);
+          $class = 'Migration_'.ucfirst(strtolower($this->_get_migration_name(basename($file, '.php'))));
 
-				$previous = $number;
-			}
+          // Validate the migration file structure
+          if ( ! class_exists($class, FALSE))
+          {
+            $output_array[] = sprintf($this->lang->line('migration_class_doesnt_exist'), $class);
+            //return FALSE;
+          }
+          elseif ( ! is_callable(array($class, $method)))
+          {
+            $output_array[] = sprintf($this->lang->line('migration_missing_'.$method.'_method'), $class);
+          }
+          else
+          {
+            $pending[$number] = array($class, $method);
+          }
+        }
+      }
+      else
+      {
+        $output_array[] =  sprintf($this->lang->line('migration_not_found'), $version);
+      }
+    }
+    // Now just run the necessary migrations
+    foreach ($pending as $number => $migration)
+    {
+      log_message('debug', 'Migrating '.$method.' from version '.$current_version.' to version '.$number);
 
-			include_once($file);
-			$class = 'Migration_'.ucfirst(strtolower($this->_get_migration_name(basename($file, '.php'))));
+      $migration[0] = new $migration[0];
+      call_user_func($migration);
+      $current_version = $number;
+      $this->_del_version($current_version);
+      $output_array[] =  'Version '.$number.' ran successfully!';
+    }
 
-			// Validate the migration file structure
-			if ( ! class_exists($class, FALSE))
-			{
-				$this->_error_string = sprintf($this->lang->line('migration_class_doesnt_exist'), $class);
-				return FALSE;
-			}
-			elseif ( ! is_callable(array($class, $method)))
-			{
-				$this->_error_string = sprintf($this->lang->line('migration_missing_'.$method.'_method'), $class);
-				return FALSE;
-			}
-
-			$pending[$number] = array($class, $method);
-		}
-
-		// Now just run the necessary migrations
-		foreach ($pending as $number => $migration)
-		{
-			log_message('debug', 'Migrating '.$method.' from version '.$current_version.' to version '.$number);
-
-			$migration[0] = new $migration[0];
-			call_user_func($migration);
-			$current_version = $number;
-			$this->_update_version($current_version);
-		}
-
-		// This is necessary when moving down, since the the last migration applied
-		// will be the down() method for the next migration up from the target
-		if ($current_version <> $target_version)
-		{
-			$current_version = $target_version;
-			$this->_update_version($current_version);
-		}
-
-		log_message('debug', 'Finished migrating to '.$current_version);
-		return $current_version;
+		return $output_array;
 	}
 
 	// --------------------------------------------------------------------
@@ -378,13 +447,12 @@ class CI_Migration {
 	public function find_migrations()
 	{
 		$migrations = array();
-
 		// Load all *_*.php files in the migrations path
 		foreach (glob($this->_migration_path.'*_*.php') as $file)
 		{
 			$name = basename($file, '.php');
 
-			// Filter out non-migration files
+      // Filter out non-migration files
 			if (preg_match($this->_migration_regex, $name))
 			{
 				$number = $this->_get_migration_number($name);
@@ -459,6 +527,39 @@ class CI_Migration {
 		$this->db->update($this->_migration_table, array(
 			'version' => $migration
 		));
+	}
+
+	// --------------------------------------------------------------------
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Insert the schema version
+	 *
+	 * @param	string	$migration	Migration reached
+	 * @return	void
+	 */
+	protected function _add_version($migration)
+	{
+		$this->db->insert($this->_migration_table, array(
+			'version' => $migration
+		));
+	}
+
+	// --------------------------------------------------------------------
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Delete the schema version
+	 *
+	 * @param	string	$migration	Migration reached
+	 * @return	void
+	 */
+	protected function _del_version($migration)
+	{
+    $this->db->where("version",$migration);
+		$this->db->delete($this->_migration_table);
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
…run at once - migrateup() will be use to run up method of all the remaining migrations and migratedown() will be use to run down method of all the migrations which were already executed. Migrations table contain all the versions which had been successfully executed. Output of both the methods is an array having status of all the migrations. One more type of migration type is added - datetime (this is of 14 digits which is same as timestamp) and timestamp is now the actual timestamp of 10 digits.