### PR TITLE
Fixed bug that download filename character code did not change 

### DIFF
--- a/system/helpers/download_helper.php
+++ b/system/helpers/download_helper.php
@@ -153,9 +153,7 @@ if ( ! function_exists('force_download'))
 		$charset = strtoupper(config_item('charset'));
 		if ($charset !== 'UTF-8')
 		{
-			$utf8_filename = (UTF8_ENABLED === TRUE)
-				? get_instance()->utf8->convert_to_utf8($filename, $charset)
-				: FALSE;
+			$utf8_filename = get_instance()->utf8->convert_to_utf8($filename, $charset);
 		}
 		else
 		{


### PR DESCRIPTION
link: https://github.com/bcit-ci/CodeIgniter/pull/5394

Fixed bug that download filename character code did not change 

https://github.com/bcit-ci/CodeIgniter/pull/5403/files#diff-c54549fcea24b456454689aab2d65904L156

This line is `false` unless you change the `charset` value with `set_config`.

This is because the following implementation is done in the Utf8 class

https://github.com/bcit-ci/CodeIgniter/blob/develop/system/core/Utf8.php#L65