### PR TITLE
Added unbuffered_get() for fetch larger dataset from MySQL

### DIFF
--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -569,14 +569,12 @@ abstract class CI_DB_driver {
 	 * @param	string	$sql
 	 * @param	array	$binds = FALSE		An array of binding data
 	 * @param	bool	$return_object = NULL
-	 * @param	bool	$_is_unbuffered = FALSE		Set the query execution as buffered or unbuffered
+	 * @param	bool	$is_unbuffered = FALSE		Set the query execution as buffered or unbuffered
 	 * @return	mixed
 	 */
-	public function query($sql, $binds = FALSE, $return_object = NULL, $_is_unbuffered=FALSE)
+	public function query($sql, $binds = FALSE, $return_object = NULL, $is_unbuffered=FALSE)
 	{	
 		// Set Buffered or Unbuffered to access it in simple query
-		$this->_is_unbuffered = $_is_unbuffered;
-
 		if ($sql === '')
 		{
 			log_message('error', 'Invalid query: '.$sql);
@@ -620,7 +618,7 @@ abstract class CI_DB_driver {
 		$time_start = microtime(TRUE);
 
 		// Run the Query
-		if (FALSE === ($this->result_id = $this->simple_query($sql)))
+		if (FALSE === ($this->result_id = $this->simple_query($sql, $is_unbuffered)))
 		{
 			if ($this->save_queries === TRUE)
 			{
@@ -735,7 +733,7 @@ abstract class CI_DB_driver {
 	
 	public function unbuffered_query($sql, $binds = FALSE, $return_object = NULL)
 	{		
-		return $this->query($sql, $binds = FALSE, $return_object = NULL, $_is_unbuffered=TRUE);
+		return $this->query($sql, $binds = FALSE, $return_object = NULL, $is_unbuffered=TRUE);
 	}
 
 	// --------------------------------------------------------------------
@@ -749,10 +747,10 @@ abstract class CI_DB_driver {
 	 * @param	string	the sql query
 	 * @return	mixed
 	 */
-	public function simple_query($sql)
+	public function simple_query($sql, $is_unbuffered=FALSE)
 	{
 		empty($this->conn_id) && $this->initialize();
-		return $this->_is_unbuffered ? $this->_execute_unbuffered($sql) : $this->_execute($sql);
+		return $is_unbuffered ? $this->_execute_unbuffered($sql) : $this->_execute($sql);
 	}
 
 	// --------------------------------------------------------------------

--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -569,10 +569,14 @@ abstract class CI_DB_driver {
 	 * @param	string	$sql
 	 * @param	array	$binds = FALSE		An array of binding data
 	 * @param	bool	$return_object = NULL
+	 * @param	bool	$_is_unbuffered = FALSE		Set the query execution as buffered or unbuffered
 	 * @return	mixed
 	 */
-	public function query($sql, $binds = FALSE, $return_object = NULL)
-	{
+	public function query($sql, $binds = FALSE, $return_object = NULL, $_is_unbuffered=FALSE)
+	{	
+		// Set Buffered or Unbuffered to access it in simple query
+		$this->_is_unbuffered = $_is_unbuffered;
+
 		if ($sql === '')
 		{
 			log_message('error', 'Invalid query: '.$sql);
@@ -715,6 +719,28 @@ abstract class CI_DB_driver {
 	// --------------------------------------------------------------------
 
 	/**
+	 * Execute the query and return the cursor object
+	 *
+	 * Accepts an SQL string as input and returns a result object upon
+	 * successful execution of a "read" type query. Returns boolean TRUE
+	 * upon successful execution of a "write" type query. Returns boolean
+	 * FALSE upon failure, and if the $db_debug variable is set to TRUE
+	 * will raise an error.
+	 *
+	 * @param	string	$sql
+	 * @param	array	$binds = FALSE		An array of binding data
+	 * @param	bool	$return_object = NULL
+	 * @return	mixed
+	 */
+	
+	public function unbuffered_query($sql, $binds = FALSE, $return_object = NULL)
+	{		
+		return $this->query($sql, $binds = FALSE, $return_object = NULL, $_is_unbuffered=TRUE);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
 	 * Simple Query
 	 * This is a simplified version of the query() function. Internally
 	 * we only use it when running transaction commands since they do
@@ -726,7 +752,7 @@ abstract class CI_DB_driver {
 	public function simple_query($sql)
 	{
 		empty($this->conn_id) && $this->initialize();
-		return $this->_execute($sql);
+		return $this->_is_unbuffered ? $this->_execute_unbuffered($sql) : $this->_execute($sql);
 	}
 
 	// --------------------------------------------------------------------

--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -1460,6 +1460,38 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	// --------------------------------------------------------------------
 
 	/**
+	 * Get cursor instead of records to fetch larger dataset
+	 *
+	 * Compiles the select statement based on the other functions called
+	 * and runs the query
+	 *
+	 * @param	string	the table
+	 * @param	string	the limit clause
+	 * @param	string	the offset clause
+	 * @return	CI_DB_result
+	 */
+	public function unbuffered_get($table = '', $limit = NULL, $offset = NULL)
+	{
+		if ($table !== '')
+		{
+			$this->_track_aliases($table);
+			$this->from($table);
+		}
+
+		if ( ! empty($limit))
+		{
+			$this->limit($limit, $offset);
+		}
+
+		$result = $this->unbuffered_query($this->_compile_select());
+		$this->_reset_select();
+		return $result;
+	}
+
+	// --------------------------------------------------------------------
+
+
+	/**
 	 * "Count All Results" query
 	 *
 	 * Generates a platform-specific query string that counts all records

--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -1482,8 +1482,8 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 		{
 			$this->limit($limit, $offset);
 		}
-
-		$result = $this->unbuffered_query($this->_compile_select());
+		// Only allow MySQLi to use the Unbuffered
+		$result = ($this->dbdriver==="mysqli") ? $this->unbuffered_query($this->_compile_select()) : $this->query($this->_compile_select());
 		$this->_reset_select();
 		return $result;
 	}

--- a/system/database/drivers/mysqli/mysqli_driver.php
+++ b/system/database/drivers/mysqli/mysqli_driver.php
@@ -302,6 +302,21 @@ class CI_DB_mysqli_driver extends CI_DB {
 	}
 
 	// --------------------------------------------------------------------
+	
+
+	/**
+	 * Execute the query and return the cursor
+	 *
+	 * @param	string	$sql	an SQL query
+	 * @return	mixed
+	 */
+	protected function _execute_unbuffered($sql)
+	{
+		return $this->conn_id->query($this->_prep_query($sql),MYSQLI_USE_RESULT);
+	}
+
+
+	// --------------------------------------------------------------------
 
 	/**
 	 * Prep the query


### PR DESCRIPTION
Added unbuffered_get() in Query Builder for MySQL. Default get() with unbufferd_row() is giving memory allocation error for larger dataset. Simply, Its not working.
So added _execute_unbuffered() method in Mysqli_driver.php and it execute the query with MYSQLI_USE_RESULT flag.
So the cursor will be returned, with that we can use unbuffered_row() to fetch row by row to prevent the memory alocation issue.
Ex:
$i = 0;
$qry = $this->db->select("id")->from("table")->unbuffered_get();
while ($row = $qry->unbuffered_row('array')) {
	$i+=1;
}
print($i);