### PR TITLE
Fixed issue with creating a resource from png using Image_lib

### DIFF
--- a/system/libraries/Image_lib.php
+++ b/system/libraries/Image_lib.php
@@ -1474,15 +1474,16 @@ class CI_Image_lib {
 					$this->set_error(array('imglib_unsupported_imagecreate', 'imglib_png_not_supported'));
 					return FALSE;
 				}
+
+				return imagecreatefrompng($path);
 			case 18:
 				if ( ! function_exists('imagecreatefromwebp'))
 				{
 					$this->set_error(array('imglib_unsupported_imagecreate', 'imglib_webp_not_supported'));
 					return FALSE;
 				}
-				return imagecreatefromwebp($path);
 
-				return imagecreatefrompng($path);
+				return imagecreatefromwebp($path);
 			default:
 				$this->set_error(array('imglib_unsupported_imagecreate'));
 				return FALSE;


### PR DESCRIPTION
Due to this pr https://github.com/bcit-ci/CodeIgniter/pull/5883 while changing the function `image_create_gd` to add support for webp, the option to create a resource from png is no longer possible.