### PR TITLE
Adds a public trans_depth function to determine transaction state

### DIFF
--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -829,13 +829,13 @@ abstract class CI_DB_driver {
 	// --------------------------------------------------------------------
 
 	/**
-	 * Lets you retrieve the transaction depth
+	 * Returns whether a transaction is currently active
 	 *
-	 * @return	int
+	 * @return	bool
 	 */
-	public function trans_depth()
+	public function trans_active()
 	{
-		return $this->_trans_depth;
+		return (bool) $this->_trans_depth;
 	}
 
 	// --------------------------------------------------------------------

--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -825,6 +825,18 @@ abstract class CI_DB_driver {
 	{
 		return $this->_trans_status;
 	}
+	
+	// --------------------------------------------------------------------
+
+	/**
+	 * Lets you retrieve the transaction depth
+	 *
+	 * @return	int
+	 */
+	public function trans_depth()
+	{
+		return $this->_trans_depth;
+	}
 
 	// --------------------------------------------------------------------
 

--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -829,7 +829,7 @@ abstract class CI_DB_driver {
 	// --------------------------------------------------------------------
 
 	/**
-	 * Returns whether a transaction is currently active
+	 * Returns TRUE if a transaction is currently active
 	 *
 	 * @return	bool
 	 */

--- a/user_guide_src/source/database/db_driver_reference.rst
+++ b/user_guide_src/source/database/db_driver_reference.rst
@@ -161,6 +161,14 @@ This article is intended to be a reference for them.
 
 		Lets you retrieve the transaction status flag to
 		determine if it has failed.
+		
+	.. php:method:: trans_depth()
+
+                :returns:	The current transaction depth
+		:rtype:	int
+
+		Lets you retrieve the transaction depth value which
+		will be 1 or greater if a transaction is active.
 
 	.. php:method:: compile_binds($sql, $binds)
 

--- a/user_guide_src/source/database/db_driver_reference.rst
+++ b/user_guide_src/source/database/db_driver_reference.rst
@@ -162,13 +162,12 @@ This article is intended to be a reference for them.
 		Lets you retrieve the transaction status flag to
 		determine if it has failed.
 		
-	.. php:method:: trans_depth()
+	.. php:method:: trans_active()
 
-                :returns:	The current transaction depth
-		:rtype:	int
+		:returns:	TRUE if a transaction is active, FALSE if not
+		:rtype:	bool
 
-		Lets you retrieve the transaction depth value which
-		will be 1 or greater if a transaction is active.
+		Determines if a transaction is currently active.
 
 	.. php:method:: compile_binds($sql, $binds)
 


### PR DESCRIPTION
Currently there is no mechanism to determine if a transaction is currently active. This function, by allowing read-only access to the protected `_trans_depth` property, can be used to determine if a transaction is currently active, if the transaction is nested, and how many levels of nesting are in effect.

For my personal use case I only need to know if a transaction is active or not, however rather than create a `trans_active()` function or similar I felt it was better to just return the underlying `_trans_depth` as there may be cases where determining if a transaction is nested is useful. It also provides for an obvious function name and I was happy to not have to choose the right name for a `trans_active`-type function.