### PR TITLE
Bug in documentation

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -1,7 +1,7 @@
 # Contributing to CodeIgniter
 
 
-CodeIgniter is a community driven project and accepts contributions of code and documentation from the community. These contributions are made in the form of Issues or [Pull Requests](http://help.github.com/send-pull-requests/) on the [CodeIgniter repository](https://github.com/bcit-ci/CodeIgniter>) on GitHub.
+CodeIgniter is a community driven project and accepts contributions of code and documentation from the community. These contributions are made in the form of Issues or [Pull Requests](http://help.github.com/send-pull-requests/) on the [CodeIgniter repository](https://github.com/bcit-ci/CodeIgniter) on GitHub.
 
 Issues are a quick way to point out a bug. If you find a bug or documentation error in CodeIgniter then please check a few things first:
 


### PR DESCRIPTION
When I clicked on Codeigniter repository on Contributing.md, it redirects to https://github.com/bcit-ci/CodeIgniter>, (showing 404), there is some extra greater than symbol, creating issue, so I have fixed and creating pull request for that :) .