### PR TITLE
PoC: SameSite attribute implementation for CI_Input::set_cookie

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -385,6 +385,7 @@ $config['sess_regenerate_destroy'] = FALSE;
 | 'cookie_path'     = Typically will be a forward slash
 | 'cookie_secure'   = Cookie will only be set if a secure HTTPS connection exists.
 | 'cookie_httponly' = Cookie will only be accessible via HTTP(S) (no javascript)
+| 'cookie_samesite' = Cookie's samesite attribute (Lax, Strict or None)
 |
 | Note: These settings (with the exception of 'cookie_prefix' and
 |       'cookie_httponly') will also affect sessions.
@@ -395,6 +396,7 @@ $config['cookie_domain']	= '';
 $config['cookie_path']		= '/';
 $config['cookie_secure']	= FALSE;
 $config['cookie_httponly'] 	= FALSE;
+$config['cookie_samesite'] 	= 'lax';
 
 /*
 |--------------------------------------------------------------------------

--- a/application/config/config.php
+++ b/application/config/config.php
@@ -396,7 +396,7 @@ $config['cookie_domain']	= '';
 $config['cookie_path']		= '/';
 $config['cookie_secure']	= FALSE;
 $config['cookie_httponly'] 	= FALSE;
-$config['cookie_samesite'] 	= 'lax';
+$config['cookie_samesite'] 	= 'Lax';
 
 /*
 |--------------------------------------------------------------------------

--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -364,7 +364,7 @@ class CI_Input {
 		}
 
 		$cookie_header = 'Set-Cookie: '.$prefix.$name.'='.rawurlencode($value);
-		$cookie_header .= ($expire === 0 ? '' : '; expires='.gmdate('D, d-M-Y H:i:s T', 0));
+		$cookie_header .= ($expire === 0 ? '' : '; expires='.gmdate('D, d-M-Y H:i:s T', $expire));
 		$cookie_header .= '; path='.$path.($domain !== '' ? '; domain='.$domain : '');
 		$cookie_header .= ($secure ? '; secure' : '').($httponly ? '; HttpOnly' : '').($samesite !== NULL ? '; SameSite='.$samesite : '');
 		header($cookie_header);

--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -365,11 +365,26 @@ class CI_Input {
 			log_message('error', $name.' cookie sent with SameSite=None, but without Secure attribute.');
 		}
 
-		$cookie_header = 'Set-Cookie: '.$prefix.$name.'='.rawurlencode($value);
-		$cookie_header .= ($expire === 0 ? '' : '; expires='.gmdate('D, d-M-Y H:i:s T', $expire));
-		$cookie_header .= '; path='.$path.($domain !== '' ? '; domain='.$domain : '');
-		$cookie_header .= ($secure ? '; secure' : '').($httponly ? '; HttpOnly' : '').'; SameSite='.$samesite;
-		header($cookie_header);
+		if (is_php('7.3'))
+		{
+			$setcookie_options = array(
+				'expires' => $expire,
+				'path' => $path,
+				'domain' => $domain,
+				'secure' => $secure,
+				'httponly' => $httponly,
+				'samesite' => $samesite,
+			);
+			setcookie($prefix.$name, $value, $setcookie_options);
+		}
+		else
+		{
+			$cookie_header = 'Set-Cookie: '.$prefix.$name.'='.rawurlencode($value);
+			$cookie_header .= ($expire === 0 ? '' : '; expires='.gmdate('D, d-M-Y H:i:s T', $expire));
+			$cookie_header .= '; path='.$path.($domain !== '' ? '; domain='.$domain : '');
+			$cookie_header .= ($secure ? '; secure' : '').($httponly ? '; HttpOnly' : '').'; SameSite='.$samesite;
+			header($cookie_header);
+		}
 	}
 
 	// --------------------------------------------------------------------

--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -300,14 +300,15 @@ class CI_Input {
 	 * @param	string		$prefix		Cookie name prefix
 	 * @param	bool		$secure		Whether to only transfer cookies via SSL
 	 * @param	bool		$httponly	Whether to only makes the cookie accessible via HTTP (no javascript)
+	 * @param	string		$samesite	SameSite attribute. NULL will avoid sending the attribute
 	 * @return	void
 	 */
-	public function set_cookie($name, $value = '', $expire = 0, $domain = '', $path = '/', $prefix = '', $secure = NULL, $httponly = NULL)
+	public function set_cookie($name, $value = '', $expire = 0, $domain = '', $path = '/', $prefix = '', $secure = NULL, $httponly = NULL, $samesite = NULL)
 	{
 		if (is_array($name))
 		{
 			// always leave 'name' in last place, as the loop will break otherwise, due to $$item
-			foreach (array('value', 'expire', 'domain', 'path', 'prefix', 'secure', 'httponly', 'name') as $item)
+			foreach (array('value', 'expire', 'domain', 'path', 'prefix', 'secure', 'httponly', 'name', 'samesite') as $item)
 			{
 				if (isset($name[$item]))
 				{
@@ -348,7 +349,25 @@ class CI_Input {
 			$expire = ($expire > 0) ? time() + $expire : 0;
 		}
 
-		setcookie($prefix.$name, $value, $expire, $path, $domain, $secure, $httponly);
+		if ($samesite === NULL && config_item('cookie_samesite') !== NULL)
+		{
+			$samesite = strtolower(config_item('cookie_samesite'));
+		}
+		elseif ($samesite !== NULL)
+		{
+			$samesite = strtolower($samesite);
+		}
+
+		if ( ! in_array($samesite, array('lax', 'strict', 'none', NULL), TRUE))
+		{
+			$samesite = NULL;
+		}
+
+		$cookie_header = 'Set-Cookie: '.$prefix.$name.'='.rawurlencode($value);
+		$cookie_header .= ($expire === 0 ? '' : '; expires='.gmdate('D, d-M-Y H:i:s T', 0));
+		$cookie_header .= '; path='.$path.($domain !== '' ? '; domain='.$domain : '');
+		$cookie_header .= ($secure ? '; secure' : '').($httponly ? '; HttpOnly' : '').($samesite !== NULL ? '; SameSite='.$samesite : '');
+		header($cookie_header);
 	}
 
 	// --------------------------------------------------------------------

--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -362,7 +362,7 @@ class CI_Input {
 
 		if ($samesite === 'None' && ! $secure)
 		{
-			log_message('error', $name.' is a non-secure cookie sent with SameSite=None. It can be discarded by the browser.');
+			log_message('error', $name.' cookie sent with SameSite=None, but without Secure attribute.');
 		}
 
 		$cookie_header = 'Set-Cookie: '.$prefix.$name.'='.rawurlencode($value);

--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -360,7 +360,7 @@ class CI_Input {
 			$samesite = 'Lax';
 		}
 
-		if ($samesite === 'None' && !$secure)
+		if ($samesite === 'None' && ! $secure)
 		{
 			log_message('error', $name.' is a non-secure cookie sent with SameSite=None. It can be discarded by the browser.');
 		}

--- a/user_guide_src/source/libraries/input.rst
+++ b/user_guide_src/source/libraries/input.rst
@@ -252,7 +252,7 @@ Class Reference
 		:param	string	$prefix: Cookie name prefix
 		:param	bool	$secure: Whether to only transfer the cookie through HTTPS
 		:param	bool	$httponly: Whether to only make the cookie accessible for HTTP requests (no JavaScript)
-		:param	string	$samesite: Cookie's SameSite attribute ('Lax', 'Strict', 'None')
+		:param	string	$samesite: SameSite attribute ('Lax', 'Strict', 'None')
 		:rtype:	void
 
 
@@ -266,14 +266,14 @@ Class Reference
 		parameter::
 
 			$cookie = array(
-				'name'     => 'The Cookie Name',
-				'value'    => 'The Value',
-				'expire'   => 86500,
-				'domain'   => '.some-domain.com',
-				'path'     => '/',
-				'prefix'   => 'myprefix_',
-				'secure'   => TRUE,
-				'samesite' => 'strict'
+				'name'		=> 'The Cookie Name',
+				'value'		=> 'The Value',
+				'expire'	=> 86500,
+				'domain'	=> '.some-domain.com',
+				'path'		=> '/',
+				'prefix'	=> 'myprefix_',
+				'secure'	=> TRUE,
+				'samesite'	=> 'Strict'
 			);
 
 			$this->input->set_cookie($cookie);

--- a/user_guide_src/source/libraries/input.rst
+++ b/user_guide_src/source/libraries/input.rst
@@ -252,7 +252,7 @@ Class Reference
 		:param	string	$prefix: Cookie name prefix
 		:param	bool	$secure: Whether to only transfer the cookie through HTTPS
 		:param	bool	$httponly: Whether to only make the cookie accessible for HTTP requests (no JavaScript)
-		:param	string	$samesite: Cookie's SameSite attribute ('lax', 'strict', 'none' or NULL)
+		:param	string	$samesite: Cookie's SameSite attribute ('Lax', 'Strict', 'None')
 		:rtype:	void
 
 
@@ -299,7 +299,7 @@ Class Reference
 
 		The *httponly* and *secure* flags, when omitted, will default to your
 		``$config['cookie_httponly']`` and ``$config['cookie_secure']`` settings.
-		The *samesite* parameter can be ``'lax'``, ``'strict'``, ``'none'`` or ``NULL``. When ``NULL``, the same-site cookie attribute is not set at all.
+		The *samesite* parameter can be ``'Lax'``, ``'Strict'`` or ``'None'``. If not set, the same-site cookie attribute will default to ``'Lax'``.
 
 		**Discrete Parameters**
 

--- a/user_guide_src/source/libraries/input.rst
+++ b/user_guide_src/source/libraries/input.rst
@@ -242,7 +242,7 @@ Class Reference
 		This method is identical to ``get()``, ``post()`` and ``cookie()``,
 		only it fetches the *php://input* stream data.
 
-	.. php:method:: set_cookie($name = ''[, $value = ''[, $expire = 0[, $domain = ''[, $path = '/'[, $prefix = ''[, $secure = NULL[, $httponly = NULL]]]]]]])
+	.. php:method:: set_cookie($name = ''[, $value = ''[, $expire = 0[, $domain = ''[, $path = '/'[, $prefix = ''[, $secure = NULL[, $httponly = NULL[, $samesite = NULL]]]]]]]])
 
 		:param	mixed	$name: Cookie name or an array of parameters
 		:param	string	$value: Cookie value
@@ -252,6 +252,7 @@ Class Reference
 		:param	string	$prefix: Cookie name prefix
 		:param	bool	$secure: Whether to only transfer the cookie through HTTPS
 		:param	bool	$httponly: Whether to only make the cookie accessible for HTTP requests (no JavaScript)
+		:param	string	$samesite: Cookie's SameSite attribute ('lax', 'strict', 'none' or NULL)
 		:rtype:	void
 
 
@@ -265,13 +266,14 @@ Class Reference
 		parameter::
 
 			$cookie = array(
-				'name'   => 'The Cookie Name',
-				'value'  => 'The Value',
-				'expire' => 86500,
-				'domain' => '.some-domain.com',
-				'path'   => '/',
-				'prefix' => 'myprefix_',
-				'secure' => TRUE
+				'name'     => 'The Cookie Name',
+				'value'    => 'The Value',
+				'expire'   => 86500,
+				'domain'   => '.some-domain.com',
+				'path'     => '/',
+				'prefix'   => 'myprefix_',
+				'secure'   => TRUE,
+				'samesite' => 'strict'
 			);
 
 			$this->input->set_cookie($cookie);
@@ -297,13 +299,14 @@ Class Reference
 
 		The *httponly* and *secure* flags, when omitted, will default to your
 		``$config['cookie_httponly']`` and ``$config['cookie_secure']`` settings.
+		The *samesite* parameter can be ``'lax'``, ``'strict'``, ``'none'`` or ``NULL``. When ``NULL``, the same-site cookie attribute is not set at all.
 
 		**Discrete Parameters**
 
 		If you prefer, you can set the cookie by passing data using individual
 		parameters::
 
-			$this->input->set_cookie($name, $value, $expire, $domain, $path, $prefix, $secure);
+			$this->input->set_cookie($name, $value, $expire, $domain, $path, $prefix, $secure, $samesite);
 
 	.. php:method:: ip_address()
 


### PR DESCRIPTION
Hello!

Here's a proof of concept for how the samesite cookie attribute could be implemented for `CI_Input::set_cookie`. While the lines for computing the `header()` call are no the nicest, I think they should do the job. We can switch, however, to the original `setcookie()` call, by taking into the account the PHP version and using the "path hack".

Any suggestions and ideas are welcomed.