### PR TITLE
Fixed bug in ZIP library

### DIFF
--- a/system/libraries/Zip.php
+++ b/system/libraries/Zip.php
@@ -366,7 +366,7 @@ class CI_Zip {
 
 		while (FALSE !== ($file = readdir($fp)))
 		{
-			if ($file[0] === '.')
+			if ($file === '.' OR $file === '..')
 			{
 				continue;
 			}


### PR DESCRIPTION
the `read_dir` method ignores files that start with a dot (like .htaccess).
I looked through the documentation and it didn't mention that the method ignores hidden files so it must be a bug.