### PR TITLE
prevent _ci_vars from being cached in _ci_cached_vars

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -950,6 +950,11 @@ class CI_Loader {
 		 * other views can have access to these variables.
 		 */
 
+		// init current _ci_vars
+		if (!is_array($_ci_vars)) {
+			$_ci_vars = [];
+		}
+
 		// merge with global cached vars (first call) or last state from nested
 		// call stack (subsequent nested calls)
 		if (!empty($this->_ci_vars_stack)) {

--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -960,7 +960,7 @@ class CI_Loader {
 
 		// push current _ci_vars state to stack and extract it
 		array_push($this->_ci_vars_stack, $_ci_vars);
-		extract($this->_ci_cached_vars);
+		extract($_ci_vars);
 
 		/**
 		 * Buffer the output

--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -957,18 +957,21 @@ class CI_Loader {
 		 */
 
 		// Init current _ci_vars as current variable configuration
-		if (!is_array($_ci_vars)) {
+		if ( ! is_array($_ci_vars))
+		{
 			$_ci_vars = [];
 		}
 
 		// Include the global cached vars into the current _ci_vars if needed
-		if (!empty($this->_ci_cached_vars)) {
+		if ( ! empty($this->_ci_cached_vars))
+		{
 			$_ci_vars = array_merge($this->_ci_cached_vars, $_ci_vars);
 		}
 
 		// Merge the last variable configuration from a parent _ci_load()
 		// call into the current _ci_vars
-		if (!empty($this->_ci_load_vars_stack)) {
+		if ( ! empty($this->_ci_load_vars_stack))
+		{
 			$previous_variable_configuration = end($this->_ci_load_vars_stack);
 			$_ci_vars = array_merge($previous_variable_configuration, $_ci_vars);
 		}

--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -94,11 +94,11 @@ class CI_Loader {
 	protected $_ci_cached_vars =	array();
 
 	/**
-	 * stack of variables for nested _ci_load calls
+	 * Stack of variable arrays to provide nested _ci_load calls all variables from parent calls
 	 *
 	 * @var	array
 	 */
-	protected $_ci_vars_stack =	array();
+	protected $_ci_load_vars_stack =	array();
 
 	/**
 	 * List of loaded classes
@@ -945,26 +945,38 @@ class CI_Loader {
 		 *
 		 * You can either set variables using the dedicated $this->load->vars()
 		 * function or via the second parameter of this function. We'll merge
-		 * the two types. Additionally we merge them with the last variables
-		 * from the nested call stack so that views that are embedded within
-		 * other views can have access to these variables.
+		 * the two types so that loaded views and files have access to these
+		 * variables.
+		 * Additionally we want all subsequent nested _ci_load() calls embedded
+		 * within the current file to 'inherit' all variables that are
+		 * accessible to the current file. For this purpose we push the current
+		 * variable configuration (_ci_vars) to the stack and remove it again
+		 * after the file or view is completely loaded. Nested _ci_load() calls
+		 * within the current file extend the stack with their variable
+		 * configuration.
 		 */
 
-		// init current _ci_vars
+		// Init current _ci_vars as current variable configuration
 		if (!is_array($_ci_vars)) {
 			$_ci_vars = [];
 		}
 
-		// merge with global cached vars (first call) or last state from nested
-		// call stack (subsequent nested calls)
-		if (!empty($this->_ci_vars_stack)) {
-			$_ci_vars = array_merge(end($this->_ci_vars_stack), $_ci_vars);
-		} else if (!empty($this->_ci_cached_vars)) {
+		// Include the global cached vars into the current _ci_vars if needed
+		if (!empty($this->_ci_cached_vars)) {
 			$_ci_vars = array_merge($this->_ci_cached_vars, $_ci_vars);
 		}
 
-		// push current _ci_vars state to stack and extract it
-		array_push($this->_ci_vars_stack, $_ci_vars);
+		// Merge the last variable configuration from a parent _ci_load()
+		// call into the current _ci_vars
+		if (!empty($this->_ci_load_vars_stack)) {
+			$previous_variable_configuration = end($this->_ci_load_vars_stack);
+			$_ci_vars = array_merge($previous_variable_configuration, $_ci_vars);
+		}
+
+		// Push the current _ci_vars to the stack
+		array_push($this->_ci_load_vars_stack, $_ci_vars);
+
+		// Extract the current _ci_vars
 		extract($_ci_vars);
 
 		/**
@@ -983,8 +995,8 @@ class CI_Loader {
 		include($_ci_path); // include() vs include_once() allows for multiple views with the same name
 		log_message('info', 'File loaded: '.$_ci_path);
 
-		// remove current _ci_vars state from stack
-		array_pop($this->_ci_vars_stack);
+		// Remove current _ci_vars from stack again
+		array_pop($this->_ci_load_vars_stack);
 
 		// Return the file data if requested
 		if ($_ci_return === TRUE)

--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -952,18 +952,14 @@ class CI_Loader {
 
 		// merge with global cached vars (first call) or last state from nested
 		// call stack (subsequent nested calls)
-		// if (!empty($this->_ci_vars_stack)) {
-		// 	$_ci_vars = array_merge(end($this->_ci_vars_stack), $_ci_vars);
-		// } else if (!empty($this->_ci_cached_vars)) {
-		// 	// merge with cached vars
-		// 	$_ci_vars = array_merge($this->_ci_cached_vars, $_ci_vars);
-		// }
-
-		empty($_ci_vars) OR $this->_ci_cached_vars = array_merge($this->_ci_cached_vars, $_ci_vars);
-
+		if (!empty($this->_ci_vars_stack)) {
+			$_ci_vars = array_merge(end($this->_ci_vars_stack), $_ci_vars);
+		} else if (!empty($this->_ci_cached_vars)) {
+			$_ci_vars = array_merge($this->_ci_cached_vars, $_ci_vars);
+		}
 
 		// push current _ci_vars state to stack and extract it
-		// array_push($this->_ci_vars_stack, $_ci_vars);
+		array_push($this->_ci_vars_stack, $_ci_vars);
 		extract($this->_ci_cached_vars);
 
 		/**
@@ -983,7 +979,7 @@ class CI_Loader {
 		log_message('info', 'File loaded: '.$_ci_path);
 
 		// remove current _ci_vars state from stack
-		// array_pop($this->_ci_vars_stack);
+		array_pop($this->_ci_vars_stack);
 
 		// Return the file data if requested
 		if ($_ci_return === TRUE)

--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -938,11 +938,10 @@ class CI_Loader {
 		 *
 		 * You can either set variables using the dedicated $this->load->vars()
 		 * function or via the second parameter of this function. We'll merge
-		 * the two types and cache them so that views that are embedded within
-		 * other views can have access to these variables.
+		 * the two types.
 		 */
-		empty($_ci_vars) OR $this->_ci_cached_vars = array_merge($this->_ci_cached_vars, $_ci_vars);
-		extract($this->_ci_cached_vars);
+		empty($this->_ci_cached_vars) OR $_ci_vars = array_merge($this->_ci_cached_vars, $_ci_vars);
+		extract($_ci_vars);
 
 		/**
 		 * Buffer the output

--- a/tests/codeigniter/core/Loader_test.php
+++ b/tests/codeigniter/core/Loader_test.php
@@ -303,11 +303,15 @@ class Loader_test extends CI_TestCase {
 		$var = 'hello';
 		$value = 'World!';
 		$content = 'This is my test page.  ';
-		$this->ci_vfs_create($view, $content.'<?php echo $'.$var.';', $this->ci_app_root, 'views');
+		$this->ci_vfs_create($view, $content.'<?php echo (isset($'.$var.') ? $'.$var.' : "undefined");', $this->ci_app_root, 'views');
 
 		// Test returning view
 		$out = $this->load->view($view, array($var => $value), TRUE);
 		$this->assertEquals($content.$value, $out);
+
+		// Test view with missing parameter in $vars
+		$out = $this->load->view($view, [], TRUE);
+		$this->assertEquals($content.'undefined', $out);
 
 		// Mock output class
 		$output = $this->getMockBuilder('CI_Output')->setMethods(array('append_output'))->getMock();

--- a/tests/codeigniter/core/Loader_test.php
+++ b/tests/codeigniter/core/Loader_test.php
@@ -318,6 +318,15 @@ class Loader_test extends CI_TestCase {
 		$vars = new stdClass();
 		$vars->$var = $value;
 		$this->assertInstanceOf('CI_Loader', $this->load->view($view, $vars));
+
+		// Create another view in VFS, nesting the first one without its own $vars
+		$nesting_view = 'unit_test_nesting_view';
+		$nesting_content = 'Here comes a nested view.  ';
+		$this->ci_vfs_create($nesting_view, $nesting_content.'<?php $loader->view("'.$view.'");', $this->ci_app_root, 'views');
+
+		// Test $vars inheritance to nested views
+		$out = $this->load->view($nesting_view, array("loader" => $this->load, $var => $value), TRUE);
+		$this->assertEquals($nesting_content.$content.$value, $out);
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
Signed-off-by: Christian Mohr <christian.mohr@insitu.de>

I propose to prevent variables from the second `$this->load->view()` parameter `$vars` to get stored within the `$this->_ci_cached_vars` cache. This cache should only be filled from a corresponding `$this->load->vars()` call and respectively cleared via `$this->load->clear_vars()`if desired. This would be the behaviour expressed within the [documentation](https://www.codeigniter.com/user_guide/libraries/loader.html?highlight=view#CI_Loader::view).

**Background**: The documentation states, that global view parameters could be set via `vars()` and afterwards used within all views without further requirements. This store can be cleared via `clear_vars()` if necessary. The `CI_Loader::view()` method provides an alternative approach for providing a single view with dynamic data. Neither does the documentation state that this data gets stored internally and send to all subsequent view calls, whether nested subviews or completely different ones. Nor is this an intuitive way to use the `view()` function since it suggests that the `$vars` parameter is used for this call only.

**Issue**: As soon as one uses `isset($variableName)` or similar within a view file, the behaviour depends on which `view()` calls with which `$vars` preceeded the current one. It should depend ONLY on which `$vars` where provided to the current call and also what was set beforehand via an explicit `vars()` call.
