### PR TITLE
remove unnecessary extra space in query builder _compile_select()

### DIFF
--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -2415,7 +2415,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 					$this->qb_select[$key] = $this->protect_identifiers($val, FALSE, $no_escape);
 				}
 
-				$sql .= implode(', ', $this->qb_select);
+				$sql .= implode(',', $this->qb_select);
 			}
 		}
 


### PR DESCRIPTION
When query builder is compiling the select make the implode with `', '`. The extra space can lead to error.

For example if we have the following:
```
$this->db->select("GROUP_CONCAT(DISTINCT id ORDER BY id SEPARATOR ',') as group_name", false)
         ->group_by('name')
         ->get('users);
```

This result will be:
```
SELECT GROUP_CONCAT(DISTINCT id ORDER BY id SEPARATOR ', ') as group_name
FROM users
GROUP BY name
```

When the expected should be:
```
SELECT GROUP_CONCAT(DISTINCT id ORDER BY id SEPARATOR ',') as group_name
FROM users
GROUP BY name
```
