### PR TITLE
Cache_memcached: setting initial value with increment/decrement when not exist

### DIFF
--- a/system/libraries/Cache/drivers/Cache_memcached.php
+++ b/system/libraries/Cache/drivers/Cache_memcached.php
@@ -210,6 +210,7 @@ class CI_Cache_memcached extends CI_Driver {
 	 */
 	public function increment($id, $offset = 1)
 	{
+		$this->_memcached->add($id, 0);
 		return $this->_memcached->increment($id, $offset);
 	}
 
@@ -224,6 +225,7 @@ class CI_Cache_memcached extends CI_Driver {
 	 */
 	public function decrement($id, $offset = 1)
 	{
+		$this->_memcached->add($id, 0);
 		return $this->_memcached->decrement($id, $offset);
 	}
 

--- a/system/libraries/Cache/drivers/Cache_memcached.php
+++ b/system/libraries/Cache/drivers/Cache_memcached.php
@@ -210,8 +210,13 @@ class CI_Cache_memcached extends CI_Driver {
 	 */
 	public function increment($id, $offset = 1)
 	{
-		$this->_memcached->add($id, 0);
-		return $this->_memcached->increment($id, $offset);
+		if (($result = $this->_memcached->increment($id, $offset)) === FALSE)
+		{
+			$this->_memcached->add($id, 0);
+			$result = $this->_memcached->increment($id, $offset);
+		}
+
+		return $result;
 	}
 
 	// ------------------------------------------------------------------------
@@ -225,8 +230,13 @@ class CI_Cache_memcached extends CI_Driver {
 	 */
 	public function decrement($id, $offset = 1)
 	{
-		$this->_memcached->add($id, 0);
-		return $this->_memcached->decrement($id, $offset);
+		if (($result = $this->_memcached->decrement($id, $offset)) === FALSE)
+		{
+			$this->_memcached->add($id, 0);
+			$result = $this->_memcached->decrement($id, $offset);
+		}
+
+		return $result;
 	}
 
 	// ------------------------------------------------------------------------

--- a/system/libraries/Cache/drivers/Cache_memcached.php
+++ b/system/libraries/Cache/drivers/Cache_memcached.php
@@ -212,7 +212,7 @@ class CI_Cache_memcached extends CI_Driver {
 	{
 		if (($result = $this->_memcached->increment($id, $offset)) === FALSE)
 		{
-			return $this->_memcached->add($id, $offset) ? $offset : $this->_memcached->increment($id, $offset);
+			return $this->_memcached->add($id, $offset) ? $offset : FALSE;
 		}
 
 		return $result;
@@ -231,7 +231,7 @@ class CI_Cache_memcached extends CI_Driver {
 	{
 		if (($result = $this->_memcached->decrement($id, $offset)) === FALSE)
 		{
-			return $this->_memcached->add($id, 0) ? 0 : $this->_memcached->decrement($id, $offset);
+			return $this->_memcached->add($id, 0) ? 0 : FALSE;
 		}
 
 		return $result;

--- a/system/libraries/Cache/drivers/Cache_memcached.php
+++ b/system/libraries/Cache/drivers/Cache_memcached.php
@@ -212,8 +212,7 @@ class CI_Cache_memcached extends CI_Driver {
 	{
 		if (($result = $this->_memcached->increment($id, $offset)) === FALSE)
 		{
-			$this->_memcached->add($id, 0);
-			$result = $this->_memcached->increment($id, $offset);
+			return $this->_memcached->add($id, $offset) ? $offset : $this->_memcached->increment($id, $offset);
 		}
 
 		return $result;
@@ -232,8 +231,7 @@ class CI_Cache_memcached extends CI_Driver {
 	{
 		if (($result = $this->_memcached->decrement($id, $offset)) === FALSE)
 		{
-			$this->_memcached->add($id, 0);
-			$result = $this->_memcached->decrement($id, $offset);
+			return $this->_memcached->add($id, 0) ? 0 : $this->_memcached->decrement($id, $offset);
 		}
 
 		return $result;


### PR DESCRIPTION
Just trying to keep consist with other drivers. I have tested `file`, `redis` and `apcu`, they would set a initial value when the item do not exist.

`Memcache` does not create an item if not exist refer [here ](https://secure.php.net/manual/en/memcache.increment.php#refsect1-memcache.increment-description).
`Memcached` would create an item, but only with binary protocol refer [here](https://secure.php.net/manual/en/memcached.increment.php#111187).I also tried it myself. 