### PR TITLE
Speed up of $this->db->count_all_results()

### DIFF
--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -1493,7 +1493,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 			$this->qb_cache_select  = array();
  		}
 
-		$result = ($this->qb_distinct === TRUE OR ! empty($this->qb_groupby) OR ! empty($this->qb_cache_groupby) OR $this->qb_limit OR $this->qb_offset)
+		$result = ($this->qb_distinct === TRUE OR ! empty($this->qb_groupby) OR ! empty($this->qb_cache_groupby) OR ! empty($this->qb_having) OR $this->qb_limit OR $this->qb_offset)
 			? $this->query($this->_count_string.$this->protect_identifiers('numrows')."\nFROM (\n".$this->_compile_select()."\n) CI_count_all_results")
 			: $this->query($this->_compile_select($this->_count_string.$this->protect_identifiers('numrows')));
 

--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -1483,8 +1483,17 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 		$qb_orderby       = $this->qb_orderby;
 		$qb_cache_orderby = $this->qb_cache_orderby;
 		$this->qb_orderby = $this->qb_cache_orderby = array();
+		
+		//if DISTINCT is not used, this should return the same count as the select, 
+		//but avoiding extra memory and extra subqueries, thus faster
+		$qb_select        = $this->qb_select;
+ 		$qb_cache_select  = $this->qb_cache_select;
+ 		if($this->qb_distinct === FALSE){
+			$this->qb_select  = ['1'];
+			$this->qb_cache_select  = [];
+ 		}
 
-		$result = ($this->qb_distinct === TRUE OR ! empty($this->qb_groupby) OR ! empty($this->qb_cache_groupby) OR ! empty($this->qb_having) OR $this->qb_limit OR $this->qb_offset)
+		$result = ($this->qb_distinct === TRUE OR ! empty($this->qb_groupby) OR ! empty($this->qb_cache_groupby) OR $this->qb_limit OR $this->qb_offset)
 			? $this->query($this->_count_string.$this->protect_identifiers('numrows')."\nFROM (\n".$this->_compile_select()."\n) CI_count_all_results")
 			: $this->query($this->_compile_select($this->_count_string.$this->protect_identifiers('numrows')));
 
@@ -1496,6 +1505,9 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 		{
 			$this->qb_orderby       = $qb_orderby;
 			$this->qb_cache_orderby = $qb_cache_orderby;
+
+			$this->qb_select        = $qb_select;
+			$this->qb_cache_select  = $qb_cache_select;
 		}
 
 		if ($result->num_rows() === 0)

--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -1489,8 +1489,8 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 		$qb_select        = $this->qb_select;
  		$qb_cache_select  = $this->qb_cache_select;
  		if($this->qb_distinct === FALSE){
-			$this->qb_select  = ['1'];
-			$this->qb_cache_select  = [];
+			$this->qb_select  = array('1');
+			$this->qb_cache_select  = array();
  		}
 
 		$result = ($this->qb_distinct === TRUE OR ! empty($this->qb_groupby) OR ! empty($this->qb_cache_groupby) OR $this->qb_limit OR $this->qb_offset)


### PR DESCRIPTION
Count_all_results is currently unnecessarily executing the full prepared select in the query, which might include subqueries that will be executed for each row. 
If the select with no limit is returning a lot of rows it gets slow, as there will be a big amount of queries performed. (As far as i know the working of subqueries, with a select with 20 subqueries, and a no limited return of 100.000 rows, it is 2.000.001 queries plus the count...)

In theory, by setting the select as i propose, you will avoid the unnecessary overwork, as each 'would be row' will simply contain a '1', and there will be only one query executed.

As far as i know, 'distinct' (which to my understanding, is the same as making a 'group by' for each field in the query) queries might return a different number of rows so this quick optimization of the query is not usable with it. In my opinion, it could be posible by converting de 'distinct' to 'group by' for each field selected, feel free to explore that.

Please, check if i missed something.