### PR TITLE
Corrected example mistake

### DIFF
--- a/user_guide_src/source/helpers/form_helper.rst
+++ b/user_guide_src/source/helpers/form_helper.rst
@@ -380,7 +380,7 @@ The following functions are available:
 
 				<fieldset>
 					<legend>Address Information</legend>
-						<p>form content here</p>
+						<p>fieldset content here</p>
 				</fieldset>
 		*/
 
@@ -401,7 +401,7 @@ The following functions are available:
 
 			<fieldset id="address_info" class="address_info">
 				<legend>Address Information</legend>
-				<p>form content here</p>
+				<p>fieldset content here</p>
 			</fieldset>
 		*/
 


### PR DESCRIPTION
Corrected an example mistake where the input script tries to echo `<p>fieldset content here</p>\n` but the result in "Produces" is `<p>form content here</p>` which is clearly an inconsistant result.