### PR TITLE
oci8 database driver: Added support of insert_id()

### DIFF
--- a/system/database/drivers/oci8/oci8_driver.php
+++ b/system/database/drivers/oci8/oci8_driver.php
@@ -463,9 +463,9 @@ class CI_DB_oci8_driver extends CI_DB {
 
 		if ($column !== NULL)
 		{
-			$sql =  'SELECT ' . strtoupper($column) . ' AS SEQ ' .
-					'FROM ' . strtoupper($this->_table) . ' ' .
-					'WHERE ROWID = ' . $this->escape($this->_rowid);
+			$sql = 'SELECT ' . strtoupper($column) . ' AS SEQ ' .
+			       'FROM ' . strtoupper($this->_table) . ' ' .
+			       'WHERE ROWID = ' . $this->escape($this->_rowid);
 			$seq = $this->query($sql)->row()->SEQ;
 			return $seq;
 		}

--- a/system/database/drivers/pdo/subdrivers/pdo_oci_driver.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_oci_driver.php
@@ -248,9 +248,9 @@ class CI_DB_pdo_oci_driver extends CI_DB_pdo_driver {
 
 		if ($column !== NULL)
 		{
-			$sql =  'SELECT ' . strtoupper($column) . ' AS SEQ ' .
-					'FROM ' . strtoupper($this->_table) . ' ' .
-					'WHERE ROWID = ' . $this->escape($this->_rowid);
+			$sql = 'SELECT ' . strtoupper($column) . ' AS SEQ ' .
+			       'FROM ' . strtoupper($this->_table) . ' ' .
+			       'WHERE ROWID = ' . $this->escape($this->_rowid);
 			$seq = $this->query($sql)->row()->SEQ;
 			return $seq;
 		}


### PR DESCRIPTION
Added support of ``$db->insert_id()`` method in OCI8 database driver. By default this method return the ROWID Oracle pseudocolumn, but you can specify another column (eg. with a sequence) using ``$db->rowid_column`` public property.

This is a sample:

```.php
$this->db->insert('FOO', [
  'FOO_FIELD' => 'BAR',
]);

var_dump($this->db->insert_id());
// string(18) "AAAmpiAAEAAAHerAAE"
```

In alternative you can specify a column with a sequence:

```.php
$this->db->rowid_column = 'FOO_ID';
$this->db->insert('FOO', [
  'FOO_FIELD' => 'BAR',
]);

var_dump($this->db->insert_id());
// string(18) "1001"
```
