### PR TITLE
Set the session driver using the value from php config

### DIFF
--- a/system/libraries/Session/Session.php
+++ b/system/libraries/Session/Session.php
@@ -95,6 +95,12 @@ class CI_Session {
 			log_message('debug', 'Session: "sess_driver" is empty; using BC fallback to "sess_use_database".');
 			$this->_driver = 'database';
 		}
+		else
+		{
+			$session_save_handler = ini_get('session.save_handler');
+			log_message('debug', 'Session: "sess_driver" is empty; using value from php.ini "'.$session_save_handler.'".');
+			$this->_driver = $session_save_handler;
+		}
 
 		$class = $this->_ci_load_classes($this->_driver);
 


### PR DESCRIPTION
I've been trying out how different session drivers perform and each time I have to modify the $config['sess_driver']

So I've added this code to set session driver using session.save_handler value if $config['sess_driver'] is set as NULL