### PR TITLE
Fix SessionUpdateTimestampHandlerInterface name

### DIFF
--- a/system/libraries/Session/SessionUpdateTimestampHandlerInterface.php
+++ b/system/libraries/Session/SessionUpdateTimestampHandlerInterface.php
@@ -49,7 +49,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  * @author	Andrey Andreev
  * @link	https://codeigniter.com/userguide3/libraries/sessions.html
  */
-interface SessionHandlerInterface {
+interface SessionUpdateTimestampHandlerInterface {
 
 	public function updateTimestamp($session_id, $data);
 	public function validateId($session_id);


### PR DESCRIPTION
Duplicated name with SessionHandlerInterface. Breaking 3.1.12