### PR TITLE
Bug fix that made the mobile not be identified by robots

### DIFF
--- a/system/libraries/User_agent.php
+++ b/system/libraries/User_agent.php
@@ -250,17 +250,19 @@ class CI_User_agent {
 	 * @return	bool
 	 */
 	protected function _compile_data()
-	{
-		$this->_set_platform();
+    {
+        $this->_set_platform();
 
-		foreach (array('_set_robot', '_set_browser', '_set_mobile') as $function)
-		{
-			if ($this->$function() === TRUE)
-			{
-				break;
-			}
-		}
-	}
+        foreach (array('_set_mobile', '_set_robot', '_set_browser') as $function)
+        {
+            if ($this->$function() === TRUE)
+            {
+                if ($function != '_set_mobile'){
+                    break;
+                }
+            }
+        }
+    }
 
 	// --------------------------------------------------------------------
 


### PR DESCRIPTION
The way it was being done, did not allow the Google Adwords robot to identify the page as mobile.

At the time it was identified as "robot", it would not be more mobile. This issue caused alerts in Google Adwords and Analytics.

It can be checked in: https://search.google.com/test/mobile-friendly