### PR TITLE
Fixes #5840 (Redis::sRemove() is deprecated) 

### DIFF
--- a/system/libraries/Cache/drivers/Cache_redis.php
+++ b/system/libraries/Cache/drivers/Cache_redis.php
@@ -55,11 +55,11 @@ class CI_Cache_redis extends CI_Driver
 	 * @var	array
 	 */
 	protected static $_default_config = array(
+		'socket_type' => 'tcp',
 		'host' => '127.0.0.1',
 		'password' => NULL,
 		'port' => 6379,
-		'timeout' => 0,
-		'database' => 0
+		'timeout' => 0
 	);
 
 	/**
@@ -69,13 +69,26 @@ class CI_Cache_redis extends CI_Driver
 	 */
 	protected $_redis;
 
+	/**
+	 * An internal cache for storing keys of serialized values.
+	 *
+	 * @var	array
+	 */
+	protected $_serialized = array();
 
 	/**
 	 * del()/delete() method name depending on phpRedis version
 	 *
 	 * @var	string
 	 */
-	protected static $_delete_name;
+    protected static $_delete_name;
+
+    /**
+	 * sRem()/sRemove() method name depending on phpRedis version
+	 * @see https://github.com/phpredis/phpredis#srem-sremove
+	 * @var	string
+	 */
+    protected static $_srem_name;
 
 	// ------------------------------------------------------------------------
 
@@ -96,11 +109,15 @@ class CI_Cache_redis extends CI_Driver
 		{
 			log_message('error', 'Cache: Failed to create Redis object; extension not loaded?');
 			return;
-		}
+        }
 
-		isset(static::$_delete_name) OR static::$_delete_name = version_compare(phpversion('phpredis'), '5', '>=')
+		isset(static::$_delete_name) OR static::$_delete_name = version_compare(phpversion('redis'), '5', '>=')
 			? 'del'
-			: 'delete';
+            : 'delete';
+
+        isset(static::$_srem_name) OR static::$_srem_name = version_compare(phpversion('redis'), '5', '>=')
+			? 'sRem'
+			: 'sRemove';
 
 		$CI =& get_instance();
 
@@ -117,7 +134,16 @@ class CI_Cache_redis extends CI_Driver
 
 		try
 		{
-			if ( ! $this->_redis->connect($config['host'], ($config['host'][0] === '/' ? 0 : $config['port']), $config['timeout']))
+			if ($config['socket_type'] === 'unix')
+			{
+				$success = $this->_redis->connect($config['socket']);
+			}
+			else // tcp socket
+			{
+				$success = $this->_redis->connect($config['host'], $config['port'], $config['timeout']);
+			}
+
+			if ( ! $success)
 			{
 				log_message('error', 'Cache: Redis connection failed. Check your configuration.');
 			}
@@ -125,11 +151,6 @@ class CI_Cache_redis extends CI_Driver
 			if (isset($config['password']) && ! $this->_redis->auth($config['password']))
 			{
 				log_message('error', 'Cache: Redis authentication failed.');
-			}
-
-			if (isset($config['database']) && $config['database'] > 0 && ! $this->_redis->select($config['database']))
-			{
-				log_message('error', 'Cache: Redis select database failed.');
 			}
 		}
 		catch (RedisException $e)
@@ -148,30 +169,14 @@ class CI_Cache_redis extends CI_Driver
 	 */
 	public function get($key)
 	{
-		$data = $this->_redis->hMGet($key, array('__ci_type', '__ci_value'));
+		$value = $this->_redis->get($key);
 
 		if ($value !== FALSE && $this->_redis->sIsMember('_ci_redis_serialized', $key))
 		{
-			return FALSE;
+			return unserialize($value);
 		}
 
-		switch ($data['__ci_type'])
-		{
-			case 'array':
-			case 'object':
-				return unserialize($data['__ci_value']);
-			case 'boolean':
-			case 'integer':
-			case 'double': // Yes, 'double' is returned and NOT 'float'
-			case 'string':
-			case 'NULL':
-				return settype($data['__ci_value'], $data['__ci_type'])
-					? $data['__ci_value']
-					: FALSE;
-			case 'resource':
-			default:
-				return FALSE;
-		}
+		return $value;
 	}
 
 	// ------------------------------------------------------------------------
@@ -187,33 +192,22 @@ class CI_Cache_redis extends CI_Driver
 	 */
 	public function save($id, $data, $ttl = 60, $raw = FALSE)
 	{
-		switch ($data_type = gettype($data))
+		if (is_array($data) OR is_object($data))
 		{
-			case 'array':
-			case 'object':
-				$data = serialize($data);
-				break;
-			case 'boolean':
-			case 'integer':
-			case 'double': // Yes, 'double' is returned and NOT 'float'
-			case 'string':
-			case 'NULL':
-				break;
-			case 'resource':
-			default:
+			if ( ! $this->_redis->sIsMember('_ci_redis_serialized', $id) && ! $this->_redis->sAdd('_ci_redis_serialized', $id))
+			{
 				return FALSE;
-		}
+			}
 
-		if ( ! $this->_redis->hMSet($id, array('__ci_type' => $data_type, '__ci_value' => $data)))
-		{
-			return FALSE;
+			isset($this->_serialized[$id]) OR $this->_serialized[$id] = TRUE;
+			$data = serialize($data);
 		}
 		else
 		{
-			$this->_redis->sRemove('_ci_redis_serialized', $id);
+			$this->_redis->{static::$_srem_name}('_ci_redis_serialized', $id);
 		}
 
-		return TRUE;
+		return $this->_redis->set($id, $data, $ttl);
 	}
 
 	// ------------------------------------------------------------------------
@@ -231,7 +225,7 @@ class CI_Cache_redis extends CI_Driver
 			return FALSE;
 		}
 
-		$this->_redis->sRemove('_ci_redis_serialized', $key);
+		$this->_redis->{static::$_srem_name}('_ci_redis_serialized', $key);
 
 		return TRUE;
 	}

--- a/system/libraries/Cache/drivers/Cache_redis.php
+++ b/system/libraries/Cache/drivers/Cache_redis.php
@@ -81,14 +81,14 @@ class CI_Cache_redis extends CI_Driver
 	 *
 	 * @var	string
 	 */
-    protected static $_delete_name;
+	protected static $_delete_name;
 
-    /**
+	/**
 	 * sRem()/sRemove() method name depending on phpRedis version
 	 * @see https://github.com/phpredis/phpredis#srem-sremove
 	 * @var	string
 	 */
-    protected static $_srem_name;
+	protected static $_srem_name;
 
 	// ------------------------------------------------------------------------
 
@@ -109,13 +109,13 @@ class CI_Cache_redis extends CI_Driver
 		{
 			log_message('error', 'Cache: Failed to create Redis object; extension not loaded?');
 			return;
-        }
+		}
 
 		isset(static::$_delete_name) OR static::$_delete_name = version_compare(phpversion('redis'), '5', '>=')
 			? 'del'
-            : 'delete';
+			: 'delete';
 
-        isset(static::$_srem_name) OR static::$_srem_name = version_compare(phpversion('redis'), '5', '>=')
+		isset(static::$_srem_name) OR static::$_srem_name = version_compare(phpversion('redis'), '5', '>=')
 			? 'sRem'
 			: 'sRemove';
 


### PR DESCRIPTION
Fixes Runtime Notice:  Function Redis::sRemove() is deprecated; in phpredis > 5; (redis cache driver)

[https://github.com/phpredis/phpredis#srem-sremove](https://github.com/phpredis/phpredis#srem-sremove)



