### PR TITLE
allow for escaping database and field names with non-standard characters

### DIFF
--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -1341,7 +1341,7 @@ abstract class CI_DB_driver {
 			return $item;
 		}
 		// Avoid breaking functions and literal values inside queries
-		elseif (ctype_digit($item) OR $item[0] === "'" OR ($this->_escape_char !== '"' && $item[0] === '"') OR strpos($item, '(') !== FALSE)
+		elseif (ctype_digit($item) OR $item[0] === "'" OR ($this->_escape_char !== '"' && $item[0] === '"') OR $item[0] === (is_array($this->_escape_char)?implode($this->_escape_char):$this->_escape_char) OR strpos($item, '(') !== FALSE)
 		{
 			return $item;
 		}
@@ -1777,7 +1777,7 @@ abstract class CI_DB_driver {
 		//
 		// Added exception for single quotes as well, we don't want to alter
 		// literal strings. -- Narf
-		if (strcspn($item, "()'") !== strlen($item))
+		if (strcspn($item, "()'".(is_array($this->_escape_char)?implode($this->_escape_char):$this->_escape_char)) !== strlen($item))
 		{
 			return $item;
 		}

--- a/system/database/drivers/cubrid/cubrid_driver.php
+++ b/system/database/drivers/cubrid/cubrid_driver.php
@@ -128,8 +128,8 @@ class CI_DB_cubrid_driver extends CI_DB {
 
 		$func = ($persistent !== TRUE) ? 'cubrid_connect' : 'cubrid_pconnect';
 		return ($this->username !== '')
-			? $func($this->hostname, $this->port, $this->database, $this->username, $this->password)
-			: $func($this->hostname, $this->port, $this->database);
+			? $func($this->hostname, $this->port, trim($this->database,(is_array($this->_escape_char)?implode($this->_escape_char):$this->_escape_char)), $this->username, $this->password)
+			: $func($this->hostname, $this->port, trim($this->database,(is_array($this->_escape_char)?implode($this->_escape_char):$this->_escape_char)));
 	}
 
 	// --------------------------------------------------------------------

--- a/system/database/drivers/mysqli/mysqli_driver.php
+++ b/system/database/drivers/mysqli/mysqli_driver.php
@@ -198,7 +198,7 @@ class CI_DB_mysqli_driver extends CI_DB {
 			}
 		}
 
-		if ($this->_mysqli->real_connect($hostname, $this->username, $this->password, $this->database, $port, $socket, $client_flags))
+		if ($this->_mysqli->real_connect($hostname, $this->username, $this->password, trim($this->database,(is_array($this->_escape_char)?implode($this->_escape_char):$this->_escape_char)), $port, $socket, $client_flags))
 		{
 			// Prior to version 5.7.3, MySQL silently downgrades to an unencrypted connection if SSL setup fails
 			if (


### PR DESCRIPTION
Signed-off-by: Kepler Gelotte <kepler@neighborwebmaster.com>

This pull request addresses feature request: Table names with commas. #2755

You can now escape database, table, and field names with the escape character(s) before submitting a request. For example:

```php
// Mysql example
$this->db->insert('`weird table name`', array('id' => 1, '`funky, name`' => 'some data'));
```
