### PR TITLE
Updated pdo_mysql_driver.php

### DIFF
--- a/system/database/drivers/pdo/subdrivers/pdo_mysql_driver.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_mysql_driver.php
@@ -331,6 +331,8 @@ class CI_DB_pdo_mysql_driver extends CI_DB_pdo_driver {
 				$retval[$i]->max_length
 			);
 
+			$retval[$i]->null		= $query[$i]->Null;
+			$retval[$i]->extra		= $query[$i]->Extra; 
 			$retval[$i]->default		= $query[$i]->Default;
 			$retval[$i]->primary_key	= (int) ($query[$i]->Key === 'PRI');
 		}


### PR DESCRIPTION
Table missing table metadata added.
- I needed the null and extra data from the table's metadata, but these were not added internally.