### PR TITLE
Exclude user_guide directory from composer installation by GitAttributes.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,3 +20,4 @@ tests/travis/ export-ignore
 
 # User Guide Source Files
 user_guide_src
+user_guide

--- a/.gitattributes
+++ b/.gitattributes
@@ -20,4 +20,6 @@ tests/travis/ export-ignore
 
 # User Guide Source Files
 user_guide_src
-user_guide
+
+# User Guide Compiled Files
+user_guide export-ignore


### PR DESCRIPTION
Exclude `user_guide` directory if package is installed with composer with the --prefer-dist flag set.

Reff: https://github.com/bcit-ci/CodeIgniter/issues/5843