### PR TITLE
Enhancement oracle dbforge, auto_increment can be used when using oracle 12.1.

### DIFF
--- a/system/database/drivers/oci8/oci8_forge.php
+++ b/system/database/drivers/oci8/oci8_forge.php
@@ -159,7 +159,29 @@ class CI_DB_oci8_forge extends CI_DB_forge {
 	 */
 	protected function _attr_auto_increment(&$attributes, &$field)
 	{
-		// Not supported - sequences and triggers must be used instead
+		if ( ! empty($attributes['AUTO_INCREMENT']) && $attributes['AUTO_INCREMENT'] === TRUE && stripos($field['type'], 'number') !== FALSE && version_compare($this->db->version(), '12.1', '>='))
+		{
+			$field['auto_increment'] = ' GENERATED ALWAYS AS IDENTITY';
+		}
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Process column
+	 *
+	 * @param	array	$field
+	 * @return	string
+	 */
+	protected function _process_column($field)
+	{
+		return $this->db->escape_identifiers($field['name'])
+			.' '.$field['type'].$field['length']
+			.$field['unsigned']
+			.$field['default']
+			.$field['auto_increment']
+			.$field['null']
+			.$field['unique'];
 	}
 
 	// --------------------------------------------------------------------

--- a/system/database/drivers/pdo/subdrivers/pdo_oci_driver.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_oci_driver.php
@@ -142,9 +142,9 @@ class CI_DB_pdo_oci_driver extends CI_DB_pdo_driver {
 		}
 
 		$version_string = parent::version();
-		if (preg_match('#Release\s(?<version>\d+(?:\.\d+)+)#', $version_string, $match))
+		if (preg_match('#(Release\s)?(?<version>\d+(?:\.\d+)+)#', $version_string, $match))
 		{
-			return $this->data_cache['version'] = $match[1];
+			return $this->data_cache['version'] = $match['version'];
 		}
 
 		return FALSE;

--- a/system/database/drivers/pdo/subdrivers/pdo_oci_forge.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_oci_forge.php
@@ -150,8 +150,32 @@ class CI_DB_pdo_oci_forge extends CI_DB_pdo_forge {
 	 */
 	protected function _attr_auto_increment(&$attributes, &$field)
 	{
-		// Not supported - sequences and triggers must be used instead
+		if ( ! empty($attributes['AUTO_INCREMENT']) && $attributes['AUTO_INCREMENT'] === TRUE && stripos($field['type'], 'number') !== FALSE && version_compare($this->db->version(), '12.1', '>='))
+		{
+			$field['auto_increment'] = ' GENERATED ALWAYS AS IDENTITY';
+		}
 	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Process column
+	 *
+	 * @param	array	$field
+	 * @return	string
+	 */
+	protected function _process_column($field)
+	{
+		return $this->db->escape_identifiers($field['name'])
+			.' '.$field['type'].$field['length']
+			.$field['unsigned']
+			.$field['default']
+			.$field['auto_increment']
+			.$field['null']
+			.$field['unique'];
+	}
+
+	// --------------------------------------------------------------------
 
 	/**
 	 * Field attribute TYPE


### PR DESCRIPTION
Added the function to use AUTO_INCREMENT using Oracle 12.1 `GENERATED ALWAYS AS IDENTITY`.
You can check with the following code.

```php
        $this->dbforge->add_field([                                                                           
            'AI_COLUMN' => [
               'TYPE' => 'NUMBER',
               'CONSTRAINT' => '2',
               'auto_increment' => true,
            ],
            'NOT_AI_COLUMN' => [
               'TYPE' => 'NUMBER',
               'CONSTRAINT' => '2',
            ],
        ]);
        $this->dbforge->create_table('DUMMY');
```