### PR TITLE
Allow cross join (join on true) in query builder

### DIFF
--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -526,7 +526,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	public function join($table, $cond, $type = '', $escape = NULL)
 	{
 		$type = trim(strtoupper($type).' JOIN');
-		preg_match('#^(((NATURAL|CROSS)\s+)|((LEFT|RIGHT)\s+)?((INNER|OUTER))\s+)?JOIN$#', $type) OR $type = 'JOIN';
+		preg_match('#^((CROSS\s+)|((NATURAL\s+)?((LEFT|RIGHT)\s+)?((INNER|OUTER))\s+))?JOIN$#', $type) OR $type = 'JOIN';
 
 		// Extract any aliases that might exist. We use this information
 		// in the protect_identifiers to know whether to add a table prefix

--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -538,6 +538,11 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 		{
 			$cond = '';
 		}
+		// Check CROSS JOIN (JOIN ON TRUE) before checking !_has_operator
+		elseif (trim(strtoupper($cond)) === 'TRUE' )
+		{
+			$cond = ' ON TRUE ';
+		}
 		elseif ( ! $this->_has_operator($cond))
 		{
 			$cond = ' USING ('.($escape ? $this->escape_identifiers($cond) : $cond).')';

--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -526,7 +526,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	public function join($table, $cond, $type = '', $escape = NULL)
 	{
 		$type = trim(strtoupper($type).' JOIN');
-		preg_match('#^(NATURAL\s+)?((LEFT|RIGHT)\s+)?((INNER|OUTER)\s+)?JOIN$#', $type) OR $type = 'JOIN';
+		preg_match('#^(((NATURAL|CROSS)\s+)|((LEFT|RIGHT)\s+)?((INNER|OUTER))\s+)?JOIN$#', $type) OR $type = 'JOIN';
 
 		// Extract any aliases that might exist. We use this information
 		// in the protect_identifiers to know whether to add a table prefix


### PR DESCRIPTION
When upgrading to CodeIgniter 3, my cross joins stopped working. That's because the the join command assumes any JOIN condition without an operator must be a USING. But that is a faulty assumption, as JOIN ON TRUE is valid SQL for generating a CROSS JOIN.