### PR TITLE
Fixed problem with session crash

### DIFF
--- a/system/libraries/Session/drivers/Session_files_driver.php
+++ b/system/libraries/Session/drivers/Session_files_driver.php
@@ -206,16 +206,7 @@ class CI_Session_files_driver extends CI_Session_driver implements SessionHandle
 			rewind($this->_file_handle);
 		}
 
-		$session_data = '';
-		for ($read = 0, $length = filesize($this->_file_path.$session_id); $read < $length; $read += self::strlen($buffer))
-		{
-			if (($buffer = fread($this->_file_handle, $length - $read)) === FALSE)
-			{
-				break;
-			}
-
-			$session_data .= $buffer;
-		}
+		$session_data = file_get_contents($this->_file_path.$session_id);
 
 		$this->_fingerprint = md5($session_data);
 		return $session_data;


### PR DESCRIPTION
Site froze (100% CPU) when user open more than 2 pages in one moment in other tabs in browser. This happened after adding the method php5_validate_id (exactly validateId) in 3.1.9 My fix resolved this problem.