### PR TITLE
Fix #5605

### DIFF
--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -587,7 +587,7 @@ class CI_Form_validation {
 			{
 				if ($row['is_array'] === FALSE)
 				{
-					isset($data[$field]) && $data[$field] = $row['postdata'];
+					isset($data[$field]) && $data[$field] = is_array($row['postdata']) ? NULL : $row['postdata'];
 				}
 				else
 				{


### PR DESCRIPTION
As for passes validation, if the field is not set to required it's the expected behavior.
When 'required' validation rule is set, the array does not pass validation so normally you'd process your code after the validation passes (no issues here).
The only issue is that post data was still pointing to an array instead of returning null when required rule was not set. 