### PR TITLE
Adapt unit tests so as not to fail with PHPUnit 8.5

### DIFF
--- a/tests/codeigniter/core/Security_test.php
+++ b/tests/codeigniter/core/Security_test.php
@@ -253,9 +253,9 @@ class Security_test extends CI_TestCase {
 		// Perform hash
 		$this->security->xss_hash();
 
-		$assertRegExp = class_exists('PHPUnit_Runner_Version')
-			? 'assertRegExp'
-			: 'assertMatchesRegularExpression';
+		$assertRegExp = method_exists($this, 'assertMatchesRegularExpression')
+			? 'assertMatchesRegularExpression'
+			: 'assertRegExp';
 		$this->$assertRegExp('#^[0-9a-f]{32}$#iS', $this->security->xss_hash);
 	}
 


### PR DESCRIPTION
When the phpunit tests are run with phpunit 8.5, they will fail because the test would call assertMatchesRegularExpression which doesn't exists in that version.

So check the existence of the method instead of checking the class 'PHPUnit_Runner_Version'.