### PR TITLE
Fix composer_autoload

### DIFF
--- a/system/core/CodeIgniter.php
+++ b/system/core/CodeIgniter.php
@@ -119,9 +119,9 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 	{
 		if ($composer_autoload === TRUE)
 		{
-			file_exists(APPPATH.'vendor/autoload.php')
-				? require_once(APPPATH.'vendor/autoload.php')
-				: log_message('error', '$config[\'composer_autoload\'] is set to TRUE but '.APPPATH.'vendor/autoload.php was not found.');
+			file_exists(FCPATH.'vendor/autoload.php')
+				? require_once(FCPATH.'vendor/autoload.php')
+				: log_message('error', '$config[\'composer_autoload\'] is set to TRUE but '.FCPATH.'vendor/autoload.php was not found.');
 		}
 		elseif (file_exists($composer_autoload))
 		{


### PR DESCRIPTION
Fix composer_autoload：I got an error when I set `$config['composer_autoload'] = TRUE;`  in `application/config/config.php` .
I find the path vender directory is wrong. It should be **FCPATH** instead of **APPPATH**.
