### PR TITLE
Ability to delete DB cache files by sql

### DIFF
--- a/system/database/DB_cache.php
+++ b/system/database/DB_cache.php
@@ -206,6 +206,32 @@ class CI_DB_Cache {
 		delete_files($dir_path, TRUE);
 	}
 
+	/**
+	 * Deletes the cache files completely by sql query
+	 *
+	 * @param	string	$sql
+	 * @return	void
+	 */
+	public function clear($sql)
+	{
+		$cache_filename=md5($sql);
+		$this->CI->load->helper('directory');
+		$directory_map = directory_map($this->db->cachedir);
+		
+		//Nesting for 2 levels
+		foreach ($directory_map as $directory_Key => $directory_array)
+		{
+			if(!empty($directory_array) && $directory_Key!='index.html')
+			foreach ($directory_array as $filename)
+			{
+				if($filename==$cache_filename)
+				{
+					unlink($this->db->cachedir.$directory_Key."/".$filename);
+				}
+			}
+		}
+	}
+
 	// --------------------------------------------------------------------
 
 	/**

--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -1604,6 +1604,21 @@ abstract class CI_DB_driver {
 	}
 
 	// --------------------------------------------------------------------
+	
+	/**
+	 * Delete the cache files associated with a particular sql
+	 *
+	 * @param	string	$sql = ''
+	 * @return	bool
+	 */
+	public function cache_clear($sql = '')
+	{
+		return $this->_cache_init()
+			? $this->CACHE->clear($sql)
+			: FALSE;
+	}
+
+	// --------------------------------------------------------------------
 
 	/**
 	 * Delete All cache files

--- a/user_guide_src/source/database/caching.rst
+++ b/user_guide_src/source/database/caching.rst
@@ -153,6 +153,17 @@ delete those particular cache files you will use::
 If you do not use any parameters the current URI will be used when
 determining what should be cleared.
 
+$this->db->cache_clear()
+==========================
+
+Deletes the cache files associated with a particular sql query. This is useful if you need to clear caching after you update your database.
+
+The caching system saves your cache files to folders that correspond to the URI of the page you are viewing. For example, if you are using same query for multiple pages, the same cache file will be generated under multiple folders. To delete those particular cache files you will use::
+
+	$this->db->cache_clear("SELECT * FROM mytable");
+
+If you do not use any parameters it will not clear anything.
+
 $this->db->cache_delete_all()
 ===============================
 


### PR DESCRIPTION
If the same query is used in multiple pages, CI DB cache will create multiple similar files in multiple folders. These can be deleted with this patch.