### PR TITLE
Fix passing NULL to setcookie value parameter

### DIFF
--- a/system/libraries/Session/Session_driver.php
+++ b/system/libraries/Session/Session_driver.php
@@ -153,7 +153,7 @@ abstract class CI_Session_driver {
 
 		return setcookie(
 			$this->_config['cookie_name'],
-			NULL,
+			'',
 			array(
 				'expires' => 1,
 				'path' => $this->_config['cookie_path'],


### PR DESCRIPTION
Fixes Passing null to parameter #2 ($value) of type string is deprecated