### PR TITLE
User agent can't differentiate between Chrome for iOS and Safari

### DIFF
--- a/system/libraries/User_agent.php
+++ b/system/libraries/User_agent.php
@@ -304,7 +304,10 @@ class CI_User_agent {
 				{
 					$this->is_browser = TRUE;
 					$this->version = $match[1];
-					$this->browser = $val;
+					// Chrome for iOS uses nearly the same user agent as Mobile Safari.
+					// The only way to detect this is to look for 'CriOS' in the user agent.
+					// https://chromium.googlesource.com/chromium/src/+/HEAD/docs/ios/user_agent.md
+					$this->browser = (strtolower($val) === 'safari' && preg_match('/(crios)/', strtolower($this->agent))) ? $this->browsers['Chrome'] : $val;
 					$this->_set_mobile();
 					return TRUE;
 				}


### PR DESCRIPTION
Google documentation: https://chromium.googlesource.com/chromium/src/+/HEAD/docs/ios/user_agent.md

Fix: check browsers that look like Safari for the special "crios" keyword and register as a Chrome browser instead if a match is found.