### PR TITLE
fix: PHP 8.1 "Serialization of 'ReflectionMethod' is not allowed"

### DIFF
--- a/system/core/CodeIgniter.php
+++ b/system/core/CodeIgniter.php
@@ -384,7 +384,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 		 * ReflectionMethod::isConstructor() is the ONLY reliable check,
 		 * knowing which method will be executed as a constructor.
 		 */
-		else
+		elseif ( ! in_array($method, get_class_methods($class)))
 		{
 			$reflection = new ReflectionMethod($class, $method);
 			if ( ! $reflection->isPublic() OR $reflection->isConstructor())


### PR DESCRIPTION
With 0925b5099919300a239909588351a6482c5e792d there have been proper fixes for CI_Migration and CI_Xmlrpcs classes.
But for CI_Codeigniter the former is_callable check has been removed without any substitution.

This causes "Serialization of 'ReflectionMethod' is not allowed" errors in several cases, especially when running PHPUnit integration tests using @runInSeparateProcess Feature.

Please accept the same fix for CI_Codeigniter main class as well.