### PR TITLE
Fix Flashdata time comparison for PHP 8

### DIFF
--- a/system/libraries/Session/Session.php
+++ b/system/libraries/Session/Session.php
@@ -398,7 +398,7 @@ class CI_Session {
 				}
 				// Hacky, but 'old' will (implicitly) always be less than time() ;)
 				// DO NOT move this above the 'new' check!
-				elseif ($value < $current_time)
+				elseif ($value === 'old' || $value < $current_time)
 				{
 					unset($_SESSION[$key], $_SESSION['__ci_vars'][$key]);
 				}


### PR DESCRIPTION
In PHP 8, string to number comparison works differently (see https://www.php.net/manual/en/migration80.incompatible.php)

This means that Flashdata now no longer clears after each request, and instead persists indefinitely.  The author of the Session library helpfully left a comment stating that the string `'old' < time()` which under PHP 8 is no longer the case.