### PR TITLE
ZIP Library Memory Optimization

### DIFF
--- a/system/libraries/Zip.php
+++ b/system/libraries/Zip.php
@@ -406,13 +406,13 @@ class CI_Zip {
 			return FALSE;
 		}
 
-		return $this->zipdata
-			.$this->directory."\x50\x4b\x05\x06\x00\x00\x00\x00"
+		$footer = $this->directory."\x50\x4b\x05\x06\x00\x00\x00\x00"
 			.pack('v', $this->entries) // total # of entries "on this disk"
 			.pack('v', $this->entries) // total # of entries overall
 			.pack('V', self::strlen($this->directory)) // size of central dir
 			.pack('V', self::strlen($this->zipdata)) // offset to start of central dir
 			."\x00\x00"; // .zip file comment length
+		return $this->zipdata . $footer;
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
This PR is submitted in order to solve issue #5864, as per @vlakoff's suggestion. It aims to stop the ZIP Library from allocating unnecessary memory on the get_zip() function. 

Signed-off-by: Andrés Ignacio Torres <andresitorresm@gmail.com>