### PR TITLE
fixed coutable warn when not found row index.

### DIFF
--- a/system/database/DB_result.php
+++ b/system/database/DB_result.php
@@ -383,7 +383,7 @@ class CI_DB_result {
 	{
 		isset($this->custom_result_object[$type]) OR $this->custom_result_object($type);
 
-		if (count($this->custom_result_object[$type]) === 0)
+		if (isset($this->custom_result_object[$type]) === false)
 		{
 			return NULL;
 		}


### PR DESCRIPTION
I using PHP7.3.

I occurred error following when not found row index.

```
Severity:    Warning
Message:     count(): Parameter must be an array or an object that implements Countable
Filename:    /var/www/html/vendor/codeigniter/framework/system/database/DB_result.php
Line Number: 386

Backtrace:
	File: /var/www/html/application/models/Group_model.php
	Line: 60
	Function: row
```

The following code can be reproduced.

```php
<?php

class Group_model extends CI_Model
{
   public function get($id) {
       $query = $this->db->get_where('group', ['id' => 1], 1);
       $not_found_index = 1000;

       return $query->row($not_found_index, Group::class);
   }
}
```
