### PR TITLE
Added exception when redis extn is not loaded

### DIFF
--- a/system/libraries/Cache/drivers/Cache_redis.php
+++ b/system/libraries/Cache/drivers/Cache_redis.php
@@ -86,7 +86,9 @@ class CI_Cache_redis extends CI_Driver
 	{
 		if ( ! $this->is_supported())
 		{
-			log_message('error', 'Cache: Failed to create Redis object; extension not loaded?');
+			$msg = "Cache: Failed to create Redis object; extension not loaded?";
+			throw new Exception($msg, 1);
+			log_message('error', $msg);
 			return;
 		}
 


### PR DESCRIPTION
Fixes: https://github.com/bcit-ci/CodeIgniter/issues/5577 . Outputs a meaningful exception when the redis extension wasn't found and prevents the redis cache library from being loaded, instead of allowing the user to proceed loading the redis library without failure.