### PR TITLE
Recursive translate_uri_dashes on each segment

### DIFF
--- a/system/core/Router.php
+++ b/system/core/Router.php
@@ -258,10 +258,9 @@ class CI_Router {
 
 		if ($this->translate_uri_dashes === TRUE)
 		{
-			$segments[0] = str_replace('-', '_', $segments[0]);
-			if (isset($segments[1]))
+			foreach($segments as &$each_segment)
 			{
-				$segments[1] = str_replace('-', '_', $segments[1]);
+				$each_segment = str_replace('-', '_', $each_segment);
 			}
 		}
 


### PR DESCRIPTION
Recursive translate_uri_dashes on each segment of the URL.
Because when your controllers are in folders, sub-folders, sub-sub-folders, etc., the translate_uri_dashes property is only applied on 2 firsts segments.