### PR TITLE
Update Ubuntu version from Precise to Trusty on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ php:
   - 7.3
   - 7.4snapshot
   - master
-  - hhvm
+  - hhvm-3.30
   
 env:
   - DB=mysql
@@ -35,12 +35,12 @@ script: php -d zend.enable_gc=0 -d date.timezone=UTC -d mbstring.func_overload=7
 matrix:
   allow_failures:
     - php: 7.4snapshot
-    - php: hhvm
     - php: master
+    - php: hhvm-3.30
   exclude:
-    - php: hhvm
+    - php: hhvm-3.30
       env: DB=pgsql
-    - php: hhvm
+    - php: hhvm-3.30
       env: DB=pdo/pgsql
     - php: 7.0
       env: DB=mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4snapshot
   - master
   - hhvm
   
@@ -33,6 +34,7 @@ script: php -d zend.enable_gc=0 -d date.timezone=UTC -d mbstring.func_overload=7
 
 matrix:
   allow_failures:
+    - php: 7.4snapshot
     - php: hhvm
     - php: master
   exclude:
@@ -47,6 +49,8 @@ matrix:
     - php: 7.2
       env: DB=mysql
     - php: 7.3
+      env: DB=mysql
+    - php: 7.4snapshot
       env: DB=mysql
     - php: master
       env: DB=mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-dist: precise
+dist: trusty
 
 php:
   - 5.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ php:
   - 7.2
   - 7.3
   - 7.4snapshot
-  - master
+  - nightly
   - hhvm-3.30
   
 env:
@@ -35,7 +35,7 @@ script: php -d zend.enable_gc=0 -d date.timezone=UTC -d mbstring.func_overload=7
 matrix:
   allow_failures:
     - php: 7.4snapshot
-    - php: master
+    - php: nightly
     - php: hhvm-3.30
   exclude:
     - php: hhvm-3.30
@@ -52,7 +52,7 @@ matrix:
       env: DB=mysql
     - php: 7.4snapshot
       env: DB=mysql
-    - php: master
+    - php: nightly
       env: DB=mysql
 
 branches:


### PR DESCRIPTION
Travis warns about old ubuntu version, now.
https://travis-ci.org/bcit-ci/CodeIgniter/jobs/584604656
Actually, the support of Precise(12.04) is ended at April 2017.
It might be better to update Xenial(16.04), but php5.4 and php5.5
are not supported in Xenial, thus, this PR updates to Trusty(14.04)
which is supported until April 2022.
https://docs.travis-ci.com/user/reference/xenial/#php-support
https://wiki.ubuntu.com/Releases.

By updating to Trusty, we could test 7.4snapshot version and 
8.0.0-dev version easily, thus I added them.

This pr also replace `php:hhvm` to `php:hhvm-3.30`.
Because composer is not support hhvm any more as
https://github.com/composer/composer/issues/8127,
thus, composer cause the error in hhvm-4.
It would be better to test in hhvm-3.30 which is the
last php support version of hhvm.
https://hhvm.com/blog/2018/12/17/hhvm-3.30.html