### PR TITLE
Add optional footer to table with custom content and aggregation functions support ( Sum, Average,Min,Max,Count )

### DIFF
--- a/system/libraries/Table.php
+++ b/system/libraries/Table.php
@@ -175,17 +175,16 @@ class CI_Table {
 	
 	
 	/**
-	 * Set the table footer sum columns
+	 * Set the table footer columns with their function or custom content 
 	 *
-	 * Can be passed as an array or discreet params
+	 * Must be passed as an array
 	 *
 	 * @param	mixed
 	 * @return	CI_Table
 	 */
 	public function set_footer_columns($args = array())
 	{
-			$this->footer_columns = func_get_args()[0];
-			
+		$this->footer_columns = func_get_args()[0];	
 		return $this;
 	}
 	// --------------------------------------------------------------------

--- a/system/libraries/Table.php
+++ b/system/libraries/Table.php
@@ -182,9 +182,16 @@ class CI_Table {
 	 * @param	mixed
 	 * @return	CI_Table
 	 */
-	public function set_footer_columns($args = array())
+	public function set_footer_columns($array)
 	{
-		$this->footer_columns = func_get_args()[0];	
+		if(! is_array($array))
+			return FALSE;
+		
+		if ( count($array) === 0 OR $array=== NULL )
+			$this->footer_columns = array();
+		else 
+			$this->footer_columns = $array;
+			
 		return $this;
 	}
 	// --------------------------------------------------------------------

--- a/system/libraries/Table.php
+++ b/system/libraries/Table.php
@@ -365,7 +365,7 @@ class CI_Table {
 			$out .= '<caption>'.$this->caption.'</caption>'.$this->newline;
 		}
 
-		// footer preparation
+		// footer initialization
 		$this->footer = array();
 		
 		// Is there a table heading to display?
@@ -386,6 +386,8 @@ class CI_Table {
 				}
 
 				$out .= $temp.(isset($heading['data']) ? $heading['data'] : '').$this->template['heading_cell_end'];
+				
+				// Set 0 to the specified columns in the footer
 				if($this->footer_columns)
 						$this->footer[isset($heading['data']) ? $heading['data'] : '']=isset($this->footer_columns[isset($heading['data']) ? $heading['data'] : '']) ? 0 : '';
 			}
@@ -403,7 +405,7 @@ class CI_Table {
 					$temp_footer_columns[array_search($key, array_keys($this->footer))]=$value ;
 				$this->footer_columns =$temp_footer_columns;
 				
-				//Map footer array key from name to index
+				//Map footer array key to index
 				$temp_footer=array();
 				$i=0;
 				foreach ($this->footer as $footer_cell)
@@ -465,6 +467,7 @@ class CI_Table {
 					
 					//Footer cell calculation
 					if(isset($this->footer_columns[$cell_key])){
+						// Filter data and get number from the cell 
 						$number=(float) filter_var($cell, FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION );
 						if($this->footer_columns[$cell_key]=="SUM")
 							$this->footer[$cell_key]+=$number;

--- a/system/libraries/Table.php
+++ b/system/libraries/Table.php
@@ -70,13 +70,13 @@ class CI_Table {
 	 * @var array
 	 */
 	public $footer		= array();
+	
 	/**
-	 * Columns that must have sum at footer
+	 *  Specified columns (and its aggregation function) to show in footer
 	 *
 	 * @var array
 	 */
-	 
-	public $footer_columns		= array();
+	public $footer_columns	= array();
 	
 
 	/**


### PR DESCRIPTION
**set_footer_columns** function is added to class. Now you can have footer at the bottom of the table where it can show Sum, Average,Min,Max, Count of column or even a custom text. Moreover it can be stylized by footer templates.

Example : 
Here we have table with WLID , DEBIT, CREDIT , DATETIME, DESCRIPTION
`$query = $this->db->query("SELECT  WLID, DEBIT, CREDIT, DATETIME ,DESCRIPTION FROM wallet  ");`

We want to have sum of CREDIT and DEBIT columns, count of non empty cells in DESCRIPTION column, and custom text "Total" in WLID column : 

`$this->table->set_footer_columns(["CREDIT"=>"SUM","DEBIT"=>"SUM","WLID"=>"Total","DESCRIPTION"=>"CNT"]);` 

Result :

![ci](https://user-images.githubusercontent.com/20352967/78338391-f514f100-75a7-11ea-9a1e-ea62b8277cd9.jpg)




