### PR TITLE
Add memcached config option in session driver

### DIFF
--- a/system/libraries/Session/drivers/Session_memcached_driver.php
+++ b/system/libraries/Session/drivers/Session_memcached_driver.php
@@ -107,6 +107,14 @@ class CI_Session_memcached_driver extends CI_Session_driver implements SessionHa
 	{
 		$this->_memcached = new Memcached();
 		$this->_memcached->setOption(Memcached::OPT_BINARY_PROTOCOL, TRUE); // required for touch() usage
+		$memcached_options = config_item('sess_memcached_options');
+		if (is_array($memcached_options))
+		{
+			foreach ($memcached_options as $key => $value)
+			{
+				$this->_memcached->setOption($key, $value);
+			}
+		}
 		$server_list = array();
 		foreach ($this->_memcached->getServerList() as $server)
 		{


### PR DESCRIPTION
The `$config['sess_save_path']` setting supports third colon-separated (`:weight`) value. But the weight value had no effect as it only worked with consistent distribution option (`Memcached::DISTRIBUTION_CONSISTENT`) but the default distribution option was `Memcached::DISTRIBUTION_MODULA`.

To fix this problem, distribution option needs to be set before `addServer`.
```
$this->_memcached->setOption(Memcached::OPT_DISTRIBUTION, Memcached::DISTRIBUTION_CONSISTENT);
```

In addition, some people may prefer setting connection timeout and [failover mechanism](https://secure.php.net/manual/en/memcached.addservers.php#118940) for the memcached servers.

This commit adds `$config['sess_memcached_options']` for setting custom memcached options.

References:
https://www.codeigniter.com/userguide3/libraries/sessions.html#memcached-driver
https://secure.php.net/manual/en/memcached.addserver.php
https://secure.php.net/manual/en/memcached.constants.php
