### PR TITLE
FIX: Fixes dynamic property deprecation error

### DIFF
--- a/system/core/URI.php
+++ b/system/core/URI.php
@@ -91,6 +91,13 @@ class CI_URI {
 	 * @var	string
 	 */
 	protected $_permitted_uri_chars;
+	
+	/**
+	 * CI Config
+	 *
+	 * @var	CI_Config
+	 */
+	public $config;
 
 	/**
 	 * Class constructor


### PR DESCRIPTION
Closes #6192

Let me know if you would prefer a scope other than `public` (as `Mock_Core_URI` needs access to it, I'm assuming `public` is fine.)