### PR TITLE
Update FTP library to make work 'delete_dir()' function

### DIFF
--- a/system/libraries/Ftp.php
+++ b/system/libraries/Ftp.php
@@ -486,26 +486,31 @@ class CI_FTP {
 		{
 			for ($i = 0, $c = count($list); $i < $c; $i++)
 			{
-				// If we can't delete the item it's probably a directory,
-				// so we'll recursively call delete_dir()
-				if ( ! preg_match('#/\.\.?$#', $list[$i]) && ! @ftp_delete($this->conn_id, $list[$i]))
-				{
-					$this->delete_dir($filepath.$list[$i]);
-				}
+				// First 2 elements of $list array would be '.' and '..', this will case errors
+				if($list[$i] != '.' && $list[$i] != '..'){
+					// If we can't delete the item it's probably a directory,
+					// so we'll recursively call delete_dir()
+					if ( ! preg_match('#/\.\.?$#', $list[$i]) && ! @ftp_delete($this->conn_id, $filepath . $list[$i]))
+					{
+						$this->delete_dir($filepath.$list[$i]);
+					}
+				}	
 			}
-		}
 
-		if (@ftp_rmdir($this->conn_id, $filepath) === FALSE)
-		{
-			if ($this->debug === TRUE)
+			if (@ftp_rmdir($this->conn_id, $filepath) === FALSE)
 			{
-				$this->_error('ftp_unable_to_delete');
+				if ($this->debug === TRUE)
+				{
+					$this->_error('ftp_unable_to_delete');
+				}
+
+				return FALSE;
 			}
 
-			return FALSE;
+			return TRUE;
 		}
 
-		return TRUE;
+		
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
This function wasnt working, because first 2 elements of $list array returns links to parent folders, like this:

[0] => '.',
[1] => '..',
here all folders and files inside dir

This was casing errors, and directory cannot be deleted. I have added new condition to check and ignore these links. Now its work.