### PR TITLE
Update Image_lib to avoid setting file permissions when not needed

### DIFF
--- a/system/libraries/Image_lib.php
+++ b/system/libraries/Image_lib.php
@@ -835,7 +835,10 @@ class CI_Image_lib {
 		imagedestroy($dst_img);
 		imagedestroy($src_img);
 
-		chmod($this->full_dst_path, $this->file_permissions);
+		if ($this->dynamic_output !== TRUE)
+		{
+			chmod($this->full_dst_path, $this->file_permissions);
+		}
 
 		return TRUE;
 	}


### PR DESCRIPTION
When processing an image, there is no need to set file permissions when using dynamic_output.
In some cases, it floods the log file with errors
ERROR  --> Severity: Warning --> chmod(): Operation not permitted ...../CodeIgniter/libraries/Image_lib.php 838