### PR TITLE
cache: redis: Check version of phpredis and redis

### DIFF
--- a/system/libraries/Cache/drivers/Cache_redis.php
+++ b/system/libraries/Cache/drivers/Cache_redis.php
@@ -98,7 +98,7 @@ class CI_Cache_redis extends CI_Driver
 			return;
 		}
 
-		isset(static::$_delete_name) OR static::$_delete_name = version_compare(phpversion('phpredis'), '5', '>=')
+		isset(static::$_delete_name) OR static::$_delete_name = version_compare(phpversion('phpredis') ?: phpversion('redis'), '5', '>=')
 			? 'del'
 			: 'delete';
 


### PR DESCRIPTION
Some distributions use redis rather than phpredis, so check for both. phpversion() returns false if the extension is not enabled.