### PR TITLE
Clean elses

### DIFF
--- a/system/database/DB_forge.php
+++ b/system/database/DB_forge.php
@@ -382,10 +382,8 @@ abstract class CI_DB_forge {
 			{
 				return TRUE;
 			}
-			else
-			{
-				$if_not_exists = FALSE;
-			}
+
+			$if_not_exists = FALSE;
 		}
 
 		$sql = ($if_not_exists)

--- a/system/database/DB_result.php
+++ b/system/database/DB_result.php
@@ -163,10 +163,8 @@ class CI_DB_result {
 		{
 			return $this->result_object();
 		}
-		else
-		{
-			return $this->custom_result_object($type);
-		}
+
+		return $this->custom_result_object($type);
 	}
 
 	// --------------------------------------------------------------------
@@ -336,7 +334,7 @@ class CI_DB_result {
 
 		if ($type === 'object') return $this->row_object($n);
 		elseif ($type === 'array') return $this->row_array($n);
-		else return $this->custom_row_object($n, $type);
+		return $this->custom_row_object($n, $type);
 	}
 
 	// --------------------------------------------------------------------

--- a/system/database/DB_result.php
+++ b/system/database/DB_result.php
@@ -334,6 +334,7 @@ class CI_DB_result {
 
 		if ($type === 'object') return $this->row_object($n);
 		elseif ($type === 'array') return $this->row_array($n);
+
 		return $this->custom_row_object($n, $type);
 	}
 

--- a/system/libraries/Email.php
+++ b/system/libraries/Email.php
@@ -941,10 +941,8 @@ class CI_Email {
 		{
 			return 'plain-attach';
 		}
-		else
-		{
-			return 'plain';
-		}
+
+		return 'plain';
 	}
 
 	// --------------------------------------------------------------------
@@ -2209,10 +2207,8 @@ class CI_Email {
 				usleep(250000);
 				continue;
 			}
-			else
-			{
-				$timestamp = 0;
-			}
+
+			$timestamp = 0;
 		}
 
 		if ($result === FALSE)

--- a/system/libraries/Encryption.php
+++ b/system/libraries/Encryption.php
@@ -682,10 +682,8 @@ class CI_Encryption {
 			{
 				return FALSE;
 			}
-			else
-			{
-				$params['mode'] = $this->_modes[$this->_driver][$params['mode']];
-			}
+
+			$params['mode'] = $this->_modes[$this->_driver][$params['mode']];
 		}
 
 		if (isset($params['hmac']) && $params['hmac'] === FALSE)

--- a/system/libraries/Session/Session.php
+++ b/system/libraries/Session/Session.php
@@ -222,10 +222,8 @@ class CI_Session {
 			{
 				return $prefix.$class;
 			}
-			else
-			{
-				log_message('debug', 'Session: '.$prefix.$class.".php found but it doesn't declare class ".$prefix.$class.'.');
-			}
+
+			log_message('debug', 'Session: '.$prefix.$class.".php found but it doesn't declare class ".$prefix.$class.'.');
 		}
 
 		return 'CI_'.$class;

--- a/system/libraries/Upload.php
+++ b/system/libraries/Upload.php
@@ -678,10 +678,8 @@ class CI_Upload {
 			$this->set_error('upload_bad_filename', 'debug');
 			return FALSE;
 		}
-		else
-		{
-			return $new_filename;
-		}
+
+		return $new_filename;
 	}
 
 	// --------------------------------------------------------------------

--- a/system/libraries/Xmlrpcs.php
+++ b/system/libraries/Xmlrpcs.php
@@ -402,15 +402,11 @@ class CI_Xmlrpcs extends CI_Xmlrpc {
 			{
 				return get_instance()->{$method_parts[1]}($m);
 			}
-			else
-			{
-				return $this->object->{$method_parts[1]}($m);
-			}
+
+			return $this->object->{$method_parts[1]}($m);
 		}
-		else
-		{
-			return call_user_func($this->methods[$methName]['function'], $m);
-		}
+
+		return call_user_func($this->methods[$methName]['function'], $m);
 	}
 
 	// --------------------------------------------------------------------
@@ -499,10 +495,8 @@ class CI_Xmlrpcs extends CI_Xmlrpc {
 
 			return new XML_RPC_Response(new XML_RPC_Values($docstring, 'string'));
 		}
-		else
-		{
-			return new XML_RPC_Response(0, $this->xmlrpcerr['introspect_unknown'], $this->xmlrpcstr['introspect_unknown']);
-		}
+
+		return new XML_RPC_Response(0, $this->xmlrpcerr['introspect_unknown'], $this->xmlrpcstr['introspect_unknown']);
 	}
 
 	// --------------------------------------------------------------------

--- a/tests/mocks/ci_testcase.php
+++ b/tests/mocks/ci_testcase.php
@@ -377,10 +377,8 @@ class CI_TestCase extends PHPUnit_Framework_TestCase {
 		{
 			return call_user_func_array($this->{$method},$args);
 		}
-		else
-		{
-			return parent::__call($method, $args);
-		}
+
+		return parent::__call($method, $args);
 	}
 
 }


### PR DESCRIPTION
I've cleaned the `else`s when we have already returned something, this saves us some lines of code :put_litter_in_its_place:

[`PHP-CS-Fixes`](https://github.com/FriendsOfPHP/PHP-CS-Fixer) helped me find them.