### PR TITLE
Redis driver: Continue waiting for the lock instead of failling

### DIFF
--- a/system/libraries/Session/drivers/Session_redis_driver.php
+++ b/system/libraries/Session/drivers/Session_redis_driver.php
@@ -391,7 +391,8 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 			elseif ( ! $this->_redis->setex($lock_key, 300, time()))
 			{
 				log_message('error', 'Session: Error while trying to obtain lock for '.$this->_key_prefix.$session_id);
-				return FALSE;
+				sleep(1);
+				continue;
 			}
 
 			$this->_lock_key = $lock_key;


### PR DESCRIPTION
Right now, one of two concurrent requests will fail if one of them sets the lock first in Redis driver, what I propose is to continue waiting for the lock to be free instead of failing.

The only downside is that the request will be delayed at least a second (obviously because of the sleep time) but, as I myself prefer that in my application, maybe everyone else having requests failing prefer this scenario, specially when calling multiple ajax request on a page load.