### PR TITLE
Create cli-production.php for CLI Bootstrap

### DIFF
--- a/cli-production.php
+++ b/cli-production.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * Codeigniter 3 CLI Bootstrap for production environment
+ */
+
+// CLI bootstrap only
+if (php_sapi_name() !== 'cli') {
+    
+    die('Access Denied');
+}
+// Pre-override ENVIRONMENT constant
+define('ENVIRONMENT', 'production');
+// Load app bootstrap
+require __DIR__ . '/index.php';

--- a/cli-production.php
+++ b/cli-production.php
@@ -9,7 +9,7 @@ if (php_sapi_name() !== 'cli') {
     
     die('Access Denied');
 }
-// Pre-override ENVIRONMENT constant
-define('ENVIRONMENT', 'production');
+// Set env for ENVIRONMENT 
+$_SERVER['CI_ENV'] = 'production';
 // Load app bootstrap
 require __DIR__ . '/index.php';


### PR DESCRIPTION
Codeigniter 3 CLI Bootstrap for production environment

`$_SERVER['CI_ENV']` could not be determined when running on CLI, we could create a CLI bootstrap to solve production CLI problem such as running crontab. 