### PR TITLE
Speed up xss_clean for numerics

### DIFF
--- a/system/core/Security.php
+++ b/system/core/Security.php
@@ -354,6 +354,12 @@ class CI_Security {
 	 */
 	public function xss_clean($str, $is_image = FALSE)
 	{
+		// Is the string a numeric? you can't have XSS in a numeric
+		if (is_numeric($str))
+		{
+			return $str;
+		}
+
 		// Is the string an array?
 		if (is_array($str))
 		{


### PR DESCRIPTION
You can't have XSS in numerics ("123", "0.54321" etc).
`is_numeric()` is very fast and when `xss_clean()` is used very often (to check all POST data, etc),
this change can be a huge benefit to the application - it just skips over all costly regex executions