### PR TITLE
urldecode($slug)

### DIFF
--- a/user_guide_src/source/tutorial/news_section.rst
+++ b/user_guide_src/source/tutorial/news_section.rst
@@ -172,7 +172,7 @@ add some code to the controller and create a new view. Go back to the
 
 	public function view($slug = NULL)
 	{
-		$data['news_item'] = $this->news_model->get_news($slug);
+		$data['news_item'] = $this->news_model->get_news(urldecode($slug));
 
 		if (empty($data['news_item']))
 		{


### PR DESCRIPTION
as $slug passed here for News::view($slug) is in url-encoded, in case of multi-bytes string, news_model->get_news($slug) will fail.