### PR TITLE
Pass the travis php7.4 test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ services:
   - postgresql
 
 before_script:
-  - sh -c "composer install --dev --no-progress"
+  - sh -c "composer install --no-progress"
   - sh -c "if [ '$DB' = 'pgsql' ] || [ '$DB' = 'pdo/pgsql' ]; then psql -c 'DROP DATABASE IF EXISTS ci_test;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'pgsql' ] || [ '$DB' = 'pdo/pgsql' ]; then psql -c 'create database ci_test;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'mysql' ] || [ '$DB' = 'mysqli' ] || [ '$DB' = 'pdo/mysql' ]; then mysql -e 'create database IF NOT EXISTS ci_test;'; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,17 @@
 language: php
-dist: trusty
+os: linux
+dist: xenial
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
   - 7.2
   - 7.3
-  - 7.4snapshot
+  - 7.4
   - nightly
-  - hhvm-3.30
-  
+
 env:
-  - DB=mysql
   - DB=mysqli
   - DB=pgsql
   - DB=sqlite
@@ -22,7 +19,9 @@ env:
   - DB=pdo/pgsql
   - DB=pdo/sqlite
 
-sudo: false
+services:
+  - mysql
+  - postgresql
 
 before_script:
   - sh -c "composer install --dev --no-progress"
@@ -32,28 +31,72 @@ before_script:
 
 script: php -d zend.enable_gc=0 -d date.timezone=UTC -d mbstring.func_overload=7 -d mbstring.internal_encoding=UTF-8 vendor/bin/phpunit --coverage-text --configuration tests/travis/$DB.phpunit.xml
 
-matrix:
+jobs:
   allow_failures:
-    - php: 7.4snapshot
+    - php: 7.4
     - php: nightly
     - php: hhvm-3.30
-  exclude:
-    - php: hhvm-3.30
+  include:
+    - php: 5.4
+      dist: trusty
+      env: DB=mysql
+    - php: 5.4
+      dist: trusty
+      env: DB=mysqli
+    - php: 5.4
+      dist: trusty
       env: DB=pgsql
-    - php: hhvm-3.30
+    - php: 5.4
+      dist: trusty
+      env: DB=sqlite
+    - php: 5.4
+      dist: trusty
+      env: DB=pdo/mysql
+    - php: 5.4
+      dist: trusty
       env: DB=pdo/pgsql
-    - php: 7.0
+    - php: 5.4
+      dist: trusty
+      env: DB=pdo/sqlite
+    - php: 5.5
+      dist: trusty
       env: DB=mysql
-    - php: 7.1
+    - php: 5.5
+      dist: trusty
+      env: DB=mysqli
+    - php: 5.5
+      dist: trusty
+      env: DB=pgsql
+    - php: 5.5
+      dist: trusty
+      env: DB=sqlite
+    - php: 5.5
+      dist: trusty
+      env: DB=pdo/mysql
+    - php: 5.5
+      dist: trusty
+      env: DB=pdo/pgsql
+    - php: 5.5
+      dist: trusty
+      env: DB=pdo/sqlite
+    - php: 5.6
+      dist: xenial
       env: DB=mysql
-    - php: 7.2
+    - php: hhvm-3.30
+      dist: trusty
       env: DB=mysql
-    - php: 7.3
-      env: DB=mysql
-    - php: 7.4snapshot
-      env: DB=mysql
-    - php: nightly
-      env: DB=mysql
+    - php: hhvm-3.30
+      dist: trusty
+      env: DB=mysqli
+    - php: hhvm-3.30
+      dist: trusty
+      env: DB=sqlite
+    - php: hhvm-3.30
+      dist: trusty
+      env: DB=pdo/mysql
+    - php: hhvm-3.30
+      dist: trusty
+      env: DB=pdo/sqlite
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ script: php -d zend.enable_gc=0 -d date.timezone=UTC -d mbstring.func_overload=7
 
 jobs:
   allow_failures:
-    - php: 7.4
     - php: nightly
     - php: hhvm-3.30
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,10 @@ services:
   - mysql
   - postgresql
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 before_script:
   - sh -c "composer install --no-progress"
   - sh -c "if [ '$DB' = 'pgsql' ] || [ '$DB' = 'pdo/pgsql' ]; then psql -c 'DROP DATABASE IF EXISTS ci_test;' -U postgres; fi"

--- a/tests/codeigniter/helpers/text_helper_test.php
+++ b/tests/codeigniter/helpers/text_helper_test.php
@@ -64,7 +64,12 @@ class Text_helper_test extends CI_TestCase {
 
 	public function test_convert_accented_characters()
 	{
-		$this->ci_vfs_clone('application/config/foreign_chars.php');
+		$path = 'application/config/foreign_chars.php';
+		$this->ci_vfs_clone($path);
+		if (is_php('7.4'))
+		{
+			copy(PROJECT_BASE.$path, APPPATH.'../'.$path);
+		}
 		$this->assertEquals('AAAeEEEIIOOEUUUeY', convert_accented_characters('ÀÂÄÈÊËÎÏÔŒÙÛÜŸ'));
 		$this->assertEquals('a e i o u n ue', convert_accented_characters('á é í ó ú ñ ü'));
 	}


### PR DESCRIPTION
By coping the file ('application/config/foreign_chars.php') directly, travis test in php7.4 are passed.
I guess that there are some encoding errors in `ci_vfs_clone` for cloning the UTF-8 file in php7.4.

The error was just a coping the file for creating test-environment, thus,
we could consider that CodeIgniter itself could pass php7.4 travis test, I guess.

EDIT: I add composer cache in Travis, because composer downloading causes error sometimes.