### PR TITLE
Set CSRF cookie empty if regenerate is activated

### DIFF
--- a/system/core/Security.php
+++ b/system/core/Security.php
@@ -238,6 +238,7 @@ class CI_Security {
 		if (config_item('csrf_regenerate'))
 		{
 			// Nothing should last forever
+			setcookie($this->_csrf_cookie_name);
 			unset($_COOKIE[$this->_csrf_cookie_name]);
 			$this->_csrf_hash = NULL;
 		}


### PR DESCRIPTION
CSRF cookie was reusable till expire even regenerate is activated. It's a security vulnerability. A cookie should be use once if regenerate activated. Setting cookie to empty is guarantee to use a cookie only once.