### PR TITLE
Fix deprecation warning on Travis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"paragonie/random_compat": "Provides better randomness in PHP 5.x"
 	},
 	"require-dev": {
-		"mikey179/vfsStream": "1.1.*",
+		"mikey179/vfsstream": "1.1.*",
 		"phpunit/phpunit": "4.* || 5.*"
 	}
 }


### PR DESCRIPTION
This PR fixes following deprecation warning by replacing
mikey179/vfsStream to mikey179/vfsstream.
https://travis-ci.org/bcit-ci/CodeIgniter/jobs/584604656#L145

```
Deprecation warning: require-dev.mikey179/vfsStream is invalid,
it should not contain uppercase characters.
Please use mikey179/vfsstream instead.
Make sure you fix this as Composer 2.0 will error.
```