### PR TITLE
Set port on base_url if not set in config

### DIFF
--- a/system/core/Config.php
+++ b/system/core/Config.php
@@ -99,13 +99,16 @@ class CI_Config {
 					$server_addr = $_SERVER['SERVER_ADDR'];
 				}
 
-				$base_url = (is_https() ? 'https' : 'http').'://'.$server_addr
-					.substr($_SERVER['SCRIPT_NAME'], 0, strpos($_SERVER['SCRIPT_NAME'], basename($_SERVER['SCRIPT_FILENAME'])));
-			}
-			else
-			{
-				$base_url = 'http://localhost/';
-			}
+                $base_url = (is_https() ? 'https' : 'http').'://'.$server_addr
+                    . ($_SERVER['SERVER_PORT'] == (is_https() ? '443' : '80') ? '' : ':' . $_SERVER['SERVER_PORT'])
+                    .substr($_SERVER['SCRIPT_NAME'], 0, strpos($_SERVER['SCRIPT_NAME'], basename($_SERVER['SCRIPT_FILENAME'])));
+            }
+            else
+            {
+                $base_url = (is_https() ? 'https' : 'http') . '://localhost'
+                    . ($_SERVER['SERVER_PORT'] == (is_https() ? '443' : '80') ? '' : ':' . $_SERVER['SERVER_PORT'])
+                    . '/';
+            }
 
 			$this->set_item('base_url', $base_url);
 		}


### PR DESCRIPTION
On OSX, port 80 cannot be used (without special permission) when testing locally and if base_url is not set in config (in favour of using the Config _constructor to set the base_url), then it should be more clever.