### PR TITLE
Add support for multiple APPPATHS

### DIFF
--- a/index.php
+++ b/index.php
@@ -299,6 +299,15 @@ switch (ENVIRONMENT)
 	define('VIEWPATH', $view_folder.DIRECTORY_SEPARATOR);
 
 /*
+ * -----------------------------------------------------------------------------
+ *  Optionally add another APPPATH to your application, useful when
+ *  creating a package, and wanting to expand with new controllers/models/etc...
+ *  Except core classes, everything else can be added to this path
+ * -----------------------------------------------------------------------------
+ */
+	//$APPPATHS = array();
+
+/*
  * --------------------------------------------------------------------
  * LOAD THE BOOTSTRAP FILE
  * --------------------------------------------------------------------

--- a/system/core/Config.php
+++ b/system/core/Config.php
@@ -83,6 +83,7 @@ class CI_Config {
 	 */
 	public function __construct()
 	{
+		$this->_config_paths = unserialize(APPPATHS);
 		$this->config =& get_config();
 
 		// Set the base_url automatically if none was provided

--- a/system/core/Hooks.php
+++ b/system/core/Hooks.php
@@ -97,15 +97,18 @@ class CI_Hooks {
 			return;
 		}
 
-		// Grab the "hooks" definition file.
-		if (file_exists(APPPATH.'config/hooks.php'))
+		foreach (unserialize(APPPATHS) as $APPPATH)
 		{
-			include(APPPATH.'config/hooks.php');
-		}
+			// Grab the "hooks" definition file.
+			if (file_exists($APPPATH.'config/hooks.php'))
+			{
+				include($APPPATH.'config/hooks.php');
+			}
 
-		if (file_exists(APPPATH.'config/'.ENVIRONMENT.'/hooks.php'))
-		{
-			include(APPPATH.'config/'.ENVIRONMENT.'/hooks.php');
+			if (file_exists($APPPATH.'config/'.ENVIRONMENT.'/hooks.php'))
+			{
+				include($APPPATH.'config/'.ENVIRONMENT.'/hooks.php');
+			}
 		}
 
 		// If there are no hooks, we're done.
@@ -198,9 +201,16 @@ class CI_Hooks {
 			return FALSE;
 		}
 
-		$filepath = APPPATH.$data['filepath'].'/'.$data['filename'];
+		$filepath = '';
+		foreach (array_reverse(unserialize(APPPATHS)) as $APPPATH)
+		{
+			if (file_exists($APPPATH.$data['filepath'].DIRECTORY_SEPARATOR.$data['filename']))
+			{
+				$filepath = $APPPATH.$data['filepath'].DIRECTORY_SEPARATOR.$data['filename'];
+			}
+		}
 
-		if ( ! file_exists($filepath))
+		if (empty($filepath))
 		{
 			return FALSE;
 		}

--- a/system/core/Router.php
+++ b/system/core/Router.php
@@ -157,14 +157,18 @@ class CI_Router {
 		// Load the routes.php file. It would be great if we could
 		// skip this for enable_query_strings = TRUE, but then
 		// default_controller would be empty ...
-		if (file_exists(APPPATH.'config/routes.php'))
-		{
-			include(APPPATH.'config/routes.php');
-		}
 
-		if (file_exists(APPPATH.'config/'.ENVIRONMENT.'/routes.php'))
+		foreach (unserialize(APPPATHS) as $APPPATH)
 		{
-			include(APPPATH.'config/'.ENVIRONMENT.'/routes.php');
+			if (file_exists($APPPATH.'config/routes.php'))
+			{
+				include($APPPATH.'config/routes.php');
+			}
+
+			if (file_exists($APPPATH.'config/'.ENVIRONMENT.'/routes.php'))
+			{
+				include($APPPATH.'config/'.ENVIRONMENT.'/routes.php');
+			}
 		}
 
 		// Validate & get reserved routes
@@ -300,7 +304,16 @@ class CI_Router {
 			$method = 'index';
 		}
 
-		if ( ! file_exists(APPPATH.'controllers/'.$this->directory.ucfirst($class).'.php'))
+		$found = FALSE;
+		foreach (unserialize(APPPATHS) as $APPPATH)
+		{
+			if (file_exists($APPPATH.'controllers/'.$this->directory.ucfirst($class).'.php'))
+			{
+				$found = TRUE;
+			}
+		}
+
+		if ( ! $found)
 		{
 			// This will trigger 404 later
 			return;
@@ -341,13 +354,16 @@ class CI_Router {
 			$test = $this->directory
 				.ucfirst($this->translate_uri_dashes === TRUE ? str_replace('-', '_', $segments[0]) : $segments[0]);
 
-			if ( ! file_exists(APPPATH.'controllers/'.$test.'.php')
-				&& $directory_override === FALSE
-				&& is_dir(APPPATH.'controllers/'.$this->directory.$segments[0])
-			)
+			foreach (unserialize(APPPATHS) as $APPPATH)
 			{
-				$this->set_directory(array_shift($segments), TRUE);
-				continue;
+				if ( ! file_exists($APPPATH.'controllers/'.$test.'.php')
+					&& $directory_override === FALSE
+					&& is_dir($APPPATH.'controllers/'.$this->directory.$segments[0])
+				)
+				{
+					$this->set_directory(array_shift($segments), TRUE);
+					continue;
+				}
 			}
 
 			return $segments;

--- a/system/database/DB.php
+++ b/system/database/DB.php
@@ -66,7 +66,7 @@ function &DB($params = '', $query_builder_override = NULL)
 		// given that the controller instance already exists
 		if (class_exists('CI_Controller', FALSE))
 		{
-			foreach (get_instance()->load->get_package_paths() as $path)
+			foreach (array_unique(array_merge(get_instance()->load->get_package_paths(), unserialize(APPPATHS))) as $path)
 			{
 				if ($path !== APPPATH)
 				{

--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -1712,7 +1712,7 @@ abstract class CI_DB_driver {
 				if (strpos($call['file'], BASEPATH.'database') === FALSE && strpos($call['class'], 'Loader') === FALSE)
 				{
 					// Found it - use a relative path for safety
-					$message[] = 'Filename: '.str_replace(array(APPPATH, BASEPATH), '', $call['file']);
+					$message[] = 'Filename: '.str_replace(array_merge(array(APPPATH, BASEPATH), unserialize(APPPATHS)), '', $call['file']);
 					$message[] = 'Line Number: '.$call['line'];
 					break;
 				}

--- a/system/helpers/html_helper.php
+++ b/system/helpers/html_helper.php
@@ -235,14 +235,17 @@ if ( ! function_exists('doctype'))
 
 		if ( ! is_array($doctypes))
 		{
-			if (file_exists(APPPATH.'config/doctypes.php'))
+			foreach (unserialize(APPPATHS) as $APPPATH)
 			{
-				include(APPPATH.'config/doctypes.php');
-			}
+				if (file_exists($APPPATH.'config/doctypes.php'))
+				{
+					include($APPPATH.'config/doctypes.php');
+				}
 
-			if (file_exists(APPPATH.'config/'.ENVIRONMENT.'/doctypes.php'))
-			{
-				include(APPPATH.'config/'.ENVIRONMENT.'/doctypes.php');
+				if (file_exists($APPPATH.'config/'.ENVIRONMENT.'/doctypes.php'))
+				{
+					include($APPPATH.'config/'.ENVIRONMENT.'/doctypes.php');
+				}
 			}
 
 			if (empty($_doctypes) OR ! is_array($_doctypes))

--- a/system/helpers/text_helper.php
+++ b/system/helpers/text_helper.php
@@ -401,14 +401,17 @@ if ( ! function_exists('convert_accented_characters'))
 
 		if ( ! is_array($array_from))
 		{
-			if (file_exists(APPPATH.'config/foreign_chars.php'))
+			foreach (unserialize(APPPATHS) as $APPPATH)
 			{
-				include(APPPATH.'config/foreign_chars.php');
-			}
+				if (file_exists($APPPATH.'config/foreign_chars.php'))
+				{
+					include($APPPATH.'config/foreign_chars.php');
+				}
 
-			if (file_exists(APPPATH.'config/'.ENVIRONMENT.'/foreign_chars.php'))
-			{
-				include(APPPATH.'config/'.ENVIRONMENT.'/foreign_chars.php');
+				if (file_exists($APPPATH.'config/'.ENVIRONMENT.'/foreign_chars.php'))
+				{
+					include($APPPATH.'config/'.ENVIRONMENT.'/foreign_chars.php');
+				}
 			}
 
 			if (empty($foreign_characters) OR ! is_array($foreign_characters))

--- a/system/libraries/Migration.php
+++ b/system/libraries/Migration.php
@@ -135,10 +135,15 @@ class CI_Migration {
 		}
 
 		// If not set, set it
-		$this->_migration_path !== '' OR $this->_migration_path = APPPATH.'migrations/';
+		$this->_migration_path !== '' OR $this->_migration_path = APPPATH.'migrations'.DIRECTORY_SEPARATOR;
 
-		// Add trailing slash if not set
-		$this->_migration_path = rtrim($this->_migration_path, '/').'/';
+		$_migration_paths = array_unique(array_merge(array($this->_migration_path), unserialize(APPPATHS)));
+		$this->_migration_path = array();
+		foreach ($_migration_paths as $_migration_path)
+		{
+			// Add trailing slash if not set
+			$this->_migration_path[] = rtrim($_migration_path, '/').'/';
+		}
 
 		// Load migration language
 		$this->lang->load('migration');
@@ -380,7 +385,13 @@ class CI_Migration {
 		$migrations = array();
 
 		// Load all *_*.php files in the migrations path
-		foreach (glob($this->_migration_path.'*_*.php') as $file)
+		$_migration_files = [];
+		foreach ($this->_migration_path as $path)
+		{
+			$_migration_files = array_merge($_migration_files, glob($path.'*_*.php'));
+		}
+
+		foreach ($_migration_files as $file)
 		{
 			$name = basename($file, '.php');
 

--- a/system/libraries/User_agent.php
+++ b/system/libraries/User_agent.php
@@ -193,15 +193,20 @@ class CI_User_agent {
 	 */
 	protected function _load_agent_file()
 	{
-		if (($found = file_exists(APPPATH.'config/user_agents.php')))
+		$found = FALSE;
+		foreach (unserialize(APPPATHS) as $APPPATH)
 		{
-			include(APPPATH.'config/user_agents.php');
-		}
+			if (file_exists($APPPATH.'config/user_agents.php'))
+			{
+				include($APPPATH.'config/user_agents.php');
+				$found = TRUE;
+			}
 
-		if (file_exists(APPPATH.'config/'.ENVIRONMENT.'/user_agents.php'))
-		{
-			include(APPPATH.'config/'.ENVIRONMENT.'/user_agents.php');
-			$found = TRUE;
+			if (file_exists($APPPATH.'config/'.ENVIRONMENT.'/user_agents.php'))
+			{
+				include($APPPATH.'config/'.ENVIRONMENT.'/user_agents.php');
+				$found = TRUE;
+			}
 		}
 
 		if ($found !== TRUE)

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -32,6 +32,8 @@ defined('BASEPATH') OR define('BASEPATH', vfsStream::url('system/'));
 defined('APPPATH') OR define('APPPATH', vfsStream::url('application/'));
 defined('VIEWPATH') OR define('VIEWPATH', APPPATH.'views/');
 defined('ENVIRONMENT') OR define('ENVIRONMENT', 'development');
+defined('APPPATHS_EXTRA') OR define('APPPATHS_EXTRA', serialize(array()));
+defined('APPPATHS') OR define('APPPATHS', serialize(array(APPPATH)));
 
 // Set localhost "remote" IP
 isset($_SERVER['REMOTE_ADDR']) OR $_SERVER['REMOTE_ADDR'] = '127.0.0.1';


### PR DESCRIPTION
#### My scenario: I wanted to create a CMS.  
These changes are needed when creating a bundle like package.  
  
Each client will have a repo, so instead of having the CMS code and
framework in every clients' repo, I make the CMS a dependency, and the CMS
has codeigniter as a dependency.  
This way it's easy to update either the codeigniter system or the CMS code, as simple as a composer update (after changing the composer.json).
  
So we end up having client application(config, controllers, helpers, language, views, libraries, everything except core) -> cms application(all the good stuff) -> system.  
  
Without these changes I cant create custom models/controllers/configs or
anything else, per clients' demand, other than what can be extended by the CMS application.  
  
I've only tested it seeing if everything works, I haven't made any tests (my testing is kind of rusty).  
And from what I can see it works, I'm not sure if it breaks anything, I'm sure someone will let me know if that's the case.