### PR TITLE
Fixed function "list_fields" using oci8 database.

### DIFF
--- a/system/database/drivers/oci8/oci8_driver.php
+++ b/system/database/drivers/oci8/oci8_driver.php
@@ -522,6 +522,8 @@ class CI_DB_oci8_driver extends CI_DB {
 		{
 			$owner = $this->username;
 		}
+		
+		$table = $this->protect_identifiers($table, TRUE, FALSE, FALSE);
 
 		return 'SELECT COLUMN_NAME FROM ALL_TAB_COLUMNS
 			WHERE UPPER(OWNER) = '.$this->escape(strtoupper($owner)).'


### PR DESCRIPTION
Without this fix, this function ignores database configuration "dbprefix" in the query.