### PR TITLE
Use PSR-1 for PHPUnit TestCase

### DIFF
--- a/tests/codeigniter/Setup_test.php
+++ b/tests/codeigniter/Setup_test.php
@@ -1,6 +1,8 @@
 <?php
 
-class Setup_test extends PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class Setup_test extends TestCase {
 
 	public function test_bootstrap_constants()
 	{

--- a/tests/mocks/ci_testcase.php
+++ b/tests/mocks/ci_testcase.php
@@ -1,6 +1,8 @@
 <?php
 
-class CI_TestCase extends PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class CI_TestCase extends TestCase {
 
 	public $ci_vfs_root;
 	public $ci_app_root;


### PR DESCRIPTION
Use [PSR-1](http://www.php-fig.org/psr/psr-1/#namespace-and-class-names) while extending PHPUnit TestCase class. This will help us when to migrate to PHPUnit 6, that [no longer support snake case namespaces](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).