### PR TITLE
on documentation

### DIFF
--- a/system/helpers/download_helper.php
+++ b/system/helpers/download_helper.php
@@ -64,7 +64,7 @@ if ( ! function_exists('force_download'))
 	 */
 	function force_download($filename = '', $data = '', $set_mime = FALSE)
 	{
-		if ($filename === '' OR $data === '')
+		if ($filename === '' AND $data === '')
 		{
 			return;
 		}


### PR DESCRIPTION
https://www.codeigniter.com/userguide3/helpers/download_helper.html
it says we can use force_download with second parameter is NULL
but online 67 there is an OR condition makes this impossible to use.
so I believe it must be an AND.

// Contents of photo.jpg will be automatically read
force_download('/path/to/photo.jpg', NULL);