### PR TITLE
use local.php values in get_config helper function

### DIFF
--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -260,6 +260,12 @@ if ( ! function_exists('get_config'))
 				exit(3); // EXIT_CONFIG
 			}
 
+            // Do we have a local.php configuration file?
+            if (file_exists($file_path = APPPATH.'config/local.php'))
+            {
+                require($file_path);
+            }
+
 			// Does the $config array exist in the file?
 			if ( ! isset($config) OR ! is_array($config))
 			{

--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -260,11 +260,11 @@ if ( ! function_exists('get_config'))
 				exit(3); // EXIT_CONFIG
 			}
 
-            // Do we have a local.php configuration file?
-            if (file_exists($file_path = APPPATH.'config/local.php'))
-            {
-                require($file_path);
-            }
+			// Do we have a local.php configuration file?
+			if (file_exists($file_path = APPPATH.'config/local.php'))
+			{
+				require($file_path);
+			}
 
 			// Does the $config array exist in the file?
 			if ( ! isset($config) OR ! is_array($config))


### PR DESCRIPTION
This looks for a file at `APPPATH.'config/local.php'` and loads the values, if found. An example of where this can currently be a problem can be found at:

https://github.com/Siphon098/CodeIgniter/blob/develop/system/core/Security.php#L275-L283

The creation of the cookie may fail even when `cookie_domain` is valid within the `local.php` config.