### PR TITLE
Use multidimensional array as rule (field name)

### DIFF
--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -221,7 +221,7 @@ class CI_Form_validation {
 		if (($is_array = (bool) preg_match_all('/\[(.*?)\]/', $field, $matches)) === TRUE)
 		{
 			sscanf($field, '%[^[][', $indexes[0]);
-			$indexes = array_merge($indexes, $matches[1]);
+			$indexes = array_merge($indexes, $matches[1][$i]);
 		}
 
 		// Build our master array
@@ -560,6 +560,12 @@ class CI_Form_validation {
 		{
 			if ( empty($keys[$i]) )
 			{
+				if ( !isset($keys[$i+1]) )
+				{
+					unset($keys[$i]);
+					return $this->_reduce_array($array, $keys, ($i+1));
+				}
+
 				return array_column($array, $keys[$i+1]);
 			}
 

--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -221,7 +221,7 @@ class CI_Form_validation {
 		if (($is_array = (bool) preg_match_all('/\[(.*?)\]/', $field, $matches)) === TRUE)
 		{
 			sscanf($field, '%[^[][', $indexes[0]);
-			$indexes = array_merge($indexes, $matches[1][$i]);
+			$indexes = array_merge($indexes, $matches[1]);
 		}
 
 		// Build our master array

--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -221,14 +221,7 @@ class CI_Form_validation {
 		if (($is_array = (bool) preg_match_all('/\[(.*?)\]/', $field, $matches)) === TRUE)
 		{
 			sscanf($field, '%[^[][', $indexes[0]);
-
-			for ($i = 0, $c = count($matches[0]); $i < $c; $i++)
-			{
-				if ($matches[1][$i] !== '')
-				{
-					$indexes[] = $matches[1][$i];
-				}
-			}
+			$indexes = array_merge($indexes, $matches[1]);
 		}
 
 		// Build our master array
@@ -565,6 +558,11 @@ class CI_Form_validation {
 	{
 		if (is_array($array) && isset($keys[$i]))
 		{
+			if ( empty($keys[$i]) )
+			{
+				return array_column($array, $keys[$i+1]);
+			}
+
 			return isset($array[$keys[$i]]) ? $this->_reduce_array($array[$keys[$i]], $keys, ($i+1)) : NULL;
 		}
 


### PR DESCRIPTION
Now it is possible validate something like this:
```JSON
{
    "name": "My custom template 00",
    "text": "Big custom text here",
    "vars": [
        {
            "name": "Birth",
            "position": 0,
            "step": 0
        },
        {
            "name": "Full name",
            "position": 1,
            "step": 0
        }
    ]
}
```

Or like this:
```HTML
<form action="" method="POST">
	<input name="name" value="My custom template 00"><br>
	<input name="text" value="Big custom text here"><br>
	<input name="vars[0][name]" value="Birth"><br>
	<input name="vars[0][position]" value="0"><br>
	<input name="vars[0][step]" value="0"><br>
	<input name="vars[1][name]" value="Full name"><br>
	<input name="vars[1][position]" value="1"><br>
	<input name="vars[1][step]" value="0"><br>
	<button type="submit">Send</button><br>
</form>
```

[The normal way to use array as field names](https://codeigniter.com/user_guide/libraries/form_validation.html#using-arrays-as-field-names)
```PHP
$this->form_validation->set_rules('options[]', 'Options', 'required');
```

The new way to use array as field name (the old one still working): 
```PHP
$validator->set_rules('var[][name]', 'Variable', 'required|min_length[4]|max_length[50]');
$validator->set_value('var[][name]');
```

Like this: https://forum.codeigniter.com/thread-63551-post-325434.html (also my problem)