### PR TITLE
Update Ubuntu version from Precise to Trusty on Travis with PHP5.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 dist: trusty
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
@@ -38,6 +37,29 @@ matrix:
     - php: 7.4snapshot
     - php: nightly
     - php: hhvm-3.30
+  include:
+    - php: 5.3
+      dist: precise
+      env: DB=mysql
+    - php: 5.3
+      dist: precise
+      env: DB=mysqli
+    - php: 5.3
+      dist: precise
+      env: DB=pgsql
+    - php: 5.3
+      dist: precise
+      env: DB=sqlite
+    - php: 5.3
+      dist: precise
+      env: DB=pdo/mysql
+    - php: 5.3
+      dist: precise
+      env: DB=pdo/pgsql
+    - php: 5.3
+      dist: precise
+      env: DB=pdo/sqlite
+
   exclude:
     - php: hhvm-3.30
       env: DB=pgsql

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4snapshot
   - master
   - hhvm
   
@@ -34,6 +35,7 @@ script: php -d zend.enable_gc=0 -d date.timezone=UTC -d mbstring.func_overload=7
 
 matrix:
   allow_failures:
+    - php: 7.4snapshot
     - php: hhvm
     - php: master
   exclude:
@@ -48,6 +50,8 @@ matrix:
     - php: 7.2
       env: DB=mysql
     - php: 7.3
+      env: DB=mysql
+    - php: 7.4snapshot
       env: DB=mysql
     - php: master
       env: DB=mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ php:
   - 7.3
   - 7.4snapshot
   - master
-  - hhvm
+  - hhvm-3.30
   
 env:
   - DB=mysql
@@ -36,12 +36,12 @@ script: php -d zend.enable_gc=0 -d date.timezone=UTC -d mbstring.func_overload=7
 matrix:
   allow_failures:
     - php: 7.4snapshot
-    - php: hhvm
     - php: master
+    - php: hhvm-3.30
   exclude:
-    - php: hhvm
+    - php: hhvm-3.30
       env: DB=pgsql
-    - php: hhvm
+    - php: hhvm-3.30
       env: DB=pdo/pgsql
     - php: 7.0
       env: DB=mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ php:
   - 7.2
   - 7.3
   - 7.4snapshot
-  - master
+  - nightly
   - hhvm-3.30
   
 env:
@@ -36,7 +36,7 @@ script: php -d zend.enable_gc=0 -d date.timezone=UTC -d mbstring.func_overload=7
 matrix:
   allow_failures:
     - php: 7.4snapshot
-    - php: master
+    - php: nightly
     - php: hhvm-3.30
   exclude:
     - php: hhvm-3.30
@@ -53,7 +53,7 @@ matrix:
       env: DB=mysql
     - php: 7.4snapshot
       env: DB=mysql
-    - php: master
+    - php: nightly
       env: DB=mysql
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-dist: precise
+dist: trusty
 
 php:
   - 5.3


### PR DESCRIPTION
This is php5.3 supported version of #5836 to `3.1-stable` branch.