### PR TITLE
Validate dates in form_validation

### DIFF
--- a/system/language/english/form_validation_lang.php
+++ b/system/language/english/form_validation_lang.php
@@ -44,6 +44,7 @@ $lang['form_validation_valid_emails']		= 'The {field} field must contain all val
 $lang['form_validation_valid_url']		= 'The {field} field must contain a valid URL.';
 $lang['form_validation_valid_ip']		= 'The {field} field must contain a valid IP.';
 $lang['form_validation_valid_mac']		= 'The {field} field must contain a valid MAC.';
+$lang['form_validation_valid_date']		= 'The {field} field must contain a valid DATE.';
 $lang['form_validation_valid_base64']		= 'The {field} field must contain a valid Base64 string.';
 $lang['form_validation_min_length']		= 'The {field} field must be at least {param} characters in length.';
 $lang['form_validation_max_length']		= 'The {field} field cannot exceed {param} characters in length.';

--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -1327,7 +1327,8 @@ class CI_Form_validation {
 	{
                 if (strpos($val, ',') === FALSE)
 		{
-                        if($val !== "week"){
+                        if($val !== "week")
+                        {
                                 return DateTime::createFromFormat($val, $str)
                                         ? (DateTime::createFromFormat($val, $str)->format($val) === $str)
                                         : FALSE;
@@ -1346,14 +1347,15 @@ class CI_Form_validation {
                                 catch (Exception $ex) 
                                 {
                                         return FALSE;
-                               }
+                                }
                         }
 		}
 
 		foreach (explode(',', $val) as $format)
 		{
-			if(DateTime::createFromFormat($format, $str) && DateTime::createFromFormat($format, $str)->format($format) === $str){
-                            return TRUE;
+			if(DateTime::createFromFormat($format, $str) && DateTime::createFromFormat($format, $str)->format($format) === $str)
+                        {
+                                return TRUE;
                         }
 		}
                 

--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -1281,7 +1281,7 @@ class CI_Form_validation {
 	/**
 	 * Validate IP Address
 	 *
-	 * @param	string
+	 * @param       string
 	 * @param	string	'ipv4' or 'ipv6' to validate a specific IP format
 	 * @return	bool
 	 */
@@ -1318,19 +1318,23 @@ class CI_Form_validation {
         // --------------------------------------------------------------------
         
         /**
-	 * Valid Date. If at first validation is true it ends.
+	 * Valid Date. Choose the HTML5 standard and the format for your region. The important thing is that the date is valid, no matter the region.
 	 *
 	 * @param	string
+         * @param	string  $formats can be one or more formats from any region of the world
 	 * @return	bool
 	 */
-	public function valid_date($str, $val)
+	public function valid_date($value, $formats)
 	{
-                if (strpos($val, ',') === FALSE)
+                // Make sure you only have one format
+                if (strpos($formats, ',') === FALSE)
 		{
-                        if($val !== "week")
+                        // Make sure the format is not week
+                        if($formats !== "week")
                         {
-                                return DateTime::createFromFormat($val, $str)
-                                        ? (DateTime::createFromFormat($val, $str)->format($val) === $str)
+                                // In addition to validating the date, compare the date formatted with the value of the form to avoid the example 2019-01-32
+                                return DateTime::createFromFormat($formats, $value)
+                                        ? (DateTime::createFromFormat($formats, $value)->format($formats) === $value)
                                         : FALSE;
                         }
                         
@@ -1339,8 +1343,10 @@ class CI_Form_validation {
                         {
                                 try
                                 {
-                                        $week= new DateTime($str);
-                                        return substr_replace($week->format("Y-W"), "W", 5, 0) === $str
+                                        // The correct format for the week is 1995-W26. HTML5 standard format for week
+                                        // After validation, I enter the W in the formatted date to check with the value of the form
+                                        $week= new DateTime($value);
+                                        return substr_replace($week->format("Y-W"), "W", 5, 0) === $value
                                                 ? TRUE
                                                 : FALSE;
                                 } 
@@ -1350,10 +1356,11 @@ class CI_Form_validation {
                                 }
                         }
 		}
-
-		foreach (explode(',', $val) as $format)
+                
+                // If you have more than one format, check all of them with the value of the form until you validate.
+		foreach (explode(',', $formats) as $format)
 		{
-			if(DateTime::createFromFormat($format, $str) && DateTime::createFromFormat($format, $str)->format($format) === $str)
+			if(DateTime::createFromFormat($format, $value) && DateTime::createFromFormat($format, $value)->format($format) === $value)
                         {
                                 return TRUE;
                         }

--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -1314,6 +1314,51 @@ class CI_Form_validation {
 
 		return (bool) filter_var($mac, FILTER_VALIDATE_MAC);
 	}
+        
+        // --------------------------------------------------------------------
+        
+        /**
+	 * Valid Date. If at first validation is true it ends.
+	 *
+	 * @param	string
+	 * @return	bool
+	 */
+	public function valid_date($str, $val)
+	{
+                if (strpos($val, ',') === FALSE)
+		{
+                        if($val !== "week"){
+                                return DateTime::createFromFormat($val, $str)
+                                        ? (DateTime::createFromFormat($val, $str)->format($val) === $str)
+                                        : FALSE;
+                        }
+                        
+                        // I could not find another way to validate a week other than this
+                        else
+                        {
+                                try
+                                {
+                                        $week= new DateTime($str);
+                                        return substr_replace($week->format("Y-W"), "W", 5, 0) === $str
+                                                ? TRUE
+                                                : FALSE;
+                                } 
+                                catch (Exception $ex) 
+                                {
+                                        return FALSE;
+                               }
+                        }
+		}
+
+		foreach (explode(',', $val) as $format)
+		{
+			if(DateTime::createFromFormat($format, $str) && DateTime::createFromFormat($format, $str)->format($format) === $str){
+                            return TRUE;
+                        }
+		}
+                
+                return FALSE;
+	}
 
 	// --------------------------------------------------------------------
 

--- a/tests/codeigniter/libraries/Form_validation_test.php
+++ b/tests/codeigniter/libraries/Form_validation_test.php
@@ -312,6 +312,21 @@ class Form_validation_test extends CI_TestCase {
 		$this->assertFalse($this->form_validation->valid_mac("01:23:45:67:89:ag:"));
 		$this->assertFalse($this->form_validation->valid_mac('0123456789ab'));
 	}
+        
+        public function test_rule_valid_date()
+	{
+		$this->assertTrue($this->form_validation->valid_date("Y-m-d,d/m/Y", "28/06/1995"));
+		$this->assertTrue($this->form_validation->valid_date("Y-m-d,d/m/Y", "1995-06-28"));
+		$this->assertTrue($this->form_validation->valid_date("week", "1995-W26"));
+                $this->assertTrue($this->form_validation->valid_date("Y-m", "1995-06"));
+                $this->assertTrue($this->form_validation->valid_date("Y-m-d h:i A", "1995-06-28 01:00 PM"));
+
+		$this->assertFalse($this->form_validation->valid_date("Y-m-d,d/m/Y", "28/06/95"));
+		$this->assertFalse($this->form_validation->valid_date("Y-m-d,d/m/Y", "1995-02-31"));
+		$this->assertFalse($this->form_validation->valid_date("week", "95-W26"));
+		$this->assertFalse($this->form_validation->valid_date("Y-m-d H:i", "1995-06-28 13:0a"));
+		$this->assertFalse($this->form_validation->valid_date("Y-m-d h:i A", "1995-06-28 01:00 pm"));
+	}
 
 	public function test_rule_valid_base64()
 	{

--- a/user_guide_src/source/libraries/form_validation.rst
+++ b/user_guide_src/source/libraries/form_validation.rst
@@ -1006,6 +1006,7 @@ Rule                      Parameter  Description                                
 **valid_ip**              Yes        Returns FALSE if the supplied IP address is not valid.
                                      Accepts an optional parameter of 'ipv4' or 'ipv6' to specify an IP format.
 **valid_mac**             No         Returns FALSE if the supplied MAC address is not valid.
+**valid_date**            Yes        Returns FALSE if the DATE is not in the requested format.                                     valid_date[Y-m-d,d/m/Y]
 **valid_base64**          No         Returns FALSE if the supplied string contains anything other than valid Base64 characters.
 ========================= ========== ============================================================================================= =======================
 


### PR DESCRIPTION
Now in _form_validation_ it is possible **to validate dates** using the **valid_date** method in set_rules(), this is amazing!

Using one or more parameters, the date validation will be based on the formats that the developer reports. Check out this [commit ](https://github.com/bcit-ci/CodeIgniter/pull/5723/commits/0f7e2cde187b69d354a617ff7e8ac778c68d41d8)**_Form_validation_test_**