### PR TITLE
Test if cache file is writable before unlink it

### DIFF
--- a/system/libraries/Cache/drivers/Cache_file.php
+++ b/system/libraries/Cache/drivers/Cache_file.php
@@ -276,7 +276,7 @@ class CI_Cache_file extends CI_Driver {
 
 		if ($data['ttl'] > 0 && time() > $data['time'] + $data['ttl'])
 		{
-			unlink($this->_cache_path.$id);
+            file_exists($this->_cache_path.$id) && unlink($this->_cache_path.$id);
 			return FALSE;
 		}
 


### PR DESCRIPTION
Make sure that file exists when unlinking it. Concurrent process run on same time may unlink in the meantime this file.


