### PR TITLE
Add support for TLS connection strings

### DIFF
--- a/system/libraries/Session/drivers/Session_redis_driver.php
+++ b/system/libraries/Session/drivers/Session_redis_driver.php
@@ -137,7 +137,7 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 		{
 			$save_path = array('path' => $matches[1]);
 		}
-		elseif (preg_match('#(?:tcp://)?([^:?]+)(?:\:(\d+))?(?<options>\?.+)?#', $this->_config['save_path'], $matches))
+		elseif (preg_match('#(?:tcp://)?((?:tls://)?[^:?]+)(?:\:(\d+))?(?<options>\?.+)?#', $this->_config['save_path'], $matches))
 		{
 			$save_path = array(
 				'host'    => $matches[1],


### PR DESCRIPTION
Signed-off-by: Daniel Guidry <ddog800@gmail.com>

This will additionally match `tls://` and include it in the first capture group (containing the host string), if found. 

I have tested this against live Redis servers using both `tcp://` and `tls://` connection strings and have tested the pattern itself against various strings.

Issue #5982 has details.