### PR TITLE
Activate DB_driver reconnect method

### DIFF
--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -469,13 +469,15 @@ abstract class CI_DB_driver {
 	 * Keep / reestablish the db connection if no queries have been
 	 * sent for a length of time exceeding the server's idle timeout.
 	 *
-	 * This is just a dummy method to allow drivers without such
-	 * functionality to not declare it, while others will override it.
+	 * This is a common method to allow drivers with their own 
+	 * functionality to override it.
 	 *
 	 * @return	void
 	 */
 	public function reconnect()
 	{
+		$this->close();
+		$this->initialize();
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
For common DB driver usage, this default reconnecting flow could support all drivers such as PDO.