### PR TITLE
Reset cached variables in load->view()

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -960,6 +960,9 @@ class CI_Loader {
 		include($_ci_path); // include() vs include_once() allows for multiple views with the same name
 		log_message('info', 'File loaded: '.$_ci_path);
 
+		// Reset cached variables
+		$this->_ci_cached_vars = array();
+
 		// Return the file data if requested
 		if ($_ci_return === TRUE)
 		{


### PR DESCRIPTION
Variable cache allows "views that are embedded within other views can have access to these variables" - according to the documentation.

But it has a side effect: if you load views in a row, the later loaded ones can access variables from the previous ones. E.g.:

`$this->load->view('first-view', ['firstVariable' => 'foo']);`
`$this->load->view('second-view');`

In second-view.php, you can access $firstVariable.

Resetting cache avoids this but keeps the embedding functionality.