### PR TITLE
Use Config::base_url() properly

### DIFF
--- a/system/helpers/html_helper.php
+++ b/system/helpers/html_helper.php
@@ -200,7 +200,7 @@ if ( ! function_exists('img'))
 				}
 				else
 				{
-					$img .= ' src="'.get_instance()->config->slash_item('base_url').$v.'"';
+					$img .= ' src="'.get_instance()->config->base_url($v).'"';
 				}
 			}
 			else
@@ -292,7 +292,7 @@ if ( ! function_exists('link_tag'))
 					}
 					else
 					{
-						$link .= 'href="'.$CI->config->slash_item('base_url').$v.'" ';
+						$link .= 'href="'.$CI->config->base_url($v).'" ';
 					}
 				}
 				else
@@ -313,7 +313,7 @@ if ( ! function_exists('link_tag'))
 			}
 			else
 			{
-				$link .= 'href="'.$CI->config->slash_item('base_url').$href.'" ';
+				$link .= 'href="'.$CI->config->base_url($href).'" ';
 			}
 
 			$link .= 'rel="'.$rel.'" type="'.$type.'" ';


### PR DESCRIPTION
Using the Config::slash_item() method, we get double forward slashes. For example, base_url = 'http://localhost:8080/' and asset is '/assets/my_asset.css', then the generated URL would be 'http://localhost:8080//assets/my_asset.css'.

This patch fixes that, so the generated URL would be 'http://localhost:8080/assets/my_asset.css'. There is actually already an analog example in the case if index_page === TRUE, where the site_url() function is used.