### PR TITLE
Add server protocol value variation

### DIFF
--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -569,7 +569,7 @@ if ( ! function_exists('set_status_header'))
 			return;
 		}
 
-		$server_protocol = (isset($_SERVER['SERVER_PROTOCOL']) && in_array($_SERVER['SERVER_PROTOCOL'], array('HTTP/1.0', 'HTTP/1.1', 'HTTP/2'), TRUE))
+		$server_protocol = (isset($_SERVER['SERVER_PROTOCOL']) && in_array($_SERVER['SERVER_PROTOCOL'], array('HTTP/1.0', 'HTTP/1.1', 'HTTP/2', 'HTTP/2.0'), TRUE))
 			? $_SERVER['SERVER_PROTOCOL'] : 'HTTP/1.1';
 		header($server_protocol.' '.$code.' '.$text, TRUE, $code);
 	}


### PR DESCRIPTION
In some Apache servers running the `HTTP/2` protocol, calling `$_SERVER['SERVER_PROTOCOL']` may return `HTTP/2.0` instead, thus causing CodeIgniter to (incorrectly) determine the output header protocol to use. This commit adds the different variation value to fix that.