### PR TITLE
PHP 8.1 Session Driver Errors

### DIFF
--- a/system/libraries/Session/drivers/Session_database_driver.php
+++ b/system/libraries/Session/drivers/Session_database_driver.php
@@ -126,7 +126,7 @@ class CI_Session_database_driver extends CI_Session_driver implements SessionHan
 	 * @param	string	$name		Session cookie name, unused
 	 * @return	bool
 	 */
-	public function open($save_path, $name)
+	public function open(string $save_path, string $name): bool
 	{
 		if (empty($this->_db->conn_id) && ! $this->_db->db_connect())
 		{
@@ -148,7 +148,8 @@ class CI_Session_database_driver extends CI_Session_driver implements SessionHan
 	 * @param	string	$session_id	Session ID
 	 * @return	string	Serialized session data
 	 */
-	public function read($session_id)
+	#[\ReturnTypeWillChange]
+	public function read(string $session_id)
 	{
 		if ($this->_get_lock($session_id) === FALSE)
 		{
@@ -204,7 +205,7 @@ class CI_Session_database_driver extends CI_Session_driver implements SessionHan
 	 * @param	string	$session_data	Serialized session data
 	 * @return	bool
 	 */
-	public function write($session_id, $session_data)
+	public function write(string $session_id, string $session_data): bool
 	{
 		// Prevent previous QB calls from messing with our queries
 		$this->_db->reset_query();
@@ -276,7 +277,7 @@ class CI_Session_database_driver extends CI_Session_driver implements SessionHan
 	 *
 	 * @return	bool
 	 */
-	public function close()
+	public function close(): bool
 	{
 		return ($this->_lock && ! $this->_release_lock())
 			? $this->_failure
@@ -293,7 +294,7 @@ class CI_Session_database_driver extends CI_Session_driver implements SessionHan
 	 * @param	string	$session_id	Session ID
 	 * @return	bool
 	 */
-	public function destroy($session_id)
+	public function destroy(string $session_id): bool
 	{
 		if ($this->_lock)
 		{
@@ -331,7 +332,8 @@ class CI_Session_database_driver extends CI_Session_driver implements SessionHan
 	 * @param	int 	$maxlifetime	Maximum lifetime of sessions
 	 * @return	bool
 	 */
-	public function gc($maxlifetime)
+	#[\ReturnTypeWillChange]
+	public function gc(int $maxlifetime)
 	{
 		// Prevent previous QB calls from messing with our queries
 		$this->_db->reset_query();

--- a/system/libraries/Session/drivers/Session_files_driver.php
+++ b/system/libraries/Session/drivers/Session_files_driver.php
@@ -129,7 +129,7 @@ class CI_Session_files_driver extends CI_Session_driver implements SessionHandle
 	 * @param	string	$name		Session cookie name
 	 * @return	bool
 	 */
-	public function open($save_path, $name)
+	public function open(string $save_path, string $name): bool
 	{
 		if ( ! is_dir($save_path))
 		{
@@ -165,7 +165,8 @@ class CI_Session_files_driver extends CI_Session_driver implements SessionHandle
 	 * @param	string	$session_id	Session ID
 	 * @return	string	Serialized session data
 	 */
-	public function read($session_id)
+	#[\ReturnTypeWillChange]
+	public function read(string $session_id)
 	{
 		// This might seem weird, but PHP 5.6 introduces session_reset(),
 		// which re-reads session data
@@ -238,7 +239,7 @@ class CI_Session_files_driver extends CI_Session_driver implements SessionHandle
 	 * @param	string	$session_data	Serialized session data
 	 * @return	bool
 	 */
-	public function write($session_id, $session_data)
+	public function write(string $session_id, string $session_data): bool
 	{
 		// If the two IDs don't match, we have a session_regenerate_id() call
 		// and we need to close the old handle and open a new one
@@ -295,7 +296,7 @@ class CI_Session_files_driver extends CI_Session_driver implements SessionHandle
 	 *
 	 * @return	bool
 	 */
-	public function close()
+	public function close(): bool
 	{
 		if (is_resource($this->_file_handle))
 		{
@@ -318,7 +319,7 @@ class CI_Session_files_driver extends CI_Session_driver implements SessionHandle
 	 * @param	string	$session_id	Session ID
 	 * @return	bool
 	 */
-	public function destroy($session_id)
+	public function destroy(string $session_id): bool
 	{
 		if ($this->close() === $this->_success)
 		{
@@ -359,7 +360,8 @@ class CI_Session_files_driver extends CI_Session_driver implements SessionHandle
 	 * @param	int 	$maxlifetime	Maximum lifetime of sessions
 	 * @return	bool
 	 */
-	public function gc($maxlifetime)
+	#[\ReturnTypeWillChange]
+	public function gc(int $maxlifetime)
 	{
 		if ( ! is_dir($this->_config['save_path']) OR ($directory = opendir($this->_config['save_path'])) === FALSE)
 		{

--- a/system/libraries/Session/drivers/Session_memcached_driver.php
+++ b/system/libraries/Session/drivers/Session_memcached_driver.php
@@ -103,7 +103,7 @@ class CI_Session_memcached_driver extends CI_Session_driver implements SessionHa
 	 * @param	string	$name		Session cookie name, unused
 	 * @return	bool
 	 */
-	public function open($save_path, $name)
+	public function open(string $save_path, string $name): bool
 	{
 		$this->_memcached = new Memcached();
 		$this->_memcached->setOption(Memcached::OPT_BINARY_PROTOCOL, TRUE); // required for touch() usage
@@ -160,7 +160,8 @@ class CI_Session_memcached_driver extends CI_Session_driver implements SessionHa
 	 * @param	string	$session_id	Session ID
 	 * @return	string	Serialized session data
 	 */
-	public function read($session_id)
+	#[\ReturnTypeWillChange]
+	public function read(string $session_id)
 	{
 		if (isset($this->_memcached) && $this->_get_lock($session_id))
 		{
@@ -186,7 +187,7 @@ class CI_Session_memcached_driver extends CI_Session_driver implements SessionHa
 	 * @param	string	$session_data	Serialized session data
 	 * @return	bool
 	 */
-	public function write($session_id, $session_data)
+	public function write(string $session_id, string $session_data): bool
 	{
 		if ( ! isset($this->_memcached, $this->_lock_key))
 		{
@@ -237,7 +238,7 @@ class CI_Session_memcached_driver extends CI_Session_driver implements SessionHa
 	 *
 	 * @return	bool
 	 */
-	public function close()
+	public function close(): bool
 	{
 		if (isset($this->_memcached))
 		{
@@ -264,7 +265,7 @@ class CI_Session_memcached_driver extends CI_Session_driver implements SessionHa
 	 * @param	string	$session_id	Session ID
 	 * @return	bool
 	 */
-	public function destroy($session_id)
+	public function destroy(string $session_id): bool
 	{
 		if (isset($this->_memcached, $this->_lock_key))
 		{
@@ -286,7 +287,8 @@ class CI_Session_memcached_driver extends CI_Session_driver implements SessionHa
 	 * @param	int 	$maxlifetime	Maximum lifetime of sessions
 	 * @return	bool
 	 */
-	public function gc($maxlifetime)
+	#[\ReturnTypeWillChange]
+	public function gc(int $maxlifetime)
 	{
 		// Not necessary, Memcached takes care of that.
 		return $this->_success;

--- a/system/libraries/Session/drivers/Session_redis_driver.php
+++ b/system/libraries/Session/drivers/Session_redis_driver.php
@@ -181,7 +181,7 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 	 * @param	string	$name		Session cookie name, unused
 	 * @return	bool
 	 */
-	public function open($save_path, $name)
+	public function open(string $save_path, string $name): bool
 	{
 		if (empty($this->_config['save_path']))
 		{
@@ -234,7 +234,8 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 	 * @param	string	$session_id	Session ID
 	 * @return	string	Serialized session data
 	 */
-	public function read($session_id)
+	#[\ReturnTypeWillChange]
+	public function read(string $session_id)
 	{
 		if (isset($this->_redis) && $this->_get_lock($session_id))
 		{
@@ -265,7 +266,7 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 	 * @param	string	$session_data	Serialized session data
 	 * @return	bool
 	 */
-	public function write($session_id, $session_data)
+	public function write(string $session_id, string $session_data): bool
 	{
 		if ( ! isset($this->_redis, $this->_lock_key))
 		{
@@ -310,7 +311,7 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 	 *
 	 * @return	bool
 	 */
-	public function close()
+	public function close(): bool
 	{
 		if (isset($this->_redis))
 		{
@@ -346,7 +347,7 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 	 * @param	string	$session_id	Session ID
 	 * @return	bool
 	 */
-	public function destroy($session_id)
+	public function destroy(string $session_id): bool
 	{
 		if (isset($this->_redis, $this->_lock_key))
 		{
@@ -372,7 +373,8 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 	 * @param	int 	$maxlifetime	Maximum lifetime of sessions
 	 * @return	bool
 	 */
-	public function gc($maxlifetime)
+	#[\ReturnTypeWillChange]
+	public function gc(int $maxlifetime)
 	{
 		// Not necessary, Redis takes care of that.
 		return $this->_success;


### PR DESCRIPTION
Using any Session driver on 8.1 will trigger: 

`CI_Session_database_driver must be compatible with SessionHandlerInterface.`

Errors upon page load. To address these: 

- Added matching `SessionHandlerInterface` typehints 
- Added [#[\ReturnTypeWillChange]](https://wiki.php.net/rfc/internal_method_return_types#proposal) for those methods require a union return type. The comment is a suppresses the deprecation notice to maintain backwards compatibility. 