### PR TITLE
Added mobile google bot to user agents

### DIFF
--- a/application/config/user_agents.php
+++ b/application/config/user_agents.php
@@ -111,6 +111,7 @@ $mobiles = array(
 	// Phones and Manufacturers
 	'motorola'		=> 'Motorola',
 	'nokia'			=> 'Nokia',
+	'nexus'			=> 'Nexus',
 	'palm'			=> 'Palm',
 	'iphone'		=> 'Apple iPhone',
 	'ipad'			=> 'iPad',


### PR DESCRIPTION
If you use the `agent->is_mobile()` method to render a mobile friendly page, you can still get dinged by google with their mobile rendering test. Though it's still considered a 'googlebot' they updated their user agent string to include 'Nexus' as seen in this blog post:

https://webmasters.googleblog.com/2016/03/updating-smartphone-user-agent-of.html

Adding nexus to the user agent string allows the method to correctly display mobile screens to googlebots when google is using the mobile user agent.