### PR TITLE
Fix method _is_conn() in Ftp library

### DIFF
--- a/system/libraries/Ftp.php
+++ b/system/libraries/Ftp.php
@@ -202,7 +202,7 @@ class CI_FTP {
 	 */
 	protected function _is_conn()
 	{
-		if ($this->conn_id !== FALSE)
+		if ($this->conn_id === FALSE)
 		{
 			if ($this->debug === TRUE)
 			{


### PR DESCRIPTION
Was returning incorrect result for valid connection making it impossible to use FTP