### PR TITLE
form validation issue

### DIFF
--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -702,6 +702,7 @@ class CI_Form_validation {
 				&& $callback === FALSE
 				&& $callable === FALSE
 				&& ! in_array($rule, array('required', 'isset', 'matches'), TRUE)
+				&& method_exists($this, $rule) === FALSE
 			)
 			{
 				continue;


### PR DESCRIPTION
I was having an issue with form validation.  I use a my_form_validation extension instead of callbacks.
i have a field, that depending on context may or may not be valid as empty string.  so the $postdata ==='' needs to be evaluated by $this->$rule . This single-line mod makes sure that the code is evaluated if $this->$rule is present even if the $postdata is empty.