### PR TITLE
Fix of Session_memcached_driver::_get_lock 

### DIFF
--- a/system/libraries/Session/drivers/Session_memcached_driver.php
+++ b/system/libraries/Session/drivers/Session_memcached_driver.php
@@ -313,6 +313,8 @@ class CI_Session_memcached_driver extends CI_Session_driver implements SessionHa
 					? $this->_memcached->add($this->_lock_key, time(), 300)
 					: FALSE;
 			}
+
+			return TRUE;
 		}
 
 		// 30 attempts to obtain a lock, in case another request already has it


### PR DESCRIPTION
Just a one line change.

It should return `TRUE` when calling of `$this->_memcached->replace()` succeed. Otherwise,  it would at last fail with 30 attempts , becasue the later calling of `$this->_memcached->get()` always get the value just set.