### PR TITLE
#5949 - By default load composer autoloader from vendor/autoload.php.

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -124,7 +124,7 @@ $config['subclass_prefix'] = 'MY_';
 |--------------------------------------------------------------------------
 |
 | Enabling this setting will tell CodeIgniter to look for a Composer
-| package auto-loader script in application/vendor/autoload.php.
+| package auto-loader script in vendor/autoload.php.
 |
 |	$config['composer_autoload'] = TRUE;
 |

--- a/system/core/CodeIgniter.php
+++ b/system/core/CodeIgniter.php
@@ -118,9 +118,9 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 	{
 		if ($composer_autoload === TRUE)
 		{
-			file_exists(APPPATH.'vendor/autoload.php')
-				? require_once(APPPATH.'vendor/autoload.php')
-				: log_message('error', '$config[\'composer_autoload\'] is set to TRUE but '.APPPATH.'vendor/autoload.php was not found.');
+			file_exists(FCPATH.'vendor/autoload.php')
+				? require_once(FCPATH.'vendor/autoload.php')
+				: log_message('error', '$config[\'composer_autoload\'] is set to TRUE but '.FCPATH.'vendor/autoload.php was not found.');
 		}
 		elseif (file_exists($composer_autoload))
 		{


### PR DESCRIPTION
Load vendor/autoload.php file from `FCPATH` instead of `APPPATH`. This will load correct file when `$config['composer_autoload']` is set to `TRUE`.