### PR TITLE
fix too many connection for oracle

### DIFF
--- a/system/database/drivers/oci8/oci8_driver.php
+++ b/system/database/drivers/oci8/oci8_driver.php
@@ -682,6 +682,14 @@ class CI_DB_oci8_driver extends CI_DB {
 	 */
 	protected function _close()
 	{
+		if (is_resource($this->curs_id))
+		{
+			oci_free_statement($this->curs_id);
+		}
+		if (is_resource($this->stmt_id))
+		{
+			oci_free_statement($this->stmt_id);
+		}
 		oci_close($this->conn_id);
 	}
 

--- a/system/database/drivers/oci8/oci8_driver.php
+++ b/system/database/drivers/oci8/oci8_driver.php
@@ -686,10 +686,12 @@ class CI_DB_oci8_driver extends CI_DB {
 		{
 			oci_free_statement($this->curs_id);
 		}
+
 		if (is_resource($this->stmt_id))
 		{
 			oci_free_statement($this->stmt_id);
 		}
+
 		oci_close($this->conn_id);
 	}
 


### PR DESCRIPTION
I ran the following error when I ran about 3000 unit tests.

ORA-01000

The cause is that the cursor became huge because `oci_free_statement` was not performed.

This code reduced the oracle open cursor by a factor of ten.

I can't submit the actual test code, but I don't think this implementation will cause a bug.

I measured the number of cursors with the following SQL.

```
select   sid,   statistic#,   value from v$sesstat where statistic# = 5   and sid in (select sid from v$session where username ='test');
```