### PR TITLE
Update Ubuntu version from Trusty to Xenial on Travis 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ services:
   - postgresql
 
 before_script:
-  - sh -c "composer install --dev --no-progress"
+  - sh -c "composer install --no-progress"
   - sh -c "if [ '$DB' = 'pgsql' ] || [ '$DB' = 'pdo/pgsql' ]; then psql -c 'DROP DATABASE IF EXISTS ci_test;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'pgsql' ] || [ '$DB' = 'pdo/pgsql' ]; then psql -c 'create database ci_test;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'mysql' ] || [ '$DB' = 'mysqli' ] || [ '$DB' = 'pdo/mysql' ]; then mysql -e 'create database IF NOT EXISTS ci_test;'; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,17 @@
 language: php
-dist: trusty
+os: linux
+dist: xenial
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
   - 7.2
   - 7.3
-  - 7.4snapshot
+  - 7.4
   - nightly
-  - hhvm-3.30
-  
+
 env:
-  - DB=mysql
   - DB=mysqli
   - DB=pgsql
   - DB=sqlite
@@ -22,7 +19,9 @@ env:
   - DB=pdo/pgsql
   - DB=pdo/sqlite
 
-sudo: false
+services:
+  - mysql
+  - postgresql
 
 before_script:
   - sh -c "composer install --dev --no-progress"
@@ -32,28 +31,72 @@ before_script:
 
 script: php -d zend.enable_gc=0 -d date.timezone=UTC -d mbstring.func_overload=7 -d mbstring.internal_encoding=UTF-8 vendor/bin/phpunit --coverage-text --configuration tests/travis/$DB.phpunit.xml
 
-matrix:
+jobs:
   allow_failures:
-    - php: 7.4snapshot
+    - php: 7.4
     - php: nightly
     - php: hhvm-3.30
-  exclude:
-    - php: hhvm-3.30
+  include:
+    - php: 5.4
+      dist: trusty
+      env: DB=mysql
+    - php: 5.4
+      dist: trusty
+      env: DB=mysqli
+    - php: 5.4
+      dist: trusty
       env: DB=pgsql
-    - php: hhvm-3.30
+    - php: 5.4
+      dist: trusty
+      env: DB=sqlite
+    - php: 5.4
+      dist: trusty
+      env: DB=pdo/mysql
+    - php: 5.4
+      dist: trusty
       env: DB=pdo/pgsql
-    - php: 7.0
+    - php: 5.4
+      dist: trusty
+      env: DB=pdo/sqlite
+    - php: 5.5
+      dist: trusty
       env: DB=mysql
-    - php: 7.1
+    - php: 5.5
+      dist: trusty
+      env: DB=mysqli
+    - php: 5.5
+      dist: trusty
+      env: DB=pgsql
+    - php: 5.5
+      dist: trusty
+      env: DB=sqlite
+    - php: 5.5
+      dist: trusty
+      env: DB=pdo/mysql
+    - php: 5.5
+      dist: trusty
+      env: DB=pdo/pgsql
+    - php: 5.5
+      dist: trusty
+      env: DB=pdo/sqlite
+    - php: 5.6
+      dist: xenial
       env: DB=mysql
-    - php: 7.2
+    - php: hhvm-3.30
+      dist: trusty
       env: DB=mysql
-    - php: 7.3
-      env: DB=mysql
-    - php: 7.4snapshot
-      env: DB=mysql
-    - php: nightly
-      env: DB=mysql
+    - php: hhvm-3.30
+      dist: trusty
+      env: DB=mysqli
+    - php: hhvm-3.30
+      dist: trusty
+      env: DB=sqlite
+    - php: hhvm-3.30
+      dist: trusty
+      env: DB=pdo/mysql
+    - php: hhvm-3.30
+      dist: trusty
+      env: DB=pdo/sqlite
 
 branches:
   only:


### PR DESCRIPTION
This PR updates Ubuntu version from Trusty(14.04) to Xenial(16.04).
By updating Trusty to Xenial, we can test in latest version of php7.4 and php8.

php5.4, php5.5 and hhvm-3.30 are not supported in Xenial, thus, they test in Trusty.
I replace `php7.4snapshot` to `php7.4`, because php7.4 is released in Nov 2019.

And "dev" option in composer command is deprecated now, as mentioned on Travis.
https://travis-ci.org/bcit-ci/CodeIgniter/jobs/600609271#L147
Thus, I remove the "dev" option from composer command on Travis test.

--
Example of difference between Trusty and Xenial:
php:nightly in Trusty
PHP 8.0.0-dev (cli) (built: Jan  7 2020 22:28:03)
php:nightly in Xenial
PHP 8.0.0-dev (cli) (built: Apr 10 2020 11:13:10)