### PR TITLE
Inserted required attribute `lang` in html tags

### DIFF
--- a/application/cache/index.html
+++ b/application/cache/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/application/config/index.html
+++ b/application/config/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/application/controllers/index.html
+++ b/application/controllers/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/application/core/index.html
+++ b/application/core/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/application/helpers/index.html
+++ b/application/helpers/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/application/hooks/index.html
+++ b/application/hooks/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/application/index.html
+++ b/application/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/application/language/english/index.html
+++ b/application/language/english/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/application/language/index.html
+++ b/application/language/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/application/libraries/index.html
+++ b/application/libraries/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/application/logs/index.html
+++ b/application/logs/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/application/models/index.html
+++ b/application/models/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/application/third_party/index.html
+++ b/application/third_party/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/application/views/errors/cli/index.html
+++ b/application/views/errors/cli/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/application/views/errors/html/index.html
+++ b/application/views/errors/html/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/application/views/errors/index.html
+++ b/application/views/errors/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/application/views/index.html
+++ b/application/views/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/system/core/compat/index.html
+++ b/system/core/compat/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/system/core/index.html
+++ b/system/core/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/system/database/drivers/cubrid/index.html
+++ b/system/database/drivers/cubrid/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/system/database/drivers/ibase/index.html
+++ b/system/database/drivers/ibase/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/system/database/drivers/index.html
+++ b/system/database/drivers/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/system/database/drivers/mssql/index.html
+++ b/system/database/drivers/mssql/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/system/database/drivers/mysql/index.html
+++ b/system/database/drivers/mysql/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/system/database/drivers/mysqli/index.html
+++ b/system/database/drivers/mysqli/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/system/database/drivers/oci8/index.html
+++ b/system/database/drivers/oci8/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/system/database/drivers/odbc/index.html
+++ b/system/database/drivers/odbc/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/system/database/drivers/pdo/index.html
+++ b/system/database/drivers/pdo/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/system/database/drivers/pdo/subdrivers/index.html
+++ b/system/database/drivers/pdo/subdrivers/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/system/database/drivers/postgre/index.html
+++ b/system/database/drivers/postgre/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/system/database/drivers/sqlite3/index.html
+++ b/system/database/drivers/sqlite3/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/system/database/drivers/sqlsrv/index.html
+++ b/system/database/drivers/sqlsrv/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/system/database/index.html
+++ b/system/database/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/system/fonts/index.html
+++ b/system/fonts/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/system/helpers/index.html
+++ b/system/helpers/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/system/index.html
+++ b/system/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/system/language/english/index.html
+++ b/system/language/english/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/system/language/index.html
+++ b/system/language/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/system/libraries/Cache/drivers/index.html
+++ b/system/libraries/Cache/drivers/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/system/libraries/Cache/index.html
+++ b/system/libraries/Cache/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/system/libraries/Session/drivers/index.html
+++ b/system/libraries/Session/drivers/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/system/libraries/Session/index.html
+++ b/system/libraries/Session/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/system/libraries/index.html
+++ b/system/libraries/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>403 Forbidden</title>
 </head>

--- a/tests/codeigniter/core/Output_test.php
+++ b/tests/codeigniter/core/Output_test.php
@@ -8,7 +8,7 @@ class Output_test extends CI_TestCase {
 	public function set_up()
 	{
 		$this->_output_data =<<<HTML
-		<html>
+		<html lang="en">
 			<head>
 				<title>Basic HTML</title>
 			</head>

--- a/user_guide_src/source/general/views.rst
+++ b/user_guide_src/source/general/views.rst
@@ -22,7 +22,7 @@ Creating a View
 Using your text editor, create a file called blogview.php, and put this
 in it::
 
-	<html>
+	<html lang="en">
 	<head>
 		<title>My Blog</title>
 	</head>
@@ -138,7 +138,7 @@ Let's try it with your controller file. Open it add this code::
 Now open your view file and change the text to variables that correspond
 to the array keys in your data::
 
-	<html>
+	<html lang="en">
 	<head>
 		<title><?php echo $title;?></title>
 	</head>
@@ -176,7 +176,7 @@ Here's a simple example. Add this to your controller::
 
 Now open your view file and create a loop::
 
-	<html>
+	<html lang="en">
 	<head>
 		<title><?php echo $title;?></title>
 	</head>

--- a/user_guide_src/source/libraries/file_uploading.rst
+++ b/user_guide_src/source/libraries/file_uploading.rst
@@ -35,7 +35,7 @@ Creating the Upload Form
 Using a text editor, create a form called upload_form.php. In it, place
 this code and save it to your **application/views/** directory::
 
-	<html>
+	<html lang="en">
 	<head>
 	<title>Upload Form</title>
 	</head>
@@ -68,7 +68,7 @@ The Success Page
 Using a text editor, create a form called upload_success.php. In it,
 place this code and save it to your **application/views/** directory::
 
-	<html>
+	<html lang="en">
 	<head>
 	<title>Upload Form</title>
 	</head>

--- a/user_guide_src/source/libraries/form_validation.rst
+++ b/user_guide_src/source/libraries/form_validation.rst
@@ -65,7 +65,7 @@ The Form
 Using a text editor, create a form called myform.php. In it, place this
 code and save it to your application/views/ folder::
 
-	<html>
+	<html lang="en">
 	<head>
 	<title>My Form</title>
 	</head>
@@ -100,7 +100,7 @@ The Success Page
 Using a text editor, create a form called formsuccess.php. In it, place
 this code and save it to your application/views/ folder::
 
-	<html>
+	<html lang="en">
 	<head>
 	<title>My Form</title>
 	</head>
@@ -359,7 +359,7 @@ function calls!**
 
 ::
 
-	<html>
+	<html lang="en">
 	<head>
 	<title>My Form</title>
 	</head>

--- a/user_guide_src/source/libraries/parser.rst
+++ b/user_guide_src/source/libraries/parser.rst
@@ -9,7 +9,7 @@ It can parse simple variables or variable tag pairs.
 If you've never used a template engine,
 pseudo-variable names are enclosed in braces, like this::
 
-	<html>
+	<html lang="en">
 		<head>
 			<title>{blog_title}</title>
 		</head>
@@ -95,7 +95,7 @@ you would like an entire block of variables to be repeated, with each
 iteration containing new values? Consider the template example we showed
 at the top of the page::
 
-	<html>
+	<html lang="en">
 		<head>
 			<title>{blog_title}</title>
 		</head>

--- a/user_guide_src/source/tutorial/static_pages.rst
+++ b/user_guide_src/source/tutorial/static_pages.rst
@@ -58,7 +58,7 @@ the following code:
 
 ::
 
-	<html>
+	<html lang="en">
 		<head>
 			<title>CodeIgniter Tutorial</title>
 		</head>


### PR DESCRIPTION
Extract from SonarAnalyzer (HTML)

> The `<html>` element should provide the `lang` attribute in order to identify the default language of a document.
> It enables assistive technologies, such as screen readers, to provide a comfortable reading experience by adapting the pronunciation and accent to the language. It also helps braille translation software, telling it to switch the control codes for accented characters for instance.

https://www.w3.org/TR/WCAG20-TECHS/html.html#H57