### PR TITLE
Remove NULL check from protected _wh_in function

### DIFF
--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -874,11 +874,6 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	{
 		$qb_cache_key = ($qb_key === 'qb_having') ? 'qb_cache_having' : 'qb_cache_where';
 
-		if ($key === NULL OR $values === NULL)
-		{
-			return $this;
-		}
-
 		if ( ! is_array($values))
 		{
 			$values = array($values);


### PR DESCRIPTION
The NULL check that has been removed was quietly skipping the where_in statement if a NULL was passed in the $value parameter. By not checking for NULL, this allows an inadvertent NULL to get pushed into the query built by the query builder and avoid any accidental updates or selects of the entire table. I couldn't find any issues where this might cause a problem. The _wh protected function that builds the 'where' portions of a query does not seem to have a NULL check like it's where_in counterpart.