### PR TITLE
Only use the output of idn_to_ascii() if it worked properly

### DIFF
--- a/system/libraries/Email.php
+++ b/system/libraries/Email.php
@@ -1017,7 +1017,11 @@ class CI_Email {
 			$domain = defined('INTL_IDNA_VARIANT_UTS46')
 				? idn_to_ascii($matches[2], 0, INTL_IDNA_VARIANT_UTS46)
 				: idn_to_ascii($matches[2]);
-			$email = $matches[1].'@'.$domain;
+			//If idn_to_ascii() fails, treat it like it doesn't exists
+			if ($domain !== FALSE)
+			{
+				$email = $account.'@'.$domain;
+			}
 		}
 
 		return (bool) filter_var($email, FILTER_VALIDATE_EMAIL);
@@ -1828,7 +1832,11 @@ class CI_Email {
 			$domain = defined('INTL_IDNA_VARIANT_UTS46')
 				? idn_to_ascii($domain, 0, INTL_IDNA_VARIANT_UTS46)
 				: idn_to_ascii($domain);
-			$email = $account.'@'.$domain;
+			//If idn_to_ascii() fails, treat it like it doesn't exists
+			if ($domain !== FALSE)
+			{
+				$email = $account.'@'.$domain;
+			}
 		}
 
 		return (filter_var($email, FILTER_VALIDATE_EMAIL) === $email && preg_match('#\A[a-z0-9._+-]+@[a-z0-9.-]{1,253}\z#i', $email));

--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -1240,7 +1240,11 @@ class CI_Form_validation {
 			$domain = defined('INTL_IDNA_VARIANT_UTS46')
 				? idn_to_ascii($matches[2], 0, INTL_IDNA_VARIANT_UTS46)
 				: idn_to_ascii($matches[2]);
-			$str = $matches[1].'@'.$domain;
+			//If idn_to_ascii() fails, treat it like it doesn't exists
+			if ($domain !== FALSE)
+			{
+				$str = $matches[1].'@'.$domain;
+			}
 		}
 
 		return (bool) filter_var($str, FILTER_VALIDATE_EMAIL);


### PR DESCRIPTION
According to the manual, idn_to_ascii will return false if it encounters a problem. This happend on one of our systems (the function exists, but there was an issue in the underlaying libraries, which prevented that the function works). This resulted on that system in:

foo@example.com -> foo@[false] -> validate("foo@")

This will obviously fail. The solution is that when the function does not work properly, to treat it like it doesn't exists at all.