### PR TITLE
fix: PHP 8.1 deprecated error in URI::ruri_string()

### DIFF
--- a/system/core/URI.php
+++ b/system/core/URI.php
@@ -656,7 +656,7 @@ class CI_URI {
 	 */
 	public function ruri_string()
 	{
-		return ltrim(load_class('Router', 'core')->directory, '/').implode('/', $this->rsegments);
+		return ltrim((string) load_class('Router', 'core')->directory, '/').implode('/', $this->rsegments);
 	}
 
 }


### PR DESCRIPTION
```
ltrim(): Passing null to parameter #1 ($string) of type string is deprecated
```

**Steps to Reproduce**
In a controller:
```php
echo $this->uri->ruri_string();
```
