### PR TITLE
Bug Fix: [cookie_helper.php] set_cookie was missing sameSite argument

### DIFF
--- a/system/helpers/cookie_helper.php
+++ b/system/helpers/cookie_helper.php
@@ -68,10 +68,10 @@ if ( ! function_exists('set_cookie'))
 	 * @param	bool	true makes the cookie accessible via http(s) only (no javascript)
 	 * @return	void
 	 */
-	function set_cookie($name, $value = '', $expire = 0, $domain = '', $path = '/', $prefix = '', $secure = NULL, $httponly = NULL)
+	function set_cookie($name, $value = '', $expire = 0, $domain = '', $path = '/', $prefix = '', $secure = NULL, $httponly = NULL, $samesite = NULL)
 	{
 		// Set the config file options
-		get_instance()->input->set_cookie($name, $value, $expire, $domain, $path, $prefix, $secure, $httponly);
+		get_instance()->input->set_cookie($name, $value, $expire, $domain, $path, $prefix, $secure, $httponly, $samesite);
 	}
 }
 

--- a/user_guide_src/source/helpers/cookie_helper.rst
+++ b/user_guide_src/source/helpers/cookie_helper.rst
@@ -25,7 +25,7 @@ Available Functions
 The following functions are available:
 
 
-.. php:function:: set_cookie($name[, $value = ''[, $expire = 0[, $domain = ''[, $path = '/'[, $prefix = ''[, $secure = NULL[, $httponly = NULL]]]]]]])
+.. php:function:: set_cookie($name[, $value = ''[, $expire = 0[, $domain = ''[, $path = '/'[, $prefix = ''[, $secure = NULL[, $httponly = NULL[, $samesite = NULL]]]]]]]])
 
 	:param	mixed	$name: Cookie name *or* associative array of all of the parameters available to this function
 	:param	string	$value: Cookie value
@@ -35,6 +35,7 @@ The following functions are available:
 	:param	string	$prefix: Cookie name prefix
 	:param	bool	$secure: Whether to only send the cookie through HTTPS
 	:param	bool	$httponly: Whether to hide the cookie from JavaScript
+	:param	string	$samesite: SameSite attribute ('Lax', 'Strict', 'None')
 	:rtype:	void
 
 	This helper function gives you friendlier syntax to set browser


### PR DESCRIPTION
Hi,

I was trying to set a cookie with **sameSite** using the cookie helper function **set_cookie**, but i found out that the function does not have samesite as **argument**, after reading the source code and PR i found that **input** class has already that parameter, so i think changes in cookie_helper was forgotten in(https://github.com/bcit-ci/CodeIgniter/pull/6025).

Thanks.