### PR TITLE
Solve error 2014 calling stored procedures mysqli

### DIFF
--- a/system/database/drivers/mysqli/mysqli_driver.php
+++ b/system/database/drivers/mysqli/mysqli_driver.php
@@ -296,7 +296,12 @@ class CI_DB_mysqli_driver extends CI_DB {
 	 */
 	protected function _execute($sql)
 	{
-		return $this->conn_id->query($this->_prep_query($sql));
+		$result = $this->conn_id->query($this->_prep_query($sql));
+		while (mysqli_more_results($this->conn_id))
+            	{
+                    mysqli_next_result($this->conn_id);
+		}
+		return $result;
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
When calling multiple stored procedures, we can run into the following error: "Commands out of sync; you can't run this command now".
In MySQL, a procedure can return more than one result set, and it will always return one extra empty result set that carries some meta information on the procedure call itself, especially error information.
Only is fetched the results of the SELECT executed within the procedure though.
Source: 
https://bugs.mysql.com/bug.php?id=71044
https://dev.mysql.com/doc/refman/5.6/en/mysql-more-results.html
https://dev.mysql.com/doc/refman/8.0/en/commands-out-of-sync.html