### PR TITLE
Issue #5454: CI_Security::xss_clean() regexp fixed to avoid capturing valid symbol sequences

### DIFF
--- a/system/core/Security.php
+++ b/system/core/Security.php
@@ -383,7 +383,7 @@ class CI_Security {
 			{
 				$oldstr = $str;
 				$str = rawurldecode($str);
-				$str = preg_replace_callback('#%(?:\s*[0-9a-f]){2,}#i', array($this, '_urldecodespaces'), $str);
+				$str = preg_replace_callback('#%(?:[0-9a-f]){2,}#i', array($this, '_urldecodespaces'), $str);
 			}
 			while ($oldstr !== $str);
 			unset($oldstr);


### PR DESCRIPTION
The CI_Security::xss_clean() is supposed to allow percent symbol and the following space, so that valid texts are not cleaned out.