### PR TITLE
Input: considering nested array keys in `get_post` and `post_get`

### DIFF
--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -212,9 +212,8 @@ class CI_Input {
 	 */
 	public function post_get($index, $xss_clean = FALSE)
 	{
-		return isset($_POST[$index])
-			? $this->post($index, $xss_clean)
-			: $this->get($index, $xss_clean);
+		$output = $this->post($index, $xss_clean);
+		return ($output !== NULL) ? $output : $this->get($index, $xss_clean);
 	}
 
 	// --------------------------------------------------------------------
@@ -228,9 +227,8 @@ class CI_Input {
 	 */
 	public function get_post($index, $xss_clean = FALSE)
 	{
-		return isset($_GET[$index])
-			? $this->get($index, $xss_clean)
-			: $this->post($index, $xss_clean);
+		$output = $this->get($index, $xss_clean);
+		return ($output !== NULL) ? $output : $this->post($index, $xss_clean);
 	}
 
 	// --------------------------------------------------------------------

--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -213,7 +213,7 @@ class CI_Input {
 	public function post_get($index, $xss_clean = FALSE)
 	{
 		$output = $this->post($index, $xss_clean);
-		return ($output !== NULL) ? $output : $this->get($index, $xss_clean);
+		return isset($output) ? $output : $this->get($index, $xss_clean);
 	}
 
 	// --------------------------------------------------------------------
@@ -228,7 +228,7 @@ class CI_Input {
 	public function get_post($index, $xss_clean = FALSE)
 	{
 		$output = $this->get($index, $xss_clean);
-		return ($output !== NULL) ? $output : $this->post($index, $xss_clean);
+		return isset($output) ? $output : $this->post($index, $xss_clean);
 	}
 
 	// --------------------------------------------------------------------

--- a/tests/codeigniter/core/Input_test.php
+++ b/tests/codeigniter/core/Input_test.php
@@ -90,12 +90,46 @@ class Input_test extends CI_TestCase {
 
 	// --------------------------------------------------------------------
 
+	public function test_post_get_array_notation()
+	{
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$_POST['foo']['bar'] = 'baz';
+		$barArray = array('bar' => 'baz');
+
+		$this->assertEquals('baz', $this->input->get_post('foo[bar]'));
+		$this->assertEquals($barArray, $this->input->get_post('foo[]'));
+		$this->assertNull($this->input->get_post('foo[baz]'));
+
+		$this->assertEquals('baz', $this->input->post_get('foo[bar]'));
+		$this->assertEquals($barArray, $this->input->post_get('foo[]'));
+		$this->assertNull($this->input->post_get('foo[baz]'));
+	}
+
+	// --------------------------------------------------------------------
+
 	public function test_get_post()
 	{
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 		$_GET['foo'] = 'bar';
 
 		$this->assertEquals('bar', $this->input->get_post('foo'));
+	}
+
+	// --------------------------------------------------------------------
+
+	public function test_get_post_array_notation()
+	{
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$_GET['foo']['bar'] = 'baz';
+		$barArray = array('bar' => 'baz');
+
+		$this->assertEquals('baz', $this->input->get_post('foo[bar]'));
+		$this->assertEquals($barArray, $this->input->get_post('foo[]'));
+		$this->assertNull($this->input->get_post('foo[baz]'));
+
+		$this->assertEquals('baz', $this->input->post_get('foo[bar]'));
+		$this->assertEquals($barArray, $this->input->post_get('foo[]'));
+		$this->assertNull($this->input->post_get('foo[baz]'));
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
With URL such as `http://ci.mine.cn/test/test_get?a[b]=test` and the following code
```
$something = $this->input->get('a[b]');
$something2 = $this->input->get_post('a[b]');
var_dump($something, $something2);
```

`$something` gets 'test', and `$something2` turns out to be `NULL`.  However, they are expected to be the same.

So I try to fix it using null comparison instead of `isset` check.