### PR TITLE
ftp_no_source_file specifies local file name

### DIFF
--- a/system/libraries/Ftp.php
+++ b/system/libraries/Ftp.php
@@ -663,7 +663,7 @@ class CI_FTP {
 		$CI =& get_instance();
 		$CI->lang->load('ftp');
 		$extra_message = ($file) ? " ($file)" : "";		
-		show_error($CI->lang->line($line).$file);
+		show_error($CI->lang->line($line).$extra_message);
 	}
 
 }

--- a/system/libraries/Ftp.php
+++ b/system/libraries/Ftp.php
@@ -309,7 +309,7 @@ class CI_FTP {
 
 		if ( ! file_exists($locpath))
 		{
-			$this->_error('ftp_no_source_file');
+			$this->_error('ftp_no_source_file', $locpath);
 			return FALSE;
 		}
 
@@ -655,13 +655,15 @@ class CI_FTP {
 	 * Display error message
 	 *
 	 * @param	string	$line
+	 * @param	string	$file
 	 * @return	void
 	 */
-	protected function _error($line)
+	protected function _error($line, $file = false)
 	{
 		$CI =& get_instance();
 		$CI->lang->load('ftp');
-		show_error($CI->lang->line($line));
+		$extra_message = ($file) ? " ($file)" : "";		
+		show_error($CI->lang->line($line).$file);
 	}
 
 }


### PR DESCRIPTION
`ftp_no_source_file` returns a general "*Unable to locate the source file. Please check your path*" error making it difficult to see where the problem is.
The method has been updated to show the file is throwing the error so that it returns "*Unable to locate the source file. Please check your path* **(your/local/filename)**"