### PR TITLE
profiler.php PHP 8.1 deprecation notice 

### DIFF
--- a/system/libraries/Profiler.php
+++ b/system/libraries/Profiler.php
@@ -496,7 +496,7 @@ class CI_Profiler {
 			}
 
 			$output .= '<tr><td style="padding:5px;vertical-align:top;color:#900;background-color:#ddd;">'
-				.$config.'&nbsp;&nbsp;</td><td style="padding:5px;color:#000;background-color:#ddd;">'.$pre.htmlspecialchars( (string) $val, ENT_QUOTES, config_item('charset')).$pre_close."</td></tr>\n";
+				.$config.'&nbsp;&nbsp;</td><td style="padding:5px;color:#000;background-color:#ddd;">'.$pre.htmlspecialchars((string) $val, ENT_QUOTES, config_item('charset')).$pre_close."</td></tr>\n";
 		}
 
 		return $output."</table>\n</fieldset>";
@@ -534,7 +534,7 @@ class CI_Profiler {
 			}
 
 			$output .= '<tr><td style="padding:5px;vertical-align:top;color:#900;background-color:#ddd;">'
-				.$key.'&nbsp;&nbsp;</td><td style="padding:5px;color:#000;background-color:#ddd;">'.$pre.htmlspecialchars( (string) $val, ENT_QUOTES, config_item('charset')).$pre_close."</td></tr>\n";
+				.$key.'&nbsp;&nbsp;</td><td style="padding:5px;color:#000;background-color:#ddd;">'.$pre.htmlspecialchars((string) $val, ENT_QUOTES, config_item('charset')).$pre_close."</td></tr>\n";
 		}
 
 		return $output."</table>\n</fieldset>";

--- a/system/libraries/Profiler.php
+++ b/system/libraries/Profiler.php
@@ -496,7 +496,7 @@ class CI_Profiler {
 			}
 
 			$output .= '<tr><td style="padding:5px;vertical-align:top;color:#900;background-color:#ddd;">'
-				.$config.'&nbsp;&nbsp;</td><td style="padding:5px;color:#000;background-color:#ddd;">'.$pre.htmlspecialchars((($val) ? $val :''), ENT_QUOTES, config_item('charset')).$pre_close."</td></tr>\n";
+				.$config.'&nbsp;&nbsp;</td><td style="padding:5px;color:#000;background-color:#ddd;">'.$pre.htmlspecialchars((string)$val, ENT_QUOTES, config_item('charset')).$pre_close."</td></tr>\n";
 		}
 
 		return $output."</table>\n</fieldset>";
@@ -534,7 +534,7 @@ class CI_Profiler {
 			}
 
 			$output .= '<tr><td style="padding:5px;vertical-align:top;color:#900;background-color:#ddd;">'
-				.$key.'&nbsp;&nbsp;</td><td style="padding:5px;color:#000;background-color:#ddd;">'.$pre.htmlspecialchars($val, ENT_QUOTES, config_item('charset')).$pre_close."</td></tr>\n";
+				.$key.'&nbsp;&nbsp;</td><td style="padding:5px;color:#000;background-color:#ddd;">'.$pre.htmlspecialchars((string)$val, ENT_QUOTES, config_item('charset')).$pre_close."</td></tr>\n";
 		}
 
 		return $output."</table>\n</fieldset>";

--- a/system/libraries/Profiler.php
+++ b/system/libraries/Profiler.php
@@ -496,7 +496,7 @@ class CI_Profiler {
 			}
 
 			$output .= '<tr><td style="padding:5px;vertical-align:top;color:#900;background-color:#ddd;">'
-				.$config.'&nbsp;&nbsp;</td><td style="padding:5px;color:#000;background-color:#ddd;">'.$pre.htmlspecialchars($val, ENT_QUOTES, config_item('charset')).$pre_close."</td></tr>\n";
+				.$config.'&nbsp;&nbsp;</td><td style="padding:5px;color:#000;background-color:#ddd;">'.$pre.htmlspecialchars((($val) ? $val :''), ENT_QUOTES, config_item('charset')).$pre_close."</td></tr>\n";
 		}
 
 		return $output."</table>\n</fieldset>";

--- a/system/libraries/Profiler.php
+++ b/system/libraries/Profiler.php
@@ -496,7 +496,7 @@ class CI_Profiler {
 			}
 
 			$output .= '<tr><td style="padding:5px;vertical-align:top;color:#900;background-color:#ddd;">'
-				.$config.'&nbsp;&nbsp;</td><td style="padding:5px;color:#000;background-color:#ddd;">'.$pre.htmlspecialchars((string)$val, ENT_QUOTES, config_item('charset')).$pre_close."</td></tr>\n";
+				.$config.'&nbsp;&nbsp;</td><td style="padding:5px;color:#000;background-color:#ddd;">'.$pre.htmlspecialchars( (string) $val, ENT_QUOTES, config_item('charset')).$pre_close."</td></tr>\n";
 		}
 
 		return $output."</table>\n</fieldset>";
@@ -534,7 +534,7 @@ class CI_Profiler {
 			}
 
 			$output .= '<tr><td style="padding:5px;vertical-align:top;color:#900;background-color:#ddd;">'
-				.$key.'&nbsp;&nbsp;</td><td style="padding:5px;color:#000;background-color:#ddd;">'.$pre.htmlspecialchars((string)$val, ENT_QUOTES, config_item('charset')).$pre_close."</td></tr>\n";
+				.$key.'&nbsp;&nbsp;</td><td style="padding:5px;color:#000;background-color:#ddd;">'.$pre.htmlspecialchars( (string) $val, ENT_QUOTES, config_item('charset')).$pre_close."</td></tr>\n";
 		}
 
 		return $output."</table>\n</fieldset>";


### PR DESCRIPTION
check for null value on $val

for this warning : 
`Message: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated`

I think there might be more cases, but I only fixed the case I ran into. (also not sure if this is a valid style of fixing)