### PR TITLE
Fix an "$this->load->vars()"  security bug

### DIFF
--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -529,7 +529,7 @@ class CI_Loader {
 		$vars = is_string($vars)
 			? array($vars => $val)
 			: $vars;
-        $vars = $this->_ci_prepare_view_vars($vars);
+         $vars = $this->_ci_prepare_view_vars($vars);
 		foreach ($vars as $key => $val)
 		{
 			$this->_ci_cached_vars[$key] = $val;

--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -529,7 +529,7 @@ class CI_Loader {
 		$vars = is_string($vars)
 			? array($vars => $val)
 			: $vars;
-         $vars = $this->_ci_prepare_view_vars($vars);
+        $vars = $this->_ci_prepare_view_vars($vars);
 		foreach ($vars as $key => $val)
 		{
 			$this->_ci_cached_vars[$key] = $val;

--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -528,8 +528,8 @@ class CI_Loader {
 	{
 		$vars = is_string($vars)
 			? array($vars => $val)
-			: $this->_ci_prepare_view_vars($vars);
-
+			: $vars;
+        $vars = $this->_ci_prepare_view_vars($vars);
 		foreach ($vars as $key => $val)
 		{
 			$this->_ci_cached_vars[$key] = $val;


### PR DESCRIPTION
```
class Welcome extends CI_Controller {
    public function index()
    {
        $this->load->vars("_ci_path", "C:/windows/win.ini");
	$this->load->view('welcome_message');
    }
}
```
The demo code could include file `C:/windows/win.ini`.
 If the first param can be controlled in  `$this->load->vars("_ci_path", "C:/windows/win.ini");`
  like this:
 `$this->load->vars($_GET['field'], $_GET['condition']);` 
The hacker can read everything or run command seriously.