### PR TITLE
Asset Versioning

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -469,3 +469,19 @@ $config['time_reference'] = 'local';
 | Array:		array('10.0.1.200', '192.168.5.0/24')
 */
 $config['proxy_ips'] = '';
+
+/*
+|--------------------------------------------------------------------------
+| Asset Version
+|--------------------------------------------------------------------------
+|
+| Enables addition of a version identify to the URL of static assets
+| such as CSS, JS and Images.
+|
+| Particularly useful when all your assets are cached.
+|
+| You should change this number whenever an update is made on any asset. This
+| enables the users browser to force the refresh of cached assets.
+|
+*/
+$config['asset_version']	= 1;

--- a/application/config/config.php
+++ b/application/config/config.php
@@ -484,4 +484,4 @@ $config['proxy_ips'] = '';
 | enables the users browser to force the refresh of cached assets.
 |
 */
-$config['asset_version']	= 1;
+$config['asset_version'] = 1;

--- a/application/config/config.php
+++ b/application/config/config.php
@@ -469,19 +469,3 @@ $config['time_reference'] = 'local';
 | Array:		array('10.0.1.200', '192.168.5.0/24')
 */
 $config['proxy_ips'] = '';
-
-/*
-|--------------------------------------------------------------------------
-| Asset Version
-|--------------------------------------------------------------------------
-|
-| Enables addition of a version identifier to the URL of static assets
-| such as CSS, JS and Images.
-|
-| Particularly useful when all your assets are cached.
-|
-| You should change this number whenever an update is made on any asset. This
-| enables the users browser to force the refresh of cached assets.
-|
-*/
-$config['asset_version'] = 1;

--- a/application/config/config.php
+++ b/application/config/config.php
@@ -475,7 +475,7 @@ $config['proxy_ips'] = '';
 | Asset Version
 |--------------------------------------------------------------------------
 |
-| Enables addition of a version identify to the URL of static assets
+| Enables addition of a version identifier to the URL of static assets
 | such as CSS, JS and Images.
 |
 | Particularly useful when all your assets are cached.

--- a/system/helpers/asset_helper.php
+++ b/system/helpers/asset_helper.php
@@ -1,40 +1,40 @@
 <?php
 /**
-* CodeIgniter
-*
-* An open source application development framework for PHP
-*
-* This content is released under the MIT License (MIT)
-*
-* Copyright (c) 2014 - 2018, British Columbia Institute of Technology
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in
-* all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-* THE SOFTWARE.
-*
-* @package	CodeIgniter
-* @author	EllisLab Dev Team
-* @copyright	Copyright (c) 2008 - 2014, EllisLab, Inc. (https://ellislab.com/)
-* @copyright	Copyright (c) 2014 - 2018, British Columbia Institute of Technology (http://bcit.ca/)
-* @license	http://opensource.org/licenses/MIT	MIT License
-* @link	https://codeigniter.com
-* @since	Version 1.0.0
-* @filesource
-*/
+ * CodeIgniter
+ *
+ * An open source application development framework for PHP
+ *
+ * This content is released under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 - 2018, British Columbia Institute of Technology
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @package	CodeIgniter
+ * @author	EllisLab Dev Team
+ * @copyright	Copyright (c) 2008 - 2014, EllisLab, Inc. (https://ellislab.com/)
+ * @copyright	Copyright (c) 2014 - 2018, British Columbia Institute of Technology (http://bcit.ca/)
+ * @license	http://opensource.org/licenses/MIT	MIT License
+ * @link	https://codeigniter.com
+ * @since	Version 1.0.0
+ * @filesource
+ */
 defined('BASEPATH') OR exit('No direct script access allowed');
 
 /**

--- a/system/helpers/asset_helper.php
+++ b/system/helpers/asset_helper.php
@@ -38,7 +38,7 @@
 defined('BASEPATH') OR exit('No direct script access allowed');
 
 /**
- * CodeIgniter CAPTCHA Helper
+ * CodeIgniter Asset Helper
  *
  * @package		CodeIgniter
  * @subpackage	Helpers

--- a/system/helpers/asset_helper.php
+++ b/system/helpers/asset_helper.php
@@ -1,65 +1,65 @@
 <?php
 /**
- * CodeIgniter
- *
- * An open source application development framework for PHP
- *
- * This content is released under the MIT License (MIT)
- *
- * Copyright (c) 2014 - 2018, British Columbia Institute of Technology
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- *
- * @package	CodeIgniter
- * @author	EllisLab Dev Team
- * @copyright	Copyright (c) 2008 - 2014, EllisLab, Inc. (https://ellislab.com/)
- * @copyright	Copyright (c) 2014 - 2018, British Columbia Institute of Technology (http://bcit.ca/)
- * @license	http://opensource.org/licenses/MIT	MIT License
- * @link	https://codeigniter.com
- * @since	Version 1.0.0
- * @filesource
- */
+* CodeIgniter
+*
+* An open source application development framework for PHP
+*
+* This content is released under the MIT License (MIT)
+*
+* Copyright (c) 2014 - 2018, British Columbia Institute of Technology
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*
+* @package	CodeIgniter
+* @author	EllisLab Dev Team
+* @copyright	Copyright (c) 2008 - 2014, EllisLab, Inc. (https://ellislab.com/)
+* @copyright	Copyright (c) 2014 - 2018, British Columbia Institute of Technology (http://bcit.ca/)
+* @license	http://opensource.org/licenses/MIT	MIT License
+* @link	https://codeigniter.com
+* @since	Version 1.0.0
+* @filesource
+*/
 defined('BASEPATH') OR exit('No direct script access allowed');
 
 /**
- * CodeIgniter Asset Helper
- *
- * @package		CodeIgniter
- * @subpackage	Helpers
- * @category	Helpers
- * @author		EllisLab Dev Team
- */
+* CodeIgniter Asset Helper
+*
+* @package		CodeIgniter
+* @subpackage	Helpers
+* @category	Helpers
+* @author		EllisLab Dev Team
+*/
 
- // --------------------------------------------------------------------
+// --------------------------------------------------------------------
 
- if ( ! function_exists('asset_version'))
- {
- 	/**
- 	 * Returns the current version URL of assets.
- 	 *
- 	 * @param	string $uri
-   * @param	string	$protocol
- 	 * @return	string
- 	 */
- 	function asset_version($uri = '', $protocol = NULL)
- 	{
+if ( ! function_exists('asset_version'))
+{
+  /**
+  * Returns the current version URL of assets.
+  *
+  * @param	string $uri
+  * @param	string	$protocol
+  * @return	string
+  */
+  function asset_version($uri = '', $protocol = NULL)
+  {
     $version = get_instance()->config->item('asset_version');
- 		return get_instance()->config->base_url($uri, $protocol) . '?v=' . $version;
- 	}
- }
+    return get_instance()->config->base_url($uri, $protocol) . '?v=' . $version;
+  }
+}

--- a/system/helpers/asset_helper.php
+++ b/system/helpers/asset_helper.php
@@ -38,28 +38,28 @@
 defined('BASEPATH') OR exit('No direct script access allowed');
 
 /**
-* CodeIgniter Asset Helper
-*
-* @package		CodeIgniter
-* @subpackage	Helpers
-* @category	Helpers
-* @author		EllisLab Dev Team
-*/
+ * CodeIgniter Asset Helper
+ *
+ * @package		CodeIgniter
+ * @subpackage	Helpers
+ * @category	Helpers
+ * @author		EllisLab Dev Team
+ */
 
-// --------------------------------------------------------------------
+// ------------------------------------------------------------------------
 
-if ( ! function_exists('asset_version'))
+if ( ! function_exists('uri_string'))
 {
-  /**
-  * Returns the current version URL of assets.
-  *
-  * @param	string $uri
-  * @param	string	$protocol
-  * @return	string
-  */
-  function asset_version($uri = '', $protocol = NULL)
-  {
-    $version = get_instance()->config->item('asset_version');
-    return get_instance()->config->base_url($uri, $protocol) . '?v=' . $version;
-  }
+        /**
+         * Returns the current version URL of assets.
+         *
+         * @param	string $uri
+         * @param	string	$protocol
+         * @return	string
+         */
+      	function asset_version($uri = '', $protocol = NULL)
+      	{
+      		$version = get_instance()->config->item('asset_version');
+      		return get_instance()->config->base_url($uri, $protocol) . '?v=' . $version;
+      	}
 }

--- a/system/helpers/asset_helper.php
+++ b/system/helpers/asset_helper.php
@@ -48,7 +48,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 
 // ------------------------------------------------------------------------
 
-if ( ! function_exists('uri_string'))
+if ( ! function_exists('asset_version'))
 {
         /**
          * Returns the current version URL of assets.
@@ -58,8 +58,8 @@ if ( ! function_exists('uri_string'))
          * @return	string
          */
       	function asset_version($uri = '', $protocol = NULL)
-      	{
-      		$version = get_instance()->config->item('asset_version');
+      	{ 
+      		$version = filemtime(FCPATH . $uri);
       		return get_instance()->config->base_url($uri, $protocol) . '?v=' . $version;
       	}
 }

--- a/system/helpers/asset_helper.php
+++ b/system/helpers/asset_helper.php
@@ -54,6 +54,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  	 * Returns the current version URL of assets.
  	 *
  	 * @param	string $uri
+   * @param	string	$protocol
  	 * @return	string
  	 */
  	function asset_version($uri = '', $protocol = NULL)

--- a/system/helpers/asset_helper.php
+++ b/system/helpers/asset_helper.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * CodeIgniter
+ *
+ * An open source application development framework for PHP
+ *
+ * This content is released under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 - 2018, British Columbia Institute of Technology
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @package	CodeIgniter
+ * @author	EllisLab Dev Team
+ * @copyright	Copyright (c) 2008 - 2014, EllisLab, Inc. (https://ellislab.com/)
+ * @copyright	Copyright (c) 2014 - 2018, British Columbia Institute of Technology (http://bcit.ca/)
+ * @license	http://opensource.org/licenses/MIT	MIT License
+ * @link	https://codeigniter.com
+ * @since	Version 1.0.0
+ * @filesource
+ */
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+/**
+ * CodeIgniter CAPTCHA Helper
+ *
+ * @package		CodeIgniter
+ * @subpackage	Helpers
+ * @category	Helpers
+ * @author		EllisLab Dev Team
+ */
+
+ // --------------------------------------------------------------------
+
+ if ( ! function_exists('asset_version'))
+ {
+ 	/**
+ 	 * Returns the current version URL of assets.
+ 	 *
+ 	 * @param	string $uri
+ 	 * @return	string
+ 	 */
+ 	function asset_version($uri = '', $protocol = NULL)
+ 	{
+    $version = get_instance()->config->item('asset_version');
+ 		return get_instance()->config->base_url($uri, $protocol) . '?v=' . $version;
+ 	}
+ }

--- a/tests/codeigniter/helpers/asset_helper_test.php
+++ b/tests/codeigniter/helpers/asset_helper_test.php
@@ -1,4 +1,5 @@
 <?php
+define('FCPATH', dirname(__FILE__).DIRECTORY_SEPARATOR);
 
 class Asset_helper_test extends CI_TestCase {
 
@@ -14,7 +15,7 @@ class Asset_helper_test extends CI_TestCase {
 	{
 		$this->ci_set_config('base_url', 'http://localhost/');
 
-		$asset_directory = 'assets_test';
+		$asset_directory = FCPATH . 'assets_test';
 
 		if (! is_dir($asset_directory))
 		{

--- a/tests/codeigniter/helpers/asset_helper_test.php
+++ b/tests/codeigniter/helpers/asset_helper_test.php
@@ -14,7 +14,7 @@ class Asset_helper_test extends CI_TestCase {
 	{
 		$this->ci_set_config('base_url', 'http://localhost/');
 
-		$asset_directory = FCPATH . 'assets_test';
+		$asset_directory = 'assets_test';
 
 		if (! is_dir($asset_directory))
 		{

--- a/tests/codeigniter/helpers/asset_helper_test.php
+++ b/tests/codeigniter/helpers/asset_helper_test.php
@@ -1,0 +1,23 @@
+<?php
+
+class Asset_helper_test extends CI_TestCase {
+
+	public function set_up()
+	{
+		$this->helper('asset');
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function test_asset_version()
+	{
+    $this->ci_set_config('asset_version', 1);
+    $this->ci_set_config('base_url', 'http://localhost/');
+
+    $this->assertEquals(
+      'http://localhost/assets/css/bootstrap.css?v=1',
+      asset_version('assets/css/bootstrap.css')
+    );
+	}
+}

--- a/tests/codeigniter/helpers/asset_helper_test.php
+++ b/tests/codeigniter/helpers/asset_helper_test.php
@@ -20,4 +20,5 @@ class Asset_helper_test extends CI_TestCase {
 			asset_version('assets/css/bootstrap.css')
 		);
 	}
+	
 }

--- a/tests/codeigniter/helpers/asset_helper_test.php
+++ b/tests/codeigniter/helpers/asset_helper_test.php
@@ -8,16 +8,16 @@ class Asset_helper_test extends CI_TestCase {
 	}
 
 	/**
-	 * @runInSeparateProcess
-	 */
+	* @runInSeparateProcess
+	*/
 	public function test_asset_version()
 	{
-    $this->ci_set_config('asset_version', 1);
-    $this->ci_set_config('base_url', 'http://localhost/');
+		$this->ci_set_config('asset_version', 1);
+		$this->ci_set_config('base_url', 'http://localhost/');
 
-    $this->assertEquals(
-      'http://localhost/assets/css/bootstrap.css?v=1',
-      asset_version('assets/css/bootstrap.css')
-    );
+		$this->assertEquals(
+			'http://localhost/assets/css/bootstrap.css?v=1',
+			asset_version('assets/css/bootstrap.css')
+		);
 	}
 }

--- a/tests/codeigniter/helpers/asset_helper_test.php
+++ b/tests/codeigniter/helpers/asset_helper_test.php
@@ -12,13 +12,27 @@ class Asset_helper_test extends CI_TestCase {
 	*/
 	public function test_asset_version()
 	{
-		$this->ci_set_config('asset_version', 1);
 		$this->ci_set_config('base_url', 'http://localhost/');
 
+		$asset_directory = FCPATH . 'assets_test';
+
+		if (! is_dir($asset_directory))
+		{
+			mkdir($asset_directory, 0755, true);
+		}
+
+		file_put_contents($asset_directory . '/test.css', '');
+
+		$time = filemtime($asset_directory . '/test.css');
+
 		$this->assertEquals(
-			'http://localhost/assets/css/bootstrap.css?v=1',
-			asset_version('assets/css/bootstrap.css')
+			'http://localhost/assets_test/test.css?v=' . $time,
+			asset_version('assets_test/test.css')
 		);
+
+		unlink($asset_directory . '/test.css');
+
+		rmdir($asset_directory);
 	}
-	
+
 }

--- a/user_guide_src/source/changelog.rst
+++ b/user_guide_src/source/changelog.rst
@@ -127,6 +127,9 @@ Release Date: Not Released
       - Added ability to generate ``data:image/png;base64`` URIs instead of writing image files to disk.
       - Updated to always create PNG images instead of JPEG.
 
+   -  :doc:`Asset Helper <helpers/asset_helper>` changes include:
+
+      - Added function :php:func:`asset_version()` for appending version identifiers to assets
 
 Version 3.1.9
 =============

--- a/user_guide_src/source/helpers/asset_helper.rst
+++ b/user_guide_src/source/helpers/asset_helper.rst
@@ -1,0 +1,47 @@
+##########
+Asset Helper
+##########
+
+The URL Helper file contains functions that assist in working with URLs.
+
+.. contents::
+  :local:
+
+.. raw:: html
+
+  <div class="custom-index container"></div>
+
+Loading this Helper
+===================
+
+This helper is loaded using the following code::
+
+	$this->load->helper('asset');
+
+Available Functions
+===================
+
+The following functions are available:
+
+.. php:function:: asset_version([$uri = ''[, $protocol = NULL]])
+
+	:param	string	$uri: Asset URI string
+	:param	string	$protocol: Protocol, e.g. 'http' or 'https'
+	:returns:	Site URL with version identifier
+	:rtype:	string
+
+  Returns an asset URL with the addition of a version identifier. Version
+  identifiers are especially useful when assets are cached in the users
+  browser.
+
+  You are encourage to use this function whenever you want to generate an asset
+  url because it enables the browser to force the refresh of assets when a
+  change is made.
+
+  Segments can be passed as strings just like the ``base_url()`` helper. Here is
+  an example::
+
+    echo asset_version('assets/css/bootstrap.css');
+
+  The above example would return something like this:
+  *http://mysite.com/assets/css/bootstrap.css?v=1*


### PR DESCRIPTION
Overview
----------------------------------------
This update enables the addition of a version identifier to assets such as JS, CSS and Images 

Before
----------------------------------------
The **base_url()** or **site_url()** helper functions are usually used for assets but it makes it difficult for end users to see updates when an asset is cached and then updated. 

After
----------------------------------------
An introduction of a helper function called **asset_version()** for assets. This would give all assets version identifiers which would thereby force a browser to refresh the assets whenever an update is made. 

Usage
----------------------------------------
- Add **'asset'** to the helper autoload

---