### PR TITLE
Resolve race condition in redis driven session key get_lock

### DIFF
--- a/system/libraries/Session/drivers/Session_redis_driver.php
+++ b/system/libraries/Session/drivers/Session_redis_driver.php
@@ -389,7 +389,7 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 				sleep(1);
 				continue;
 			}
-			elseif ($ttl === -1 && ! $this->_redis->setex($lock_key, 300, time()))
+			elseif ( ! $this->_redis->setex($lock_key, 300, time()))
 			{
 				log_message('error', 'Session: Error while trying to obtain lock for '.$this->_key_prefix.$session_id);
 				return FALSE;

--- a/system/libraries/Session/drivers/Session_redis_driver.php
+++ b/system/libraries/Session/drivers/Session_redis_driver.php
@@ -389,8 +389,9 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 
 			if ( ! $result)
 			{
-				log_message('error', 'Session: Error while trying to obtain lock for '.$this->_key_prefix.$session_id);
-				return FALSE;
+				// Sleep for 0.1s to wait for lock releases.
+				usleep(100000);
+				continue;
 			}
 
 			$this->_lock_key = $lock_key;

--- a/system/libraries/Session/drivers/Session_redis_driver.php
+++ b/system/libraries/Session/drivers/Session_redis_driver.php
@@ -389,7 +389,8 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 				sleep(1);
 				continue;
 			}
-			elseif ($ttl === -1 && ! $this->_redis->setex($lock_key, 300, time())) {
+			elseif ($ttl === -1 && ! $this->_redis->setex($lock_key, 300, time()))
+			{
 				log_message('error', 'Session: Error while trying to obtain lock for '.$this->_key_prefix.$session_id);
 				return FALSE;
 			}

--- a/system/libraries/Session/drivers/Session_redis_driver.php
+++ b/system/libraries/Session/drivers/Session_redis_driver.php
@@ -383,15 +383,15 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 				continue;
 			}
 
-			$result = ($ttl === -2)
-				? $this->_redis->set($lock_key, time(), array('nx', 'ex' => 300))
-				: $this->_redis->setex($lock_key, 300, time());
-
-			if ( ! $result)
+			if ($ttl === -2 && ! $this->_redis->set($lock_key, time(), array('nx', 'ex' => 300)))
 			{
-				// Sleep for 0.1s to wait for lock releases.
-				usleep(100000);
+				// Sleep for 1s to wait for lock releases.
+				sleep(1);
 				continue;
+			}
+			elseif ($ttl === -1 && ! $this->_redis->setex($lock_key, 300, time())) {
+				log_message('error', 'Session: Error while trying to obtain lock for '.$this->_key_prefix.$session_id);
+				return FALSE;
 			}
 
 			$this->_lock_key = $lock_key;


### PR DESCRIPTION
This PR tries to provide a better design of session key get_lock design, mentioned in #5382 and by @sskaje .

The previous design may fail when multiple threads are trying the access the same session at nearly the same time. Most of the threads will be killed.

Although this behavior may be corrected by adding checks in custom CI controllers or custom CI libraries, in my understanding session operations in CI controllers should never fail because of one issue come from the driver. In other words, race conditions should be handled in the driver.

BTW, I have completely read that issue and related discussions. As for >300s / no-TTL problem, every lock is going to have TTL, except someone tries to operate sessions by himself, not by the driver IMO.
If this does happen, then he totally deserves the long time waiting for the lock releases.