### PR TITLE
we should reset select after get sql

### DIFF
--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -1451,9 +1451,9 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 		{
 			$this->limit($limit, $offset);
 		}
-
-		$result = $this->query($this->_compile_select());
+		$sql = $this->_compile_select();
 		$this->_reset_select();
+		$result = $this->query($sql);
 		return $result;
 	}
 


### PR DESCRIPTION
if one select sql is error, then will trigger exception handler, and _reset_select won't run . and in exception handler we trigger an update sql ,then update qb_where array will merge with select qb_where array because we do not _reset_select after we get compile sql, then update sql trigger an error again

so we need _reset_select after we get complied select sql