### PR TITLE
Stop using a group to manage serialised items

### DIFF
--- a/system/libraries/Cache/drivers/Cache_redis.php
+++ b/system/libraries/Cache/drivers/Cache_redis.php
@@ -125,7 +125,7 @@ class CI_Cache_redis extends CI_Driver
 			{
 				log_message('error', 'Cache: Redis authentication failed.');
 			}
-			$obj_redis->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_PHP);
+			this->_redis->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_PHP);
 		}
 		catch (RedisException $e)
 		{

--- a/system/libraries/Cache/drivers/Cache_redis.php
+++ b/system/libraries/Cache/drivers/Cache_redis.php
@@ -125,7 +125,7 @@ class CI_Cache_redis extends CI_Driver
 			{
 				log_message('error', 'Cache: Redis authentication failed.');
 			}
-			this->_redis->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_PHP);
+			$this->_redis->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_PHP);
 		}
 		catch (RedisException $e)
 		{

--- a/system/libraries/Cache/drivers/Cache_redis.php
+++ b/system/libraries/Cache/drivers/Cache_redis.php
@@ -186,7 +186,7 @@ class CI_Cache_redis extends CI_Driver
 	 */
 	public function increment($id, $offset = 1)
 	{
-		$oldValue = (int) $this->-redis->get($id);
+		$oldValue = (int) $this->_redis->get($id);
 
 		$ttl = $this->_redis->ttl($id);
 		if ($ttl < 0) {

--- a/system/libraries/Cache/drivers/Cache_redis.php
+++ b/system/libraries/Cache/drivers/Cache_redis.php
@@ -193,7 +193,7 @@ class CI_Cache_redis extends CI_Driver
 			$ttl = self::DEFAULT_TTL;
 		}
 
-		return $this->_redis->set($id, $oldValue += $offset, $ttl);
+		return $this->_redis->set($id, $oldValue + $offset, $ttl);
 
 	}
 


### PR DESCRIPTION
fixes #5738

When using a group to manage which objects should be serialised the
performance of the application suffers with larger amounts of keys. We
originally moved this to be a set / check on each key use (eg first get
the item, then check if its a member of the group). This made things
much faster when managing lots of keys.

We also use the non default but often used eviction policy allkeys-lru
Having this setting on meant that it is possible for redis to remove
this item and when this occurs the driver returns strings for
everything.

There is a very slight overhead when caching primitive values but also
does not allow any risks of cache corruption

Incr and Decr have had to be recreated so its no longer an atomic
operation, meaning there is a potential case where these will not work
as expected. the only fix I could see here is to check is numeric on way
in and out of the cache and manually serialise instead of the driver
handling it.

The membership group also continues to grow over time if keys expire
naturally, meaning that key consumes more and more of the available
cache as time goes on increasing the likelihood of an eviction of the
item