### PR TITLE
Fixed bug that can not be changed from not null to null in oci.

### DIFF
--- a/system/database/drivers/oci8/oci8_forge.php
+++ b/system/database/drivers/oci8/oci8_forge.php
@@ -81,6 +81,13 @@ class CI_DB_oci8_forge extends CI_DB_forge {
 	 */
 	protected $_unsigned		= FALSE;
 
+	/**
+	* NULL value representation in CREATE/ALTER TABLE statements
+	*
+	* @var string
+	*/
+	protected $_null        = 'NULL';
+
 	// --------------------------------------------------------------------
 
 	/**


### PR DESCRIPTION
When I ran the following code, the NOT NULL constraint of the target column did not come off.

```php
$this->dbforge->modify_column('EXAMPLE', [
            'COLUMN_1' => [
                'null' => true,
            ],
            'COLUMN_2' => [
                'null' => true,
            ]
]);
```

**Expected query**

```sql
ALTER TABLE "EXAMPLE" MODIFY (
	"COLUMN_1" NULL,
        "COLUMN_2" NULL)
```

**Actual query**
```sql
ALTER TABLE "EXAMPLE" MODIFY (
	"COLUMN_1",
        "COLUMN_2")
```

**Execution environment**

Oracle 12c
PHP 7.2