### PR TITLE
Add the ability to get the first Input item value from many

### DIFF
--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -138,7 +138,7 @@ class CI_Input {
 			return $output;
 		}
 		
-		if(is_string($index) === TRUE && strpos($index, ',') !== FALSE)
+		if (is_string($index) === TRUE && strpos($index, ',') !== FALSE)
 		{
 			// Explode index list
 			$index_keys = explode(',', $index);
@@ -149,7 +149,7 @@ class CI_Input {
 				// Trim index value
 				$index = trim($index);
 
-				if(($value = $this->_fetch_from_array($array, $index, $xss_clean)) !== NULL)
+				if (($value = $this->_fetch_from_array($array, $index, $xss_clean)) !== NULL)
 				{
 					return $value;
 				}

--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -137,6 +137,26 @@ class CI_Input {
 
 			return $output;
 		}
+		
+		if(is_string($index) === TRUE && strpos($index, ',') !== FALSE)
+		{
+			// Explode index list
+			$index_keys = explode(',', $index);
+
+			// Go through indexes
+			foreach ($index_keys as $index)
+			{
+				// Trim index value
+				$index = trim($index);
+
+				if(($value = $this->_fetch_from_array($array, $index, $xss_clean)) !== NULL)
+				{
+					return $value;
+				}
+			}
+
+			return NULL;
+		}
 
 		if (isset($array[$index]))
 		{

--- a/user_guide_src/source/libraries/input.rst
+++ b/user_guide_src/source/libraries/input.rst
@@ -36,6 +36,10 @@ With CodeIgniter's built in methods you can simply do this::
 
 	$something = $this->input->post('something');
 
+Additionally, you can use a comma-separated string of items to get the first one that's not NULL if any:
+
+	$something = $this->input->post('something, another');
+
 The main methods are:
 
 -  ``$this->input->post()``
@@ -59,11 +63,15 @@ from the **php://input** stream at any time, just by using the
 
 	$this->input->raw_input_stream;
 
-Additionally if the input stream is form-encoded like $_POST you can 
+Additionally, if the input stream is form-encoded like $_POST you can 
 access its values by calling the
 ``input_stream()`` method::
 
 	$this->input->input_stream('key');
+
+This method also supports using a comma-separated string of items to get the first one that's not NULL if any:
+
+	$this->input->input_stream('something, another');
 
 Similar to other methods such as ``get()`` and ``post()``, if the
 requested data is not found, it will return NULL and you can also
@@ -118,6 +126,12 @@ Class Reference
 			$this->input->post(NULL, TRUE); // returns all POST items with XSS filter
 			$this->input->post(NULL, FALSE); // returns all POST items without XSS filter
 
+		To return the first item value that's not NULL if any, call with
+		a comma-separated string of items:
+		::
+
+			$this->input->post('something, another');
+
 		To return an array of multiple POST parameters, pass all the required keys
 		as an array.
 		::
@@ -150,6 +164,12 @@ Class Reference
 
 			$this->input->get(NULL, TRUE); // returns all GET items with XSS filter
 			$this->input->get(NULL, FALSE); // returns all GET items without XSS filtering
+
+		To return the first item value that's not NULL if any, call with
+		a comma-separated string of items:
+		::
+
+			$this->input->get('something, another');
 
 		To return an array of multiple GET parameters, pass all the required keys
 		as an array.
@@ -204,6 +224,12 @@ Class Reference
 			$this->input->cookie('some_cookie');
 			$this->input->cookie('some_cookie', TRUE); // with XSS filter
 
+		To return the first item value that's not NULL if any, call with
+		a comma-separated string of items:
+		::
+
+			$this->input->cookie('something, another');
+
 		To return an array of multiple cookie values, pass all the required keys
 		as an array.
 		::
@@ -225,6 +251,12 @@ Class Reference
 		methods, only it fetches server data (``$_SERVER``)::
 
 			$this->input->server('some_data');
+
+		To return the first item value that's not NULL if any, call with
+		a comma-separated string of items:
+		::
+
+			$this->input->server('something, another');
 
 		To return an array of multiple ``$_SERVER`` values, pass all the required keys
 		as an array.


### PR DESCRIPTION
This pull request adds a feature to the Input core library that allows the developer to use a comma-separated string of items to any of the `get(), post(), cookie(), server(), input_stream()` methods and get back the value of the first item that's not NULL if one is found, otherwise NULL is returned as expected. This is an example of the expected usage:

`$requested_items = $this->input->get->('item_id, item_selection');`

This is useful for example when you're designing an API and you want to allow the user to either supply a String called `item_id `or an Array called `items_selection` for the requested data, but want to avoid having to manually check which one (of many) has been used by the user.

I hope this example showcases how this feature could be useful.