### PR TITLE
Fix sphinx warning message

### DIFF
--- a/user_guide_src/source/installation/upgrade_320.rst
+++ b/user_guide_src/source/installation/upgrade_320.rst
@@ -194,7 +194,7 @@ You should change it to::
 	form_upload('name', $extra);
 
 Step 10: Remove usage of previously deprecated functionalities
-=============================================================
+==============================================================
 
 The following is a list of functionalities deprecated in previous
 CodeIgniter versions that have been removed in 3.2.0:


### PR DESCRIPTION
Not a big deal, but addresses Sphinx warning message "Title underline too short."