### PR TITLE
Fix database connection leak when closing PDO connection

### DIFF
--- a/system/database/drivers/pdo/pdo_driver.php
+++ b/system/database/drivers/pdo/pdo_driver.php
@@ -326,4 +326,17 @@ class CI_DB_pdo_driver extends CI_DB {
 		return 'TRUNCATE TABLE '.$table;
 	}
 
+	// --------------------------------------------------------------------
+
+	/**
+	 * Close DB Connection
+	 *
+	 * @return	void
+	 */
+	protected function _close()
+	{
+		$this->result_id = FALSE;
+		$this->conn_id = FALSE;
+	}
+
 }


### PR DESCRIPTION
We discovered a resource leak (database connection leak) in our application's test suite. We investigated and discovered that, although the test suite was calling `CI_DB_driver::close()` after each test, the `result_id` member variable still maintained an internal reference to the database connection, which kept the connection from being closed.

This is using pdo_sqlsrv; I have not tested other PDO drivers.

This PR addresses the problem by clearing `result_id` within CodeIgniter's PDO driver's `_close` method, but if another approach would be better, please let me know.