### PR TITLE
Add single quote to converted character

### DIFF
--- a/system/helpers/url_helper.php
+++ b/system/helpers/url_helper.php
@@ -492,8 +492,8 @@ if ( ! function_exists('url_title'))
 
 		$trans = array(
 			'&.+?;'			=> '',
-			'[^\w\d _-]'		=> '',
-			'\s+'			=> $separator,
+			'[^\w\d\' _-]'		=> '',
+			'[\s\']+'		=> $separator,
 			'('.$q_separator.')+'	=> $separator
 		);
 


### PR DESCRIPTION
In many non-english languages, single quote ( ' ) - or apostrophe - is a word separator. It has to be converted into separator (dash or underscore) when the function url_title is called. I updated the regex condition to convert single quotes into separator.

For those that would say : "single quotes must be converted before calling the url_title function", I'll answer that for foreign languages, we already have to convert accented characters. To avoid having too many function calls just for creating a slug, it would be nice to convert the single quote in the url_title function.