### PR TITLE
Fixed docblock on model function. Changed @param model from string to mixed

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -226,7 +226,7 @@ class CI_Loader {
 	 *
 	 * Loads and instantiates models.
 	 *
-	 * @param	string	$model		Model name
+	 * @param	mixed	$model		Model name
 	 * @param	string	$name		An optional object name to assign to
 	 * @param	bool	$db_conn	An optional database connection configuration to initialize
 	 * @return	object


### PR DESCRIPTION
In the model function the $model parameter accepts either a string or an array.