### PR TITLE
fix issue on session_regenerate with PHP 7.0 or greater

### DIFF
--- a/system/libraries/Session/drivers/Session_database_driver.php
+++ b/system/libraries/Session/drivers/Session_database_driver.php
@@ -159,7 +159,17 @@ class CI_Session_database_driver extends CI_Session_driver implements SessionHan
 		$this->_db->reset_query();
 
 		// Needed by write() to detect session_regenerate_id() calls
-		$this->_session_id = $session_id;
+		if (is_php('7.0'))
+		{
+			if(is_null($this->_session_id))
+			{
+				$this->_session_id = $session_id;
+			}
+		}
+		else
+		{
+			$this->_session_id = $session_id;
+		}
 
 		$this->_db
 			->select('data')
@@ -212,9 +222,12 @@ class CI_Session_database_driver extends CI_Session_driver implements SessionHan
 		// Was the ID regenerated?
 		if (isset($this->_session_id) && $session_id !== $this->_session_id)
 		{
-			if ( ! $this->_release_lock() OR ! $this->_get_lock($session_id))
+			if (!is_php('7.0'))
 			{
-				return $this->_failure;
+				if ( ! $this->_release_lock() OR ! $this->_get_lock($session_id))
+				{
+					return $this->_failure;
+				}
 			}
 
 			$this->_row_exists = FALSE;

--- a/system/libraries/Session/drivers/Session_memcached_driver.php
+++ b/system/libraries/Session/drivers/Session_memcached_driver.php
@@ -165,7 +165,17 @@ class CI_Session_memcached_driver extends CI_Session_driver implements SessionHa
 		if (isset($this->_memcached) && $this->_get_lock($session_id))
 		{
 			// Needed by write() to detect session_regenerate_id() calls
-			$this->_session_id = $session_id;
+			if (is_php('7.0'))
+			{
+				if(is_null($this->_session_id))
+				{
+					$this->_session_id = $session_id;
+				}
+			}
+			else
+			{
+				$this->_session_id = $session_id;
+			}
 
 			$session_data = (string) $this->_memcached->get($this->_key_prefix.$session_id);
 			$this->_fingerprint = md5($session_data);

--- a/system/libraries/Session/drivers/Session_redis_driver.php
+++ b/system/libraries/Session/drivers/Session_redis_driver.php
@@ -239,7 +239,17 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 		if (isset($this->_redis) && $this->_get_lock($session_id))
 		{
 			// Needed by write() to detect session_regenerate_id() calls
-			$this->_session_id = $session_id;
+			if (is_php('7.0'))
+			{
+				if(is_null($this->_session_id))
+				{
+					$this->_session_id = $session_id;
+				}
+			}
+			else
+			{
+				$this->_session_id = $session_id;
+			}
 
 			$session_data = $this->_redis->get($this->_key_prefix.$session_id);
 


### PR DESCRIPTION
If the PHP version in use is 7 or greater, then there is a problem when doing session_regenerate(), because when we call read() it always affect $this->sessionID = $sessionID which means that in write() function you can't detect a $sessionID regenerate, because when we get there the $this->sessionID is always equal to $sessionID.

This happen because in PHP 7 when session_regenerate() is call, this function executes internally and in the following order:
- write() (with the initial session;
- close();
- open();
- read() (already with the new session).

With this PR the session will be prepared for PHP 7 or greater and for PHP 5