### PR TITLE
Update User Agents

### DIFF
--- a/application/config/user_agents.php
+++ b/application/config/user_agents.php
@@ -88,7 +88,8 @@ $browsers = array(
 	'IBrowse'		=> 'IBrowse',
 	'Maxthon'		=> 'Maxthon',
 	'Ubuntu'		=> 'Ubuntu Web Browser',
-	'Vivaldi'		=> 'Vivaldi'
+	'Vivaldi'		=> 'Vivaldi',
+	'MALGJS'		=> 'LG OEM Windows Devices'
 );
 
 $mobiles = array(


### PR DESCRIPTION
'MALGJS' means LG OEM Windows Devices. (like a notebook) with Windows 10 but detected as mobile.
but IE11 browser in LG OEM devices with Windows 10 agent value like this:
Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; MALGJS; rv:11.0) like Gecko