### PR TITLE
Adapt to new version of php-redis

### DIFF
--- a/system/libraries/Session/drivers/Session_redis_driver.php
+++ b/system/libraries/Session/drivers/Session_redis_driver.php
@@ -37,6 +37,8 @@
  */
 defined('BASEPATH') OR exit('No direct script access allowed');
 
+define('PHPREDIS_VERSION', phpversion('redis'));
+
 /**
  * CodeIgniter Session Redis Driver
  *
@@ -453,7 +455,7 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 	 */
 	protected function _expire_key($key, $ttl)
 	{
-		if (version_compare(phpversion('redis'), '5', '>='))
+		if (version_compare(PHPREDIS_VERSION, '5', '>='))
 			return $this->_redis->expire($key, $ttl);
 		return $this->_redis->setTimeout($key, $ttl);
 	}
@@ -470,7 +472,7 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 	 */
 	protected function _delete_key($key)
 	{
-		if (version_compare(phpversion('redis'), '5', '>='))
+		if (version_compare(PHPREDIS_VERSION, '5', '>='))
 			return $this->_redis->del($key);
 		return $this->_redis->delete($key);
 	}

--- a/system/libraries/Session/drivers/Session_redis_driver.php
+++ b/system/libraries/Session/drivers/Session_redis_driver.php
@@ -240,7 +240,7 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 			$this->_session_id = $session_id;
 		}
 
-		$this->_expire($this->_lock_key, 300);
+		$this->_expire_key($this->_lock_key, 300);
 		if ($this->_fingerprint !== ($fingerprint = md5($session_data)) OR $this->_key_exists === FALSE)
 		{
 			if ($this->_redis->set($this->_key_prefix.$session_id, $session_data, $this->_config['expiration']))
@@ -253,7 +253,7 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 			return $this->_fail();
 		}
 
-		return ($this->_expire($this->_key_prefix.$session_id, $this->_config['expiration']))
+		return ($this->_expire_key($this->_key_prefix.$session_id, $this->_config['expiration']))
 			? $this->_success
 			: $this->_fail();
 	}
@@ -273,7 +273,7 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 		{
 			try {
 				$ping = $this->_redis->ping();
-				if ($ping === '+PONG' || $ping === TRUE)
+				if ($ping === '+PONG' OR $ping === TRUE)
 				{
 					$this->_release_lock();
 					if ($this->_redis->close() === FALSE)
@@ -308,7 +308,7 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 	{
 		if (isset($this->_redis, $this->_lock_key))
 		{
-			if (($result = $this->_delete($this->_key_prefix.$session_id)) !== 1)
+			if (($result = $this->_delete_key($this->_key_prefix.$session_id)) !== 1)
 			{
 				log_message('debug', 'Session: Redis::del() expected to return 1, got '.var_export($result, TRUE).' instead.');
 			}
@@ -369,7 +369,7 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 		// correct session ID.
 		if ($this->_lock_key === $this->_key_prefix.$session_id.':lock')
 		{
-			return $this->_expire($this->_lock_key, 300);
+			return $this->_expire_key($this->_lock_key, 300);
 		}
 
 		// 30 attempts to obtain a lock, in case another request already has it
@@ -443,15 +443,15 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 	// ------------------------------------------------------------------------
 
 	/**
-	 * Expire
+	 * Expire key
 	 *
 	 * Sets expiration for a key
 	 *
 	 * @param	string	$key	Redis key
-	 * @param	int		$ttl	The key's remaining Time To Live, in seconds.
+	 * @param	int	$ttl	The key's remaining Time To Live, in seconds.
 	 * @return	bool
 	 */
-	protected function _expire($key, $ttl)
+	protected function _expire_key($key, $ttl)
 	{
 		if (method_exists($this->_redis, 'expire'))
 			return $this->_redis->expire($key, $ttl);
@@ -461,14 +461,14 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 	// ------------------------------------------------------------------------
 
 	/**
-	 * Delete
+	 * Delete key
 	 *
 	 * Deletes a key
 	 *
 	 * @param	string	$key		Redis key
 	 * @return	bool
 	 */
-	protected function _delete($key)
+	protected function _delete_key($key)
 	{
 		if (method_exists($this->_redis, 'del'))
 			return $this->_redis->del($key);

--- a/system/libraries/Session/drivers/Session_redis_driver.php
+++ b/system/libraries/Session/drivers/Session_redis_driver.php
@@ -209,8 +209,8 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 			}
 			else
 			{
-				$this->_redis = $redis;
 				$this->php5_validate_id();
+				$this->_redis = $redis;
 				return $this->_success;
 			}
 		}

--- a/system/libraries/Session/drivers/Session_redis_driver.php
+++ b/system/libraries/Session/drivers/Session_redis_driver.php
@@ -447,13 +447,15 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 	 *
 	 * Sets expiration for a key
 	 *
+	 * @param	string	$key	Redis key
+	 * @param	int		$ttl	The key's remaining Time To Live, in seconds.
 	 * @return	bool
 	 */
-	protected function _expire($key, $timeout)
+	protected function _expire($key, $ttl)
 	{
 		if (method_exists($this->_redis, 'expire'))
-			return $this->_redis->expire($key, $timeout);
-		return $this->_redis->setTimeout($key, $timeout);
+			return $this->_redis->expire($key, $ttl);
+		return $this->_redis->setTimeout($key, $ttl);
 	}
 
 	// ------------------------------------------------------------------------
@@ -463,6 +465,7 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 	 *
 	 * Deletes a key
 	 *
+	 * @param	string	$key		Redis key
 	 * @return	bool
 	 */
 	protected function _delete($key)

--- a/system/libraries/Session/drivers/Session_redis_driver.php
+++ b/system/libraries/Session/drivers/Session_redis_driver.php
@@ -97,11 +97,11 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 	protected $_delete_name;
 
 	/**
-	 * Response of ping() method in phpRedis
+	 * Success return value of ping() method in phpRedis
 	 * 
 	 * @var mixed
 	 */
-	protected $_ping_response;
+	protected $_ping_success;
 
 	// ------------------------------------------------------------------------
 
@@ -120,13 +120,13 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 		{
 			$this->_setTimeout_name = 'expire';
 			$this->_delete_name = 'del';
-			$this->_ping_response = TRUE;
+			$this->_ping_success = TRUE;
 		}
 		else
 		{
 			$this->_setTimeout_name = 'setTimeout';
 			$this->_delete_name = 'delete';
-			$this->_ping_response = '+PONG';
+			$this->_ping_success = '+PONG';
 		}
 
 		if (empty($this->_config['save_path']))
@@ -313,7 +313,7 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 		if (isset($this->_redis))
 		{
 			try {
-				if ($this->_redis->ping() === $this->_ping_response)
+				if ($this->_redis->ping() === $this->_ping_success)
 				{
 					$this->_release_lock();
 					if ($this->_redis->close() === FALSE)

--- a/system/libraries/Session/drivers/Session_redis_driver.php
+++ b/system/libraries/Session/drivers/Session_redis_driver.php
@@ -453,7 +453,7 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 	 */
 	protected function _expire_key($key, $ttl)
 	{
-		if (method_exists($this->_redis, 'expire'))
+		if (version_compare(phpversion('redis'), '5', '>='))
 			return $this->_redis->expire($key, $ttl);
 		return $this->_redis->setTimeout($key, $ttl);
 	}
@@ -470,7 +470,7 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 	 */
 	protected function _delete_key($key)
 	{
-		if (method_exists($this->_redis, 'del'))
+		if (version_compare(phpversion('redis'), '5', '>='))
 			return $this->_redis->del($key);
 		return $this->_redis->delete($key);
 	}


### PR DESCRIPTION
In the new version of php-redis since `5.0.0`, some of the methods have been deprecated, like `Redis::setTimeout` and `Redis::delete`. Also, `Redis::ping` now returns `TRUE` (#5801).