### PR TITLE
Additional config for session cookie samesite attribute 

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -385,6 +385,12 @@ $config['sess_regenerate_destroy'] = FALSE;
 | 'cookie_path'     = Typically will be a forward slash
 | 'cookie_secure'   = Cookie will only be set if a secure HTTPS connection exists.
 | 'cookie_httponly' = Cookie will only be accessible via HTTP(S) (no javascript)
+| 'cookie_samesite' = Identify whether or not to allow a cookie to be accessed. 
+|					  SameSite attribute include 'Strict', 'Lax', or 'None' (The first character must be an uppercase letter)
+|
+|    				  'Lax' enables only first-party cookies to be sent/accessed
+|					  'Strict' is a subset of 'lax' and won’t fire if the incoming link is from an external site
+|    				  'None' signals that the cookie data can be shared with third parties/external sites
 |
 | Note: These settings (with the exception of 'cookie_prefix' and
 |       'cookie_httponly') will also affect sessions.
@@ -395,6 +401,7 @@ $config['cookie_domain']	= '';
 $config['cookie_path']		= '/';
 $config['cookie_secure']	= FALSE;
 $config['cookie_httponly'] 	= FALSE;
+$config['cookie_samesite'] 	= 'None';
 
 /*
 |--------------------------------------------------------------------------

--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -302,7 +302,7 @@ class CI_Input {
 	 * @param	bool		$httponly	Whether to only makes the cookie accessible via HTTP (no javascript)
 	 * @return	void
 	 */
-	public function set_cookie($name, $value = '', $expire = 0, $domain = '', $path = '/', $prefix = '', $secure = NULL, $httponly = NULL)
+	public function set_cookie($name, $value = '', $expire = 0, $domain = '', $path = '/', $prefix = '', $secure = NULL, $httponly = NULL, $samesite = NULL)
 	{
 		if (is_array($name))
 		{
@@ -340,8 +340,9 @@ class CI_Input {
 			: (bool) $httponly;
 			
 		// Handle cookie 'samesite' attribute
-		$samesite = config_item('cookie_samesite');
-		$samesite = empty($samesite)? 'None' : $samesite;
+		$samesite = ($samesite === NULL && config_item('cookie_samesite') !== NULL)
+			? config_item('cookie_samesite')
+			: 'None';
 
 		if ( ! is_numeric($expire) OR $expire < 0)
 		{

--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -338,6 +338,9 @@ class CI_Input {
 		$httponly = ($httponly === NULL && config_item('cookie_httponly') !== NULL)
 			? (bool) config_item('cookie_httponly')
 			: (bool) $httponly;
+			
+		// Handle cookie 'samesite' attribute
+		$samesite = empty(config_item('cookie_samesite'))? 'None' : config_item('cookie_samesite');
 
 		if ( ! is_numeric($expire) OR $expire < 0)
 		{
@@ -347,8 +350,20 @@ class CI_Input {
 		{
 			$expire = ($expire > 0) ? time() + $expire : 0;
 		}
-
-		setcookie($prefix.$name, $value, $expire, $path, $domain, $secure, $httponly);
+		
+		// using setcookie with array option to add cookie 'samesite' attribute
+		setcookie(
+			$prefix.$name, 
+			$value, 
+			array(
+				'expires' => $expire, 
+				'path' => $path,
+				'domain' => $domain, 
+				'secure' => $secure, 
+				'httponly' => $httponly,
+				'samesite' => $samesite // add samesite attribute
+			)
+		);
 	}
 
 	// --------------------------------------------------------------------

--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -340,7 +340,8 @@ class CI_Input {
 			: (bool) $httponly;
 			
 		// Handle cookie 'samesite' attribute
-		$samesite = empty(config_item('cookie_samesite'))? 'None' : config_item('cookie_samesite');
+		$samesite = config_item('cookie_samesite');
+		$samesite = empty($samesite)? 'None' : $samesite;
 
 		if ( ! is_numeric($expire) OR $expire < 0)
 		{

--- a/system/core/Security.php
+++ b/system/core/Security.php
@@ -273,14 +273,18 @@ class CI_Security {
 			return FALSE;
 		}
 
+		// using setcookie with array option to add cookie 'samesite' attribute
 		setcookie(
-			$this->_csrf_cookie_name,
-			$this->_csrf_hash,
-			$expire,
-			config_item('cookie_path'),
-			config_item('cookie_domain'),
-			$secure_cookie,
-			config_item('cookie_httponly')
+			$this->_csrf_cookie_name, 
+			$this->_csrf_hash, 
+			array(
+				'expires' => $expire, 
+				'path' => config_item('cookie_path'),
+				'domain' => config_item('cookie_domain'), 
+				'secure' => $secure_cookie, 
+				'httponly' => config_item('cookie_httponly'),
+				'samesite' => config_item('cookie_samesite') // add samesite attribute
+			)
 		);
 		log_message('info', 'CSRF cookie sent');
 

--- a/system/helpers/cookie_helper.php
+++ b/system/helpers/cookie_helper.php
@@ -67,10 +67,10 @@ if ( ! function_exists('set_cookie'))
 	 * @param	bool	true makes the cookie accessible via http(s) only (no javascript)
 	 * @return	void
 	 */
-	function set_cookie($name, $value = '', $expire = 0, $domain = '', $path = '/', $prefix = '', $secure = NULL, $httponly = NULL)
+	function set_cookie($name, $value = '', $expire = 0, $domain = '', $path = '/', $prefix = '', $secure = NULL, $httponly = NULL, $samesite = NULL)
 	{
 		// Set the config file options
-		get_instance()->input->set_cookie($name, $value, $expire, $domain, $path, $prefix, $secure, $httponly);
+		get_instance()->input->set_cookie($name, $value, $expire, $domain, $path, $prefix, $secure, $httponly, $samesite);
 	}
 }
 

--- a/system/libraries/Session/Session.php
+++ b/system/libraries/Session/Session.php
@@ -144,14 +144,18 @@ class CI_Session {
 		// unless it is being currently created or regenerated
 		elseif (isset($_COOKIE[$this->_config['cookie_name']]) && $_COOKIE[$this->_config['cookie_name']] === session_id())
 		{
+			// using setcookie with array option to add cookie 'samesite' attribute
 			setcookie(
 				$this->_config['cookie_name'],
-				session_id(),
-				(empty($this->_config['cookie_lifetime']) ? 0 : time() + $this->_config['cookie_lifetime']),
-				$this->_config['cookie_path'],
-				$this->_config['cookie_domain'],
-				$this->_config['cookie_secure'],
-				TRUE
+				session_id(), 
+				array(
+					'expires' => (empty($this->_config['cookie_lifetime']) ? 0 : time() + $this->_config['cookie_lifetime']),
+					'path' => $this->_config['cookie_path'],
+					'domain' => $this->_config['cookie_domain'],
+					'secure' => $this->_config['cookie_secure'],
+					'httponly' => TRUE,
+					'samesite' => config_item('cookie_samesite') // add samesite attribute
+				)
 			);
 		}
 
@@ -267,12 +271,18 @@ class CI_Session {
 		isset($params['cookie_domain']) OR $params['cookie_domain'] = config_item('cookie_domain');
 		isset($params['cookie_secure']) OR $params['cookie_secure'] = (bool) config_item('cookie_secure');
 
+		// additional for cookie 'samesite' attribute
+		isset($params['cookie_samesite']) OR $params['cookie_samesite'] = config_item('cookie_samesite'); 
+		
 		session_set_cookie_params(
-			$params['cookie_lifetime'],
-			$params['cookie_path'],
-			$params['cookie_domain'],
-			$params['cookie_secure'],
-			TRUE // HttpOnly; Yes, this is intentional and not configurable for security reasons
+			array(
+				'lifetime' => $params['cookie_lifetime'],
+				'path' => $params['cookie_path'],
+				'domain' => $params['cookie_domain'],
+				'secure' => $params['cookie_secure'],
+				'httponly' => TRUE, // HttpOnly; Yes, this is intentional and not configurable for security reasons
+				'samesite' => $params['cookie_samesite'] // The value of the samesite element should be either None, Lax or Strict
+			)
 		);
 
 		if (empty($expiration))

--- a/system/libraries/Session/Session_driver.php
+++ b/system/libraries/Session/Session_driver.php
@@ -148,6 +148,19 @@ abstract class CI_Session_driver implements SessionHandlerInterface {
 			$this->_config['cookie_secure'],
 			TRUE
 		);
+		// using setcookie with array option to add cookie 'samesite' attribute
+		return setcookie(
+			$this->_config['cookie_name'],
+			NULL,
+			array(
+				'expires' => 1, 
+				'path' => $this->_config['cookie_path'],
+				'domain' => $this->_config['cookie_domain'],
+				'secure' => $this->_config['cookie_secure'],
+				'httponly' => TRUE,
+				'samesite' => $this->_config['cookie_samesite'] // add samesite attribute
+			)
+		);
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
I write some additional config and edit core system to handle samesite attribute that will be rejected in most of browser nowadays.

`_The "csrf_cookie_name" cookie will be rejected immediately because it has the "sameSite" attribute that has a value of "none" or an invalid value, without the "secure" attribute. To find out more about the "sameSite" attribute, read https://developer.mozilla.org/docs/Web/HTTP/Cookies_`

Based on issues [5791](https://github.com/bcit-ci/CodeIgniter/issues/5791) and [5874](https://github.com/bcit-ci/CodeIgniter/pull/5874) 

Using function `setcookie `  with `array option` to add '_samesite_' attribute that didn't handle previously. The value of _samesite_ depends on _cookie_samesite_ on configuration file.