### PR TITLE
Check decoding result before returning

### DIFF
--- a/system/core/Security.php
+++ b/system/core/Security.php
@@ -782,9 +782,12 @@ class CI_Security {
 	{
 		$input    = $matches[0];
 		$nospaces = preg_replace('#\s+#', '', $input);
-		return ($nospaces === $input)
+		$is_the_same_character = $nospaces === $input;
+		$decoded_input = rawurldecode($nospaces);
+		$is_invalid_character = !(mb_check_encoding($decoded_input));
+		return ($is_the_same_character || $is_invalid_character)
 			? $input
-			: rawurldecode($nospaces);
+			: $decoded_input;
 	}
 
 	// ----------------------------------------------------------------

--- a/tests/codeigniter/core/Security_test.php
+++ b/tests/codeigniter/core/Security_test.php
@@ -74,6 +74,17 @@ class Security_test extends CI_TestCase {
 
 	// --------------------------------------------------------------------
 
+	public function test_xss_clean_with_invalid_unicode()
+	{
+		$harm_string = "I have a invalid unicode with space and should keep it as is. % ca";
+
+		$harmless_string = $this->security->xss_clean($harm_string);
+
+		$this->assertEquals("I have a invalid unicode with space and should keep it as is. % ca", $harmless_string);
+	}
+
+	// --------------------------------------------------------------------
+
 	public function test_xss_clean_string_array()
 	{
 		$harm_strings = array(


### PR DESCRIPTION
The issue #5125 (which is closed) is a problem which could be solved by this pull request.
I've faced this issue when the user post some data with `% ca`.
The method `$this->input->post( 'mycustomfield', $xss_clean = true);` will convert `% ca` to a invalid character.

Signed-off-by: Rafael Cardoso <xinhus@gmail.com>