### PR TITLE
Fixes Travis pipeline. Adding PHPUnit 8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_script:
   - sh -c "if [ '$DB' = 'pgsql' ] || [ '$DB' = 'pdo/pgsql' ]; then psql -c 'create database ci_test;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'mysql' ] || [ '$DB' = 'mysqli' ] || [ '$DB' = 'pdo/mysql' ]; then mysql -e 'create database IF NOT EXISTS ci_test;'; fi"
 
-script: php -d zend.enable_gc=0 -d date.timezone=UTC -d mbstring.func_overload=7 -d mbstring.internal_encoding=UTF-8 vendor/bin/phpunit --coverage-text --configuration tests/travis/$DB.phpunit.xml
+script: test $(php -r 'echo PHP_VERSION_ID;') -lt 70300 && php -d zend.enable_gc=0 -d date.timezone=UTC -d mbstring.func_overload=7 -d mbstring.internal_encoding=UTF-8 vendor/bin/phpunit --coverage-text --configuration tests/travis/$DB.phpunit.xml || php -d zend.enable_gc=0 -d date.timezone=UTC -d mbstring.internal_encoding=UTF-8 vendor/bin/phpunit --coverage-text --configuration tests/travis/$DB.phpunit.xml
 
 jobs:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,15 @@ php:
   - 7.4
   - nightly
 
-env:
-  - DB=mysqli
-  - DB=pgsql
-  - DB=sqlite
-  - DB=pdo/mysql
-  - DB=pdo/pgsql
-  - DB=pdo/sqlite
+  global:
+    - XDEBUG_MODE=coverage
+  jobs:
+    - DB=mysqli
+    - DB=pgsql
+    - DB=sqlite
+    - DB=pdo/mysql
+    - DB=pdo/pgsql
+    - DB=pdo/sqlite
 
 services:
   - mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ php:
   - 7.4
   - nightly
 
+env:
   global:
     - XDEBUG_MODE=coverage
   jobs:

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"paragonie/random_compat": "Provides better randomness in PHP 5.x"
 	},
 	"require-dev": {
-		"mikey179/vfsstream": "1.1.*",
+		"mikey179/vfsstream": "1.6.*",
 		"phpunit/phpunit": "4.* || 5.*"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,6 @@
 	},
 	"require-dev": {
 		"mikey179/vfsstream": "1.6.*",
-		"phpunit/phpunit": "4.* || 5.*"
+		"phpunit/phpunit": "4.* || 5.* || 8.*"
 	}
 }

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -65,6 +65,13 @@ else
 
 is_php('5.6') && ini_set('php.internal_encoding', 'UTF-8');
 
+if (is_php('7.0'))
+{
+	$test_case_code = file_get_contents(PROJECT_BASE.'vendor/phpunit/phpunit/src/Framework/TestCase.php');
+	$test_case_code = preg_replace('/^\s+((?:protected|public)(?: static)? function \w+\(\)): void/m', '$1', $test_case_code);
+	file_put_contents(PROJECT_BASE.'vendor/phpunit/phpunit/src/Framework/TestCase.php', $test_case_code);
+}
+
 include_once SYSTEM_PATH.'core/compat/mbstring.php';
 include_once SYSTEM_PATH.'core/compat/hash.php';
 include_once SYSTEM_PATH.'core/compat/password.php';

--- a/tests/codeigniter/Setup_test.php
+++ b/tests/codeigniter/Setup_test.php
@@ -1,6 +1,6 @@
 <?php
 
-class Setup_test extends PHPUnit_Framework_TestCase {
+class Setup_test extends \PHPUnit\Framework\TestCase {
 
 	public function test_bootstrap_constants()
 	{

--- a/tests/codeigniter/core/Input_test.php
+++ b/tests/codeigniter/core/Input_test.php
@@ -18,6 +18,14 @@ class Input_test extends CI_TestCase {
 
 	// --------------------------------------------------------------------
 
+	public function tear_down()
+	{
+		$_POST = [];
+		$_GET = [];
+	}
+
+	// --------------------------------------------------------------------
+
 	public function test_get_not_exists()
 	{
 		$this->assertSame(array(), $this->input->get());
@@ -93,7 +101,7 @@ class Input_test extends CI_TestCase {
 	public function test_post_get_array_notation()
 	{
 		$_SERVER['REQUEST_METHOD'] = 'POST';
-		$_POST['foo']['bar'] = 'baz';
+		$_POST['foo'] = array('bar' => 'baz');
 		$barArray = array('bar' => 'baz');
 
 		$this->assertEquals('baz', $this->input->get_post('foo[bar]'));
@@ -120,7 +128,7 @@ class Input_test extends CI_TestCase {
 	public function test_get_post_array_notation()
 	{
 		$_SERVER['REQUEST_METHOD'] = 'GET';
-		$_GET['foo']['bar'] = 'baz';
+		$_GET['foo'] = array('bar' => 'baz');
 		$barArray = array('bar' => 'baz');
 
 		$this->assertEquals('baz', $this->input->get_post('foo[bar]'));
@@ -169,7 +177,7 @@ class Input_test extends CI_TestCase {
 		$this->assertEquals("Hello, i try to [removed]alert&#40;'Hack'&#41;;[removed] your site", $harmless);
 
 		$_SERVER['REQUEST_METHOD'] = 'POST';
-		$_POST['foo']['bar'] = 'baz';
+		$_POST['foo'] = array('bar' => 'baz');
 		$barArray = array('bar' => 'baz');
 
 		$this->assertEquals('baz', $this->input->post('foo[bar]'));

--- a/tests/codeigniter/database/query_builder/select_test.php
+++ b/tests/codeigniter/database/query_builder/select_test.php
@@ -74,7 +74,7 @@ class Select_test extends CI_TestCase {
 		                    ->row();
 
 		// Average should be 2.5
-		$this->assertEquals('2.5', $job_avg->id);
+		$this->assertEquals(2.5, (float) $job_avg->id);
 	}
 
 	// ------------------------------------------------------------------------

--- a/tests/codeigniter/helpers/file_helper_test.php
+++ b/tests/codeigniter/helpers/file_helper_test.php
@@ -6,10 +6,7 @@ class File_helper_Test extends CI_TestCase {
 	{
 		$this->helper('file');
 
-		vfsStreamWrapper::register();
-		vfsStreamWrapper::setRoot(new vfsStreamDirectory('testDir'));
-
-		$this->_test_dir = vfsStreamWrapper::getRoot();
+		$this->_test_dir = vfsStream::setup('');
 	}
 
 	// --------------------------------------------------------------------

--- a/tests/codeigniter/helpers/text_helper_test.php
+++ b/tests/codeigniter/helpers/text_helper_test.php
@@ -64,12 +64,7 @@ class Text_helper_test extends CI_TestCase {
 
 	public function test_convert_accented_characters()
 	{
-		$path = 'application/config/foreign_chars.php';
-		$this->ci_vfs_clone($path);
-		if (is_php('7.4'))
-		{
-			copy(PROJECT_BASE.$path, APPPATH.'../'.$path);
-		}
+		$this->ci_vfs_clone('application/config/foreign_chars.php');
 		$this->assertEquals('AAAeEEEIIOOEUUUeY', convert_accented_characters('ÀÂÄÈÊËÎÏÔŒÙÛÜŸ'));
 		$this->assertEquals('a e i o u n ue', convert_accented_characters('á é í ó ú ñ ü'));
 	}

--- a/tests/mocks/ci_testcase.php
+++ b/tests/mocks/ci_testcase.php
@@ -35,7 +35,7 @@ class CI_TestCase extends PHPUnit_Framework_TestCase {
 	public function setUp()
 	{
 		// Setup VFS with base directories
-		$this->ci_vfs_root = vfsStream::setup();
+		$this->ci_vfs_root = vfsStream::setup('');
 		$this->ci_app_root = vfsStream::newDirectory('application')->at($this->ci_vfs_root);
 		$this->ci_base_root = vfsStream::newDirectory('system')->at($this->ci_vfs_root);
 		$this->ci_view_root = vfsStream::newDirectory('views')->at($this->ci_app_root);

--- a/tests/mocks/ci_testcase.php
+++ b/tests/mocks/ci_testcase.php
@@ -1,6 +1,6 @@
 <?php
 
-class CI_TestCase extends PHPUnit_Framework_TestCase {
+class CI_TestCase extends \PHPUnit\Framework\TestCase {
 
 	public $ci_vfs_root;
 	public $ci_app_root;
@@ -381,4 +381,18 @@ class CI_TestCase extends PHPUnit_Framework_TestCase {
 		return parent::__call($method, $args);
 	}
 
+	public function setExpectedException($exception_class, $exception_message = '', $exception_code = null)
+	{
+		$use_expect_exception = method_exists($this, 'expectException');
+
+		if ($use_expect_exception)
+		{
+			$this->expectException($exception_class);
+			$exception_message !== '' && $this->expectExceptionMessage($exception_message);
+		}
+		else
+		{
+			parent::setExpectedException($exception_class, $exception_message, $exception_code);
+		}
+	}
 }

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -8,7 +8,8 @@
 	stopOnError="false"
 	stopOnFailure="false"
 	stopOnIncomplete="false"
-	stopOnSkipped="false">
+	stopOnSkipped="false"
+	beStrictAboutTestsThatDoNotTestAnything="false">
 	<testsuites>
 		<testsuite name="CodeIgniter Core Test Suite">
 			<directory suffix="test.php">./codeigniter/core</directory>


### PR DESCRIPTION
Lately, the Travis builds were not so green. :P This PR addresses that.

* Added PHPUnit 8 as a potential PHPUnit version. This also sets up the ground for adding in a future PR PHP 8 in the Travis pipeline
* Upgraded to latest vfsstream. The `if` added in #5946 was removed, as it seems there's no issue with PHP 7.4 in latest version.
* `-d mbstring.func_overload=7` is added conditionally now, only if PHP < 7.3
* PHPUnit's `TestCase`'s `void` return type hints were removed to maintain compatibility. This approach was inspired by one of symfony's phpunit bridge features
* other fixes

As already being said, this is a ground for adding PHP 8 in the Travis pipeline, in another separate PR, with test fixes that will most probably come as well.