### PR TITLE
Update Exceptions.php

### DIFF
--- a/system/core/Exceptions.php
+++ b/system/core/Exceptions.php
@@ -171,6 +171,17 @@ class CI_Exceptions {
 		else
 		{
 			set_status_header($status_code);
+			if (is_array($message))
+			{
+				foreach ($message as &$value)
+				{
+				   $value = htmlspecialchars($value);
+				}
+			}
+			else
+			{
+				$message = htmlspecialchars($message);
+			}
 			$message = '<p>'.(is_array($message) ? implode('</p><p>', $message) : $message).'</p>';
 			$template = 'html'.DIRECTORY_SEPARATOR.$template;
 		}


### PR DESCRIPTION
In some cases, error messages could lead to Cross-Site Scripting vulnerability. This small fix sanitize potential user input from GET/POST parameters that could be returned into error messages.

For example with this kind of code:
`
		if (isset($_GET['page'])) { 
			$this->load->view($_GET['page']);
		 }
`

If the page is load with _/?page=<script>PAYLOAD</script>_ the JavaScript will be executed.