### PR TITLE
reset query after completing a multi-table delete if reset_data parameter is true

### DIFF
--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -2236,11 +2236,16 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 		}
 		elseif (is_array($table))
 		{
-			empty($where) && $reset_data = FALSE;
+			$single_table_reset_data = $reset_data;
+			empty($where) && $single_table_reset_data = FALSE;
 
 			foreach ($table as $single_table)
 			{
-				$this->delete($single_table, $where, $limit, $reset_data);
+				$this->delete($single_table, $where, $limit, $single_table_reset_data);
+			}
+			if ($reset_data)
+			{
+				$this->_reset_write();
 			}
 
 			return;


### PR DESCRIPTION
Delete queries were not properly reset if multiple tables were passed causing subsequent queries to retain the query attributes passed for the delete query

Signed-off-by: Ben Gennaria <ben@gennaria.com>