### PR TITLE
Give force_download a header conforming to RFC 6266

### DIFF
--- a/system/helpers/download_helper.php
+++ b/system/helpers/download_helper.php
@@ -152,7 +152,7 @@ if ( ! function_exists('force_download'))
 		if (strtoupper($encoding) !== 'UTF-8')
 		{
 			$converted_filename = get_instance()->utf8->convert_to_utf8($utf8_filename, $encoding);
-			if ($converted_filename)
+			if ($converted_filename !== FALSE)
 			{
 				$utf8_filename = $converted_filename;
 			}

--- a/system/helpers/download_helper.php
+++ b/system/helpers/download_helper.php
@@ -148,10 +148,10 @@ if ( ! function_exists('force_download'))
 		}
 
 		$utf8_filename = $filename;
-		$encoding = config_item('charset');
-		if (strtoupper($encoding) !== 'UTF-8')
+		$charset = config_item('charset');
+		if (strtoupper($charset) !== 'UTF-8')
 		{
-			$converted_filename = get_instance()->utf8->convert_to_utf8($utf8_filename, $encoding);
+			$converted_filename = get_instance()->utf8->convert_to_utf8($utf8_filename, $charset);
 			if ($converted_filename !== FALSE)
 			{
 				$utf8_filename = $converted_filename;

--- a/system/helpers/download_helper.php
+++ b/system/helpers/download_helper.php
@@ -151,13 +151,10 @@ if ( ! function_exists('force_download'))
 		$encoding = config_item('charset');
 		if (strtoupper($encoding) !== 'UTF-8')
 		{
-			if (MB_ENABLED)
+			$CI =& get_instance();
+			if ($converted_filename = $CI->utf8->convert_to_utf8($utf8_filename, $encoding) )
 			{
-				$utf8_filename = mb_convert_encoding($utf8_filename, 'UTF-8', $encoding);
-			}
-			elseif (ICONV_ENABLED)
-			{
-				$utf8_filename = @iconv($encoding, 'UTF-8', $utf8_filename);
+				$utf8_filename = $converted_filename;
 			}
 		}
 

--- a/system/helpers/download_helper.php
+++ b/system/helpers/download_helper.php
@@ -147,21 +147,21 @@ if ( ! function_exists('force_download'))
 			@ob_clean();
 		}
 
-		$utf8_filename = $filename;
+		$disposition = 'attachment; filename="'.$filename.'";';
 		$charset = config_item('charset');
 		if (strtoupper($charset) !== 'UTF-8')
 		{
-			$converted_filename = get_instance()->utf8->convert_to_utf8($utf8_filename, $charset);
-			if ($converted_filename !== FALSE)
+			// charset attribute (RFC 6266 only allows UTF-8)
+			$utf8_filename = get_instance()->utf8->convert_to_utf8($filename, $charset);
+			if ($utf8_filename !== FALSE)
 			{
-				$utf8_filename = $converted_filename;
+				$disposition .= ' filename*=UTF-8\'\''.rawurlencode($utf8_filename);
 			}
 		}
 
 		// Generate the server headers
 		header('Content-Type: '.$mime);
-		// charset attribute (RFC 6266 only allows UTF-8)
-		header('Content-Disposition: attachment; filename="'.$filename.'"; filename*=UTF-8\'\''.rawurlencode($utf8_filename));
+		header('Content-Disposition: '.$disposition);
 		header('Expires: 0');
 		header('Content-Transfer-Encoding: binary');
 		header('Content-Length: '.$filesize);

--- a/system/helpers/download_helper.php
+++ b/system/helpers/download_helper.php
@@ -149,7 +149,7 @@ if ( ! function_exists('force_download'))
 
 		// Generate the server headers
 		header('Content-Type: '.$mime);
-		header('Content-Disposition: attachment; filename="'.$filename.'"');
+		header('Content-Disposition: attachment; filename="'.$filename.'"; filename*=UTF-8\'\''.rawurlencode($filename));
 		header('Expires: 0');
 		header('Content-Transfer-Encoding: binary');
 		header('Content-Length: '.$filesize);

--- a/system/helpers/download_helper.php
+++ b/system/helpers/download_helper.php
@@ -151,8 +151,8 @@ if ( ! function_exists('force_download'))
 		$encoding = config_item('charset');
 		if (strtoupper($encoding) !== 'UTF-8')
 		{
-			$CI =& get_instance();
-			if ($converted_filename = $CI->utf8->convert_to_utf8($utf8_filename, $encoding) )
+			$converted_filename = get_instance()->utf8->convert_to_utf8($utf8_filename, $encoding);
+			if ($converted_filename)
 			{
 				$utf8_filename = $converted_filename;
 			}

--- a/system/helpers/download_helper.php
+++ b/system/helpers/download_helper.php
@@ -147,9 +147,24 @@ if ( ! function_exists('force_download'))
 			@ob_clean();
 		}
 
+		$utf8_filename = $filename;
+		$encoding = config_item('charset');
+		if (strtoupper($encoding) !== 'UTF-8')
+		{
+			if (MB_ENABLED)
+			{
+				$utf8_filename = mb_convert_encoding($utf8_filename, 'UTF-8', $encoding);
+			}
+			elseif (ICONV_ENABLED)
+			{
+				$utf8_filename = @iconv($encoding, 'UTF-8', $utf8_filename);
+			}
+		}
+
 		// Generate the server headers
 		header('Content-Type: '.$mime);
-		header('Content-Disposition: attachment; filename="'.$filename.'"; filename*=UTF-8\'\''.rawurlencode($filename));
+		// charset attribute (RFC 6266 only allows UTF-8)
+		header('Content-Disposition: attachment; filename="'.$filename.'"; filename*=UTF-8\'\''.rawurlencode($utf8_filename));
 		header('Expires: 0');
 		header('Content-Transfer-Encoding: binary');
 		header('Content-Length: '.$filesize);


### PR DESCRIPTION
When I created an application to download multibyte file name, the file name got corrupted.

Changed give force_download a header conforming to "RFC6266"

The phenomenon that the file name is garbled can be confirmed with Internet Explorer 11 older.

https://tools.ietf.org/html/rfc6266

```php
<?php

class Downloader extends CI_Controller
{
    public function __construct()
    {
         parent::__construct();
         $this->load->helper('download');
     }

     public function download()
     {
         force_download('マルチバイト.txt', 'test');
      }
}
```