### PR TITLE
Update delete_files() in file helper.

### DIFF
--- a/system/helpers/file_helper.php
+++ b/system/helpers/file_helper.php
@@ -99,12 +99,13 @@ if ( ! function_exists('delete_files'))
 	 * within the supplied base directory will be nuked as well.
 	 *
 	 * @param	string	$path		File path
-	 * @param	bool	$del_dir	Whether to delete any directories found in the path
+	 * @param	bool	$del_dir	Whether to delete the self directory including any sub-directories and files
+	 * @param	bool	$del_subdir	Whether to delete any sub-directories found in the path
 	 * @param	bool	$htdocs		Whether to skip deleting .htaccess and index page files
-	 * @param	int	$_level		Current directory depth level (default: 0; internal use only)
+	 * @param	int		$_level		Current directory depth level (default: 0; internal use only)
 	 * @return	bool
 	 */
-	function delete_files($path, $del_dir = FALSE, $htdocs = FALSE, $_level = 0)
+	function delete_files($path, $del_dir = FALSE, $del_subdir = FALSE, $htdocs = FALSE, $_level = 0)
 	{
 		// Trim the trailing slash
 		$path = rtrim($path, '/\\');
@@ -122,7 +123,7 @@ if ( ! function_exists('delete_files'))
 
 				if (is_dir($filepath) && $filename[0] !== '.' && ! is_link($filepath))
 				{
-					delete_files($filepath, $del_dir, $htdocs, $_level + 1);
+					delete_files($filepath, $del_dir, $del_subdir, $htdocs, $_level + 1);
 				}
 				elseif ($htdocs !== TRUE OR ! preg_match('/^(\.htaccess|index\.(html|htm|php)|web\.config)$/i', $filename))
 				{
@@ -133,7 +134,7 @@ if ( ! function_exists('delete_files'))
 
 		closedir($current_dir);
 
-		return ($del_dir === TRUE && $_level > 0)
+		return ($del_dir OR ($del_subdir === TRUE && $_level > 0))
 			? @rmdir($path)
 			: TRUE;
 	}

--- a/system/helpers/file_helper.php
+++ b/system/helpers/file_helper.php
@@ -102,7 +102,7 @@ if ( ! function_exists('delete_files'))
 	 * @param	bool	$del_dir	Whether to delete the self directory including any sub-directories and files
 	 * @param	bool	$del_subdir	Whether to delete any sub-directories found in the path
 	 * @param	bool	$htdocs		Whether to skip deleting .htaccess and index page files
-	 * @param	int		$_level		Current directory depth level (default: 0; internal use only)
+	 * @param	int	$_level		Current directory depth level (default: 0; internal use only)
 	 * @return	bool
 	 */
 	function delete_files($path, $del_dir = FALSE, $del_subdir = FALSE, $htdocs = FALSE, $_level = 0)

--- a/user_guide_src/source/helpers/file_helper.rst
+++ b/user_guide_src/source/helpers/file_helper.rst
@@ -63,26 +63,34 @@ The following functions are available:
 
 	.. note:: This function acquires an exclusive lock on the file while writing to it.
 
-.. php:function:: delete_files($path[, $del_dir = FALSE[, $htdocs = FALSE]])
+.. php:function:: delete_files($path[, $del_dir = FALSE[, $del_subdir = FALSE[, $htdocs = FALSE]]])
 
 	:param	string	$path: Directory path
-	:param	bool	$del_dir: Whether to also delete directories
+	:param	bool	$del_dir: Whether to delete the self directory including any sub-directories and files
+	:param	bool	$del_subdir: Whether to delete any sub-directories found in the path
 	:param	bool	$htdocs: Whether to skip deleting .htaccess and index page files
 	:returns:	TRUE on success, FALSE in case of an error
 	:rtype:	bool
 
-	Deletes ALL files contained in the supplied path.
+	Deletes ALL files and directories contained in the supplied path.
 
 	Example::
 
 		delete_files('./path/to/directory/');
 
-	If the second parameter is set to TRUE, any directories contained within the supplied
-	root path will be deleted as well.
+	If the second parameter is set to TRUE, the directory will be deleted including any directories or files
+	contained within the supplied root path.
 
 	Example::
 
 		delete_files('./path/to/directory/', TRUE);
+
+	If the second parameter is set to FALSE and the third parameter is set to TRUE, any directories or files contained
+	within the supplied root path will be deleted only.
+
+	Example::
+
+		delete_files('./path/to/directory/', FALSE, TRUE);
 
 	.. note:: The files must be writable or owned by the system in order to be deleted.
 


### PR DESCRIPTION
Hi,
Existing delete_files() function of Codeigniter file helper deletes sub-directories and files which are inside the supplied root path. But it does not delete the directory. Sometimes, you may want to delete a directory including any sub-directories and files. 

Imagine: we create a folder (i.e. 12_companyName) in the upload directory when a company registered by the user so that all upload files goes there. User has the ability to delete the registered company. Now, we want our script to delete concern folder of the company including its sub-directories and files, then delete from the database. Can we do that using delete_files() function?

Of course No.

Here is the solution:

delete_files($path[, $del_dir = FALSE[, $del_subdir = FALSE[, $htdocs = FALSE]]])

:param	string	$path: Directory path
:param	bool	$del_dir: Whether to delete the self directory including any sub-directories and files
:param	bool	$del_subdir: Whether to delete any sub-directories found in the path
:param	bool	$htdocs: Whether to skip deleting .htaccess and index page files
:returns:	TRUE on success, FALSE in case of an error
:rtype:	bool

If the second parameter is set to TRUE, the directory will be deleted including any directories or files contained within the supplied root path.

	Example::

		delete_files('./path/to/directory/', TRUE);

If the second parameter is set to FALSE and the third parameter is set to TRUE, any directories or files contained within the supplied root path will be deleted only.

	Example::

		delete_files('./path/to/directory/', FALSE, TRUE);