### PR TITLE
Cleanly handle array values for CSRF tokens

### DIFF
--- a/system/core/Security.php
+++ b/system/core/Security.php
@@ -229,6 +229,7 @@ class CI_Security {
 
 		// Check CSRF token validity, but don't error on mismatch just yet - we'll want to regenerate
 		$valid = isset($_POST[$this->_csrf_token_name], $_COOKIE[$this->_csrf_cookie_name])
+			&& is_string($_POST[$this->_csrf_token_name])
 			&& hash_equals($_POST[$this->_csrf_token_name], $_COOKIE[$this->_csrf_cookie_name]);
 
 		// We kill this since we're done and we don't want to pollute the _POST array

--- a/tests/codeigniter/core/Security_test.php
+++ b/tests/codeigniter/core/Security_test.php
@@ -49,6 +49,18 @@ class Security_test extends CI_TestCase {
 
 	// --------------------------------------------------------------------
 
+	public function test_csrf_verify_invalid_array()
+	{
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$_POST[$this->security->csrf_token_name] = [$this->security->csrf_hash];
+
+		$this->setExpectedException('RuntimeException', 'CI Error: The action you have requested is not allowed');
+
+		$this->security->csrf_verify();
+	}
+
+	// --------------------------------------------------------------------
+
 	public function test_get_csrf_hash()
 	{
 		$this->assertEquals($this->security->csrf_hash, $this->security->get_csrf_hash());


### PR DESCRIPTION
If the user POSTs an array value for the CSRF token, then CodeIgniter
generates a PHP warning while trying to validate the CSRF value:

```
Severity: Warning
Message: hash_equals(): Expected known_string to be a string, array given
Filename: core/Security.php
Line Number: 231
```

Since the POSTed CSRF token is under the control of the user,
CodeIgniter should cleanly handle this, instead of generating a warning.

Fixes #5825