### PR TITLE
Update query builder group_by phpdoc param type

### DIFF
--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -1191,7 +1191,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	/**
 	 * GROUP BY
 	 *
-	 * @param	string	$by
+	 * @param	string|string[]	$by
 	 * @param	bool	$escape
 	 * @return	CI_DB_query_builder
 	 */


### PR DESCRIPTION
According to the documentation of [query builder](https://codeigniter.com/userguide3/database/query_builder.html), the `group_by`  function should accept array or string. However, the phpdoc of the function only accept string. My IDE keep warning me about this so here is the change I made.

Thanks