### PR TITLE
Improve create_captcha()'s logging

### DIFF
--- a/system/helpers/captcha_helper.php
+++ b/system/helpers/captcha_helper.php
@@ -109,7 +109,9 @@ if ( ! function_exists('create_captcha'))
 			{
 				log_message('error', 'create_captcha(): "img_path" and "img_url" are required.');
 				return FALSE;
-			} elseif ( ! is_dir($img_path) OR ! is_really_writable($img_path))
+			}
+
+			if ( ! is_dir($img_path) OR ! is_really_writable($img_path))
 			{
 				log_message('error', "create_captcha(): '$img_path' is not a dir, nor it's writable.");
 				return FALSE;

--- a/system/helpers/captcha_helper.php
+++ b/system/helpers/captcha_helper.php
@@ -107,7 +107,7 @@ if ( ! function_exists('create_captcha'))
 		{
 			if ($img_path === '' OR $img_url === '')
 			{
-				log_message('error', 'create_captcha(): "$img_path" and "$img_url" are required.');
+				log_message('error', 'create_captcha(): $img_path and $img_url are required.');
 				return FALSE;
 			}
 

--- a/system/helpers/captcha_helper.php
+++ b/system/helpers/captcha_helper.php
@@ -113,7 +113,7 @@ if ( ! function_exists('create_captcha'))
 
 			if ( ! is_dir($img_path) OR ! is_really_writable($img_path))
 			{
-				log_message('error', "create_captcha(): '$img_path' is not a dir, nor it's writable.");
+				log_message('error', "create_captcha(): '{$img_path}' is not a dir, nor is it writable.");
 				return FALSE;
 			}
 

--- a/system/helpers/captcha_helper.php
+++ b/system/helpers/captcha_helper.php
@@ -107,7 +107,7 @@ if ( ! function_exists('create_captcha'))
 		{
 			if ($img_path === '' OR $img_url === '')
 			{
-				log_message('error', 'create_captcha(): "img_path" and "img_url" are required.');
+				log_message('error', 'create_captcha(): "$img_path" and "$img_url" are required.');
 				return FALSE;
 			}
 

--- a/system/helpers/captcha_helper.php
+++ b/system/helpers/captcha_helper.php
@@ -99,13 +99,19 @@ if ( ! function_exists('create_captcha'))
 
 		if ( ! extension_loaded('gd'))
 		{
+			log_message('error', 'create_captcha(): GD extension is not loaded.');
 			return FALSE;
 		}
 
 		if ($img_url !== '' OR $img_path !== '')
 		{
-			if ($img_path === '' OR $img_url === '' OR ! is_dir($img_path) OR ! is_really_writable($img_path))
+			if ($img_path === '' OR $img_url === '')
 			{
+				log_message('error', 'create_captcha(): "img_path" and "img_url" are required.');
+				return FALSE;
+			} elseif ( ! is_dir($img_path) OR ! is_really_writable($img_path))
+			{
+				log_message('error', "create_captcha(): '$img_path' is not a dir, nor it's writable.");
 				return FALSE;
 			}
 


### PR DESCRIPTION
While moving to a different server, I noticed that `create_captcha()` was returning `false`, and since there was no logging made, I had to change manually the captcha helper to do some step-by-step debugging. It turned out that php-gd wasn't installed.

Since I'm already touching it, I added some logging for the scenario where img_path wouldn't be writable, as well.