### PR TITLE
use null coalesce to suppress deprecation notice in php 8.1

### DIFF
--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -727,7 +727,7 @@ if ( ! function_exists('remove_invisible_characters'))
 
 		do
 		{
-			$str = preg_replace($non_displayables, '', $str, -1, $count);
+			$str = preg_replace($non_displayables, '', $str??'', -1, $count);
 		}
 		while ($count);
 


### PR DESCRIPTION
Signed-off-by: Tony Dunlop <tony.dunlop@fisss.org>

spotted a deprecation notice when running unit test with php 8.1

addresses the following:

`RuntimeException: preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated on line 726 in file /vendor/codeigniter/framework/system/core/Common.php`