### PR TITLE
Replace phpunit/phpunit with sminnee/phpunit in php8+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,8 @@ services:
   - mysql
   - postgresql
 
-cache:
-  directories:
-    - $HOME/.composer/cache
-
 before_script:
+  - sh -c "if [ '${TRAVIS_PHP_VERSION:0:2}' = '8.' ] || [ '$TRAVIS_PHP_VERSION' = 'nightly' ]; then sed -i 's/phpunit\/phpunit/sminnee\/phpunit/g' composer.json; composer config -g platform.php 7.4.11; fi"
   - sh -c "composer install --no-progress"
   - sh -c "if [ '$DB' = 'pgsql' ] || [ '$DB' = 'pdo/pgsql' ]; then psql -c 'DROP DATABASE IF EXISTS ci_test;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'pgsql' ] || [ '$DB' = 'pdo/pgsql' ]; then psql -c 'create database ci_test;' -U postgres; fi"


### PR DESCRIPTION
This PR replaces phpunit/phpunit with sminnee/phpunit in php8+ travis test.
The errors occurring in phpunit itself would be resolved by this replacement.

This commit also removes cache directory.
I set this setting to avoid composer download errors, but this setting didn't work well.