### PR TITLE
Replace php7.4snapshot to php7.4 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
 sudo: false
 
 before_script:
-  - sh -c "composer install --dev --no-progress"
+  - sh -c "composer install --no-progress"
   - sh -c "if [ '$DB' = 'pgsql' ] || [ '$DB' = 'pdo/pgsql' ]; then psql -c 'DROP DATABASE IF EXISTS ci_test;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'pgsql' ] || [ '$DB' = 'pdo/pgsql' ]; then psql -c 'create database ci_test;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'mysql' ] || [ '$DB' = 'mysqli' ] || [ '$DB' = 'pdo/mysql' ]; then mysql -e 'create database IF NOT EXISTS ci_test;'; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
-  - 7.4snapshot
+  - 7.4
   - nightly
   - hhvm-3.30
   
@@ -34,7 +34,7 @@ script: php -d zend.enable_gc=0 -d date.timezone=UTC -d mbstring.func_overload=7
 
 matrix:
   allow_failures:
-    - php: 7.4snapshot
+    - php: 7.4
     - php: nightly
     - php: hhvm-3.30
   exclude:
@@ -50,7 +50,7 @@ matrix:
       env: DB=mysql
     - php: 7.3
       env: DB=mysql
-    - php: 7.4snapshot
+    - php: 7.4
       env: DB=mysql
     - php: nightly
       env: DB=mysql


### PR DESCRIPTION
php7.4 is released in Nov 2019.
It would be better to replace `php7.4snapshot` to `php7.4` on Travis test.

And "dev" option in composer command is deprecated now, as mentioned on Travis test.
https://travis-ci.org/bcit-ci/CodeIgniter/jobs/600609271#L147
Thus, I remove the "dev" option from composer command on Travis test.