### PR TITLE
Update DB_driver.php

### DIFF
--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -1131,11 +1131,12 @@ abstract class CI_DB_driver {
 	 * position is the primary key
 	 *
 	 * @param	string	$table	Table name
+	 * @param	bool	$refresh_cache	Refresh data cache
 	 * @return	string
 	 */
-	public function primary($table)
+	public function primary($table, $refresh_cache = FALSE)
 	{
-		$fields = $this->list_fields($table);
+		$fields = $this->list_fields($table, $refresh_cache);
 		return is_array($fields) ? current($fields) : FALSE;
 	}
 
@@ -1174,12 +1175,13 @@ abstract class CI_DB_driver {
 	 * Returns an array of table names
 	 *
 	 * @param	string	$constrain_by_prefix = FALSE
+	 * @param	bool	$refresh_cache	Refresh data cache
 	 * @return	array
 	 */
-	public function list_tables($constrain_by_prefix = FALSE)
+	public function list_tables($constrain_by_prefix = FALSE, $refresh_cache = FALSE)
 	{
 		// Is there a cached result?
-		if (isset($this->data_cache['table_names']))
+		if ($refresh_cache === FALSE && isset($this->data_cache['table_names']))
 		{
 			return $this->data_cache['table_names'];
 		}
@@ -1229,11 +1231,12 @@ abstract class CI_DB_driver {
 	 * Determine if a particular table exists
 	 *
 	 * @param	string	$table_name
+	 * @param	bool	$refresh_cache	Refresh data cache
 	 * @return	bool
 	 */
-	public function table_exists($table_name)
+	public function table_exists($table_name, $refresh_cache = FALSE)
 	{
-		return in_array($this->protect_identifiers($table_name, TRUE, FALSE, FALSE), $this->list_tables());
+		return in_array($this->protect_identifiers($table_name, TRUE, FALSE, FALSE), $this->list_tables(FALSE, $refresh_cache));
 	}
 
 	// --------------------------------------------------------------------
@@ -1242,12 +1245,13 @@ abstract class CI_DB_driver {
 	 * Fetch Field Names
 	 *
 	 * @param	string	$table	Table name
+	 * @param	bool	$refresh_cache	Refresh data cache
 	 * @return	array
 	 */
-	public function list_fields($table)
+	public function list_fields($table, $refresh_cache = FALSE)
 	{
 		// Is there a cached result?
-		if (isset($this->data_cache['field_names'][$table]))
+		if ($refresh_cache === FALSE && isset($this->data_cache['field_names'][$table]))
 		{
 			return $this->data_cache['field_names'][$table];
 		}
@@ -1293,11 +1297,12 @@ abstract class CI_DB_driver {
 	 *
 	 * @param	string
 	 * @param	string
+	 * @param	bool	$refresh_cache	Refresh data cache
 	 * @return	bool
 	 */
-	public function field_exists($field_name, $table_name)
+	public function field_exists($field_name, $table_name, $refresh_cache = FALSE)
 	{
-		return in_array($field_name, $this->list_fields($table_name));
+		return in_array($field_name, $this->list_fields($table_name, $refresh_cache));
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
Add the parameter "refresh_cache" to allow users to refresh the data cache used for listing the table and field data of the database.
This is particularly useful when using the functions like "field_exists" and "table_exists" on migration files.
This is aimed to solve a problem which occurs when using dbforge to make a change to a table or a field and verifying the integrity of the database afterwards due to the fact that these functions are returning information of the database prior to changes.

The following example will show the problem.

Example:

```
$this->db->field_exists('photo', 'user'); // this will return TRUE
$this->db->field_exists('new_photo', 'user'); // this will return FALSE

$this->dbforge->modify_column('user', array(
	'photo' => array(
		'name' => 'new_photo',
		'type' => 'VARCHAR',
		'constraint' => '256',
		'null' => TRUE
	)
));

$this->db->field_exists('photo', 'user'); // this will return TRUE
$this->db->field_exists('new_photo', 'user'); // this will return FALSE
```

This happens because the function "field_exists" will get the information previously stored in the variable "data_cache" instead of getting the correct information. This behaviour is correct when using the database normally, but when making changes to the database through migrations is not correct, because you want to know the current state of the database and not the state previously loaded. By using the added parameter it is possible to maintain the normal operation of these functions and at the same time give users the ability to use them safely.