### PR TITLE
Added config option to disable view variable caching

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -469,3 +469,19 @@ $config['time_reference'] = 'local';
 | Array:		array('10.0.1.200', '192.168.5.0/24')
 */
 $config['proxy_ips'] = '';
+
+/* 
+|--------------------------------------------------------------------------
+| Cache view vars
+|--------------------------------------------------------------------------
+|
+| Variable caching allows for view variables to be passed down from one view to another
+| This means that the variables set in one view are passed into the next call to the same view loading
+| This option allows you to disable variable caching in views, meaning each view load will NOT inherit variables belonging to the previous load
+| Enable/disable view variable caching. 
+|
+| Defaults to TRUE.
+|
+| Accepted values are TRUE or FALSE
+*/
+$config['cache_view_vars'] = FALSE;

--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -493,6 +493,11 @@ class CI_Loader {
 	 */
 	public function view($view, $vars = array(), $return = FALSE)
 	{
+		if(config_item('cache_view_vars') === FALSE)
+		{
+			$this->clear_vars();
+		}
+
 		return $this->_ci_load(array('_ci_view' => $view, '_ci_vars' => $this->_ci_prepare_view_vars($vars), '_ci_return' => $return));
 	}
 


### PR DESCRIPTION
This is an enhancement to the [fix here](https://github.com/bcit-ci/CodeIgniter/pull/2684)

## The problem
Variables from one view are loaded into the next instance of the same view loaded. Sometimes this behavior may be undesirable. Added a config item & option to disable the caching of the view variables.

**If the config item hasn't been added:**
Defaults to TRUE (even if the variable is not declared in the config file - to allow for upgrades using only system directory copy)

> Config variable is currently set to `FALSE` for testing. Forgot to change it back to `TRUE` before sending the PR

The caching currently occurs in the `Loader` class & the `view()` method to be specific

## Current solution
Clear the cache on every load if we have disabled variable caching

## Optimal solution
This would mean preventing the actual variable caching from happening. Since I wasn't sure whether this would break things, I used the first approach.

### Will the optimal solution break the usability in future?
No. In future, the actual usability **won't be affected**, the only thing that will change is where the check for caching/clearing cache occurs.
