### PR TITLE
PHP 8.2 compatibility, a couple of bug fixes, move CI_DB class declaration

### DIFF
--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -15,10 +15,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.1', '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6', '5.5', '5.4']
+        php: [ '8.2', '8.1', '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6', '5.5', '5.4']
         DB: [ 'pdo/mysql', 'pdo/pgsql', 'pdo/sqlite', 'mysqli', 'pgsql', 'sqlite' ]
         compiler: [ default ]
         include:
+          - php: '8.2'
+            DB: 'pdo/mysql'
+            compiler: jit
+          - php: '8.2'
+            DB: 'pdo/pgsql'
+            compiler: jit
+          - php: '8.2'
+            DB: 'pdo/sqlite'
+            compiler: jit
+          - php: '8.2'
+            DB: 'mysqli'
+            compiler: jit
+          - php: '8.2'
+            DB: 'pgsql'
+            compiler: jit
+          - php: '8.2'
+            DB: 'sqlite'
+            compiler: jit
           - php: '8.1'
             DB: 'pdo/mysql'
             compiler: jit

--- a/system/core/CodeIgniter.php
+++ b/system/core/CodeIgniter.php
@@ -253,10 +253,11 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  */
 	$URI =& load_class('URI', 'core', $CFG);
 
-/*
+/**
  * ------------------------------------------------------
  *  Instantiate the routing class and set the routing
  * ------------------------------------------------------
+ * @var CI_Router|NULL
  */
 	$RTR =& load_class('Router', 'core', isset($routing) ? $routing : NULL);
 

--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -57,7 +57,7 @@ if ( ! function_exists('is_php'))
 	/**
 	 * Determines if the current version of PHP is equal to or greater than the supplied value
 	 *
-	 * @param	string
+	 * @param	string $version
 	 * @return	bool	TRUE if the current version is $version or higher
 	 */
 	function is_php($version)
@@ -85,7 +85,7 @@ if ( ! function_exists('is_really_writable'))
 	 * the file, based on the read-only attribute.
 	 *
 	 * @link	https://bugs.php.net/bug.php?id=54709
-	 * @param	string
+	 * @param	string	$file
 	 * @return	bool
 	 */
 	function is_really_writable($file)
@@ -133,9 +133,9 @@ if ( ! function_exists('load_class'))
 	 * exist it is instantiated and set to a static variable. If it has
 	 * previously been instantiated the variable is returned.
 	 *
-	 * @param	string	the class name being requested
-	 * @param	string	the directory where the class should be found
-	 * @param	mixed	an optional argument to pass to the class constructor
+	 * @param	string	$class	the class name being requested
+	 * @param	string	$directory	the directory where the class should be found
+	 * @param	mixed	$param	an optional argument to pass to the class constructor
 	 * @return	object
 	 */
 	function &load_class($class, $directory = 'libraries', $param = NULL)
@@ -206,7 +206,7 @@ if ( ! function_exists('is_loaded'))
 	 * Keeps track of which libraries have been loaded. This function is
 	 * called by the load_class() function above
 	 *
-	 * @param	string
+	 * @param	string	$class
 	 * @return	array
 	 */
 	function &is_loaded($class = '')
@@ -232,7 +232,7 @@ if ( ! function_exists('get_config'))
 	 * This function lets us grab the config file even if the Config class
 	 * hasn't been instantiated yet
 	 *
-	 * @param	array
+	 * @param	array	$replace
 	 * @return	array
 	 */
 	function &get_config(Array $replace = array())
@@ -287,7 +287,7 @@ if ( ! function_exists('config_item'))
 	/**
 	 * Returns the specified config item
 	 *
-	 * @param	string
+	 * @param	string	$item
 	 * @return	mixed
 	 */
 	function config_item($item)
@@ -395,9 +395,9 @@ if ( ! function_exists('show_error'))
 	 * This function will send the error page directly to the
 	 * browser and exit.
 	 *
-	 * @param	string
-	 * @param	int
-	 * @param	string
+	 * @param	string	$message
+	 * @param	int	$status_code
+	 * @param	string	$heading
 	 * @return	void
 	 */
 	function show_error($message, $status_code = 500, $heading = 'An Error Was Encountered')
@@ -430,8 +430,8 @@ if ( ! function_exists('show_404'))
 	 * However, instead of the standard error template it displays
 	 * 404 errors.
 	 *
-	 * @param	string
-	 * @param	bool
+	 * @param	string	$page
+	 * @param	bool	$log_error
 	 * @return	void
 	 */
 	function show_404($page = '', $log_error = TRUE)
@@ -452,8 +452,8 @@ if ( ! function_exists('log_message'))
 	 * We use this as a simple mechanism to access the logging
 	 * class and send messages to be logged.
 	 *
-	 * @param	string	the error level: 'error', 'debug' or 'info'
-	 * @param	string	the error message
+	 * @param	string	$level	the error level: 'error', 'debug' or 'info'
+	 * @param	string	$message	the error message
 	 * @return	void
 	 */
 	function log_message($level, $message)
@@ -477,8 +477,8 @@ if ( ! function_exists('set_status_header'))
 	/**
 	 * Set HTTP Status Header
 	 *
-	 * @param	int	the status code
-	 * @param	string
+	 * @param	int	$code	the status code
+	 * @param	string	$text
 	 * @return	void
 	 */
 	function set_status_header($code = 200, $text = '')
@@ -706,8 +706,8 @@ if ( ! function_exists('remove_invisible_characters'))
 	 * This prevents sandwiching null characters
 	 * between ascii characters, like Java\0script.
 	 *
-	 * @param	string
-	 * @param	bool
+	 * @param	string	$str
+	 * @param	bool	$url_encoded
 	 * @return	string
 	 */
 	function remove_invisible_characters($str, $url_encoded = TRUE)
@@ -777,8 +777,8 @@ if ( ! function_exists('_stringify_attributes'))
 	 * Helper function used to convert a string, array, or object
 	 * of attributes to a string.
 	 *
-	 * @param	mixed	string, array, object
-	 * @param	bool
+	 * @param	mixed	$attributes	string, array, object
+	 * @param	bool	$js
 	 * @return	string
 	 */
 	function _stringify_attributes($attributes, $js = FALSE)

--- a/system/core/Controller.php
+++ b/system/core/Controller.php
@@ -50,6 +50,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  * @author		EllisLab Dev Team
  * @link		https://codeigniter.com/userguide3/general/controllers.html
  */
+#[AllowDynamicProperties]
 class CI_Controller {
 
 	/**

--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -49,6 +49,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  * @author		EllisLab Dev Team
  * @link		https://codeigniter.com/userguide3/libraries/loader.html
  */
+#[AllowDynamicProperties]
 class CI_Loader {
 
 	// All these are set automatically. Don't mess with them.

--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -444,7 +444,7 @@ class CI_Loader {
 	/**
 	 * Load the Database Forge Class
 	 *
-	 * @param	object	$db	Database object
+	 * @param	CI_DB	$db	Database object
 	 * @param	bool	$return	Whether to return the DB Forge class object or not
 	 * @return	object
 	 */
@@ -686,7 +686,7 @@ class CI_Loader {
 	 * Loads language files.
 	 *
 	 * @param	string|string[]	$files	List of language file names to load
-	 * @param	string		Language name
+	 * @param	string  $lang Language name
 	 * @return	object
 	 */
 	public function language($files, $lang = '')
@@ -1425,7 +1425,7 @@ class CI_Loader {
 	 * Get a reference to a specific library or model.
 	 *
 	 * @param 	string	$component	Component name
-	 * @return	bool
+	 * @return	object
 	 */
 	protected function &_ci_get_component($component)
 	{

--- a/system/core/Router.php
+++ b/system/core/Router.php
@@ -59,6 +59,13 @@ class CI_Router {
 	public $config;
 
 	/**
+	 * CI_URI class object
+	 *
+	 * @var	object
+	 */
+	public $uri;
+
+	/**
 	 * List of routes
 	 *
 	 * @var	array

--- a/system/core/Router.php
+++ b/system/core/Router.php
@@ -91,7 +91,7 @@ class CI_Router {
 	 *
 	 * @var	string
 	 */
-	public $directory = '';
+	public $directory;
 
 	/**
 	 * Default controller (and method if specific)
@@ -340,7 +340,7 @@ class CI_Router {
 	protected function _validate_request($segments)
 	{
 		$c = count($segments);
-		$directory_override = $this->directory !== '';
+		$directory_override = isset($this->directory);
 
 		// Loop through our segments and return as soon as a controller
 		// is found or when such a directory doesn't exist

--- a/system/core/Security.php
+++ b/system/core/Security.php
@@ -1041,7 +1041,7 @@ class CI_Security {
 	 * Do Never Allowed
 	 *
 	 * @used-by	CI_Security::xss_clean()
-	 * @param 	string
+	 * @param 	string	$str
 	 * @return 	string
 	 */
 	protected function _do_never_allowed($str)

--- a/system/core/URI.php
+++ b/system/core/URI.php
@@ -52,6 +52,13 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 class CI_URI {
 
 	/**
+	 * CI_Config instance
+	 *
+	 * @var	CI_Config
+	 */
+	public $config;
+
+	/**
 	 * List of cached URI segments
 	 *
 	 * @var	array

--- a/system/database/DB.php
+++ b/system/database/DB.php
@@ -39,18 +39,20 @@
 defined('BASEPATH') OR exit('No direct script access allowed');
 
 
-// JTA moved this here for kicks
-	require_once(BASEPATH.'database/DB_driver.php');
-	require_once(BASEPATH.'database/DB_query_builder.php');
-		/**
-		 * CI_DB
-		 *
-		 * Acts as an alias for both CI_DB_driver and CI_DB_query_builder.
-		 *
-		 * @see	CI_DB_query_builder
-		 * @see	CI_DB_driver
-		 */
-		class CI_DB extends CI_DB_query_builder {}
+// S. Imp moved this here from the conditional below because it
+// accomplishes the same thing more efficiently while dramatically
+// reducing the number of errors reported by phpstan
+require_once(BASEPATH.'database/DB_driver.php');
+require_once(BASEPATH.'database/DB_query_builder.php');
+/**
+ * CI_DB
+ *
+ * Acts as an alias for both CI_DB_driver and CI_DB_query_builder.
+ *
+ * @see	CI_DB_query_builder
+ * @see	CI_DB_driver
+ */
+class CI_DB extends CI_DB_query_builder {}
 
 
 

--- a/system/database/DB.php
+++ b/system/database/DB.php
@@ -38,6 +38,23 @@
  */
 defined('BASEPATH') OR exit('No direct script access allowed');
 
+
+// JTA moved this here for kicks
+	require_once(BASEPATH.'database/DB_driver.php');
+	require_once(BASEPATH.'database/DB_query_builder.php');
+		/**
+		 * CI_DB
+		 *
+		 * Acts as an alias for both CI_DB_driver and CI_DB_query_builder.
+		 *
+		 * @see	CI_DB_query_builder
+		 * @see	CI_DB_driver
+		 */
+		class CI_DB extends CI_DB_query_builder {}
+
+
+
+
 /**
  * Initialize the database
  *
@@ -148,21 +165,6 @@ function &DB($params = '')
 		show_error('You have not selected a database type to connect to.');
 	}
 
-	require_once(BASEPATH.'database/DB_driver.php');
-	require_once(BASEPATH.'database/DB_query_builder.php');
-	if ( ! class_exists('CI_DB', FALSE))
-	{
-		/**
-		 * CI_DB
-		 *
-		 * Acts as an alias for both CI_DB_driver and CI_DB_query_builder.
-		 *
-		 * @see	CI_DB_query_builder
-		 * @see	CI_DB_driver
-		 */
-		class CI_DB extends CI_DB_query_builder {}
-	}
-
 	// Load the DB driver
 	$driver_file = BASEPATH.'database/drivers/'.$params['dbdriver'].'/'.$params['dbdriver'].'_driver.php';
 	file_exists($driver_file) OR show_error('Invalid DB driver');
@@ -174,6 +176,9 @@ function &DB($params = '')
 
 	// Instantiate the DB adapter
 	$driver = 'CI_DB_'.$params['dbdriver'].'_driver';
+	/**
+	 * @var CI_DB_driver
+	 */
 	$DB = new $driver($params);
 
 	// Check for a subdriver

--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -51,6 +51,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  * @author		EllisLab Dev Team
  * @link		https://codeigniter.com/userguide3/database/
  */
+#[AllowDynamicProperties]
 abstract class CI_DB_driver {
 
 	/**

--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -927,8 +927,8 @@ abstract class CI_DB_driver {
 	/**
 	 * Compile Bindings
 	 *
-	 * @param	string	the sql statement
-	 * @param	array	an array of bind data
+	 * @param	string	$sql	the sql statement
+	 * @param	array	$binds	an array of bind data
 	 * @return	string
 	 */
 	public function compile_binds($sql, $binds)
@@ -992,7 +992,7 @@ abstract class CI_DB_driver {
 	/**
 	 * Determines if a query is a "write" type.
 	 *
-	 * @param	string	An SQL query string
+	 * @param	string	$sql	An SQL query string
 	 * @return	bool
 	 */
 	public function is_write_type($sql)
@@ -1005,7 +1005,7 @@ abstract class CI_DB_driver {
 	/**
 	 * Calculate the aggregate query elapsed time
 	 *
-	 * @param	int	The number of decimal places
+	 * @param	int	$decimals	The number of decimal places
 	 * @return	string
 	 */
 	public function elapsed_time($decimals = 6)
@@ -1045,7 +1045,7 @@ abstract class CI_DB_driver {
 	 * Escapes data based on type
 	 * Sets boolean and null types
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	mixed
 	 */
 	public function escape($str)
@@ -1115,7 +1115,7 @@ abstract class CI_DB_driver {
 	 * Calls the individual driver for platform
 	 * specific escaping for LIKE conditions
 	 *
-	 * @param	string|string[]
+	 * @param	string|string[]	$str
 	 * @return	mixed
 	 */
 	public function escape_like_str($str)
@@ -1128,7 +1128,7 @@ abstract class CI_DB_driver {
 	/**
 	 * Platform-dependent string escape
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	string
 	 */
 	protected function _escape_str($str)
@@ -1161,7 +1161,7 @@ abstract class CI_DB_driver {
 	 * Generates a platform-specific query string that counts all records in
 	 * the specified database
 	 *
-	 * @param	string
+	 * @param	string	$table
 	 * @return	int
 	 */
 	public function count_all($table = '')
@@ -1299,8 +1299,8 @@ abstract class CI_DB_driver {
 	/**
 	 * Determine if a particular field exists
 	 *
-	 * @param	string
-	 * @param	string
+	 * @param	string	$field_name
+	 * @param	string	$table_name
 	 * @return	bool
 	 */
 	public function field_exists($field_name, $table_name)
@@ -1392,8 +1392,8 @@ abstract class CI_DB_driver {
 	/**
 	 * Generate an insert string
 	 *
-	 * @param	string	the table upon which the query will be performed
-	 * @param	array	an associative array data of key/values
+	 * @param	string	$table	the table upon which the query will be performed
+	 * @param	array	$data	an associative array data of key/values
 	 * @return	string
 	 */
 	public function insert_string($table, $data)
@@ -1416,9 +1416,9 @@ abstract class CI_DB_driver {
 	 *
 	 * Generates a platform-specific insert string from the supplied data
 	 *
-	 * @param	string	the table name
-	 * @param	array	the insert keys
-	 * @param	array	the insert values
+	 * @param	string	$table	the table name
+	 * @param	array	$keys	the insert keys
+	 * @param	array	$values	the insert values
 	 * @return	string
 	 */
 	protected function _insert($table, $keys, $values)
@@ -1431,9 +1431,9 @@ abstract class CI_DB_driver {
 	/**
 	 * Generate an update string
 	 *
-	 * @param	string	the table upon which the query will be performed
-	 * @param	array	an associative array data of key/values
-	 * @param	mixed	the "where" statement
+	 * @param	string	$table	the table upon which the query will be performed
+	 * @param	array	$data	an associative array data of key/values
+	 * @param	mixed	$where	the "where" statement
 	 * @return	string
 	 */
 	public function update_string($table, $data, $where)
@@ -1463,8 +1463,8 @@ abstract class CI_DB_driver {
 	 *
 	 * Generates a platform-specific update string from the supplied data
 	 *
-	 * @param	string	the table name
-	 * @param	array	the update data
+	 * @param	string	$table	the table name
+	 * @param	array	$values	the update data
 	 * @return	string
 	 */
 	protected function _update($table, $values)
@@ -1485,7 +1485,7 @@ abstract class CI_DB_driver {
 	/**
 	 * Tests whether the string has an SQL operator
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	bool
 	 */
 	protected function _has_operator($str)
@@ -1498,7 +1498,7 @@ abstract class CI_DB_driver {
 	/**
 	 * Returns the SQL string operator
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	string
 	 */
 	protected function _get_operator($str)
@@ -1564,7 +1564,7 @@ abstract class CI_DB_driver {
 	/**
 	 * Set Cache Directory Path
 	 *
-	 * @param	string	the path to the cache directory
+	 * @param	string	$path the path to the cache directory
 	 * @return	void
 	 */
 	public function cache_set_path($path = '')
@@ -1683,9 +1683,9 @@ abstract class CI_DB_driver {
 	/**
 	 * Display an error message
 	 *
-	 * @param	string	the error message
-	 * @param	string	any "swap" values
-	 * @param	bool	whether to localize the message
+	 * @param	string	$error	the error message
+	 * @param	string	$swap	any "swap" values
+	 * @param	bool	$native	whether to localize the message
 	 * @return	string	sends the application/views/errors/error_db.php template
 	 */
 	public function display_error($error = '', $swap = '', $native = FALSE)
@@ -1755,10 +1755,10 @@ abstract class CI_DB_driver {
 	 * insert the table prefix (if it exists) in the proper position, and escape only
 	 * the correct identifiers.
 	 *
-	 * @param	string
-	 * @param	bool
-	 * @param	mixed
-	 * @param	bool
+	 * @param	string	$item
+	 * @param	bool	$prefix_single
+	 * @param	mixed	$protect_identifiers
+	 * @param	bool	$field_exists
 	 * @return	string
 	 */
 	public function protect_identifiers($item, $prefix_single = FALSE, $protect_identifiers = NULL, $field_exists = TRUE)

--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -722,7 +722,7 @@ abstract class CI_DB_driver {
 	 * we only use it when running transaction commands since they do
 	 * not require all the features of the main query() function.
 	 *
-	 * @param	string	the sql query
+	 * @param	string	$sql	the sql query
 	 * @return	mixed
 	 */
 	public function simple_query($sql)

--- a/system/database/DB_query_builder.php
+++ b/system/database/DB_query_builder.php
@@ -278,8 +278,8 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 *
 	 * Generates the SELECT portion of the query
 	 *
-	 * @param	string
-	 * @param	mixed
+	 * @param	string	$select
+	 * @param	mixed	$escape
 	 * @return	CI_DB_query_builder
 	 */
 	public function select($select = '*', $escape = NULL)
@@ -320,8 +320,8 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 *
 	 * Generates a SELECT MAX(field) portion of a query
 	 *
-	 * @param	string	the field
-	 * @param	string	an alias
+	 * @param	string	$select	the field
+	 * @param	string	$alias	an alias
 	 * @return	CI_DB_query_builder
 	 */
 	public function select_max($select = '', $alias = '')
@@ -336,8 +336,8 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 *
 	 * Generates a SELECT MIN(field) portion of a query
 	 *
-	 * @param	string	the field
-	 * @param	string	an alias
+	 * @param	string	$select	the field
+	 * @param	string	$alias	an alias
 	 * @return	CI_DB_query_builder
 	 */
 	public function select_min($select = '', $alias = '')
@@ -352,8 +352,8 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 *
 	 * Generates a SELECT AVG(field) portion of a query
 	 *
-	 * @param	string	the field
-	 * @param	string	an alias
+	 * @param	string	$select	the field
+	 * @param	string	$alias	an alias
 	 * @return	CI_DB_query_builder
 	 */
 	public function select_avg($select = '', $alias = '')
@@ -368,8 +368,8 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 *
 	 * Generates a SELECT SUM(field) portion of a query
 	 *
-	 * @param	string	the field
-	 * @param	string	an alias
+	 * @param	string	$select	the field
+	 * @param	string	$alias	an alias
 	 * @return	CI_DB_query_builder
 	 */
 	public function select_sum($select = '', $alias = '')
@@ -518,10 +518,10 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 *
 	 * Generates the JOIN portion of the query
 	 *
-	 * @param	string
-	 * @param	string	the join condition
-	 * @param	string	the type of join
-	 * @param	string	whether not to try to escape identifiers
+	 * @param	string	$table
+	 * @param	string	$cond	the join condition
+	 * @param	string	$type	the type of join
+	 * @param	string	$escape	whether not to try to escape identifiers
 	 * @return	CI_DB_query_builder
 	 */
 	public function join($table, $cond, $type = '', $escape = NULL)
@@ -607,9 +607,9 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 * Generates the WHERE portion of the query.
 	 * Separates multiple calls with 'AND'.
 	 *
-	 * @param	mixed
-	 * @param	mixed
-	 * @param	bool
+	 * @param	mixed	$key
+	 * @param	mixed	$value
+	 * @param	bool	$escape
 	 * @return	CI_DB_query_builder
 	 */
 	public function where($key, $value = NULL, $escape = NULL)
@@ -625,9 +625,9 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 * Generates the WHERE portion of the query.
 	 * Separates multiple calls with 'OR'.
 	 *
-	 * @param	mixed
-	 * @param	mixed
-	 * @param	bool
+	 * @param	mixed	$key
+	 * @param	mixed	$value
+	 * @param	bool	$escape
 	 * @return	CI_DB_query_builder
 	 */
 	public function or_where($key, $value = NULL, $escape = NULL)
@@ -1373,9 +1373,9 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 *
 	 * Allows key/value pairs to be set for inserting or updating
 	 *
-	 * @param	mixed
-	 * @param	string
-	 * @param	bool
+	 * @param	mixed	$key
+	 * @param	string	$value
+	 * @param	bool	$escape
 	 * @return	CI_DB_query_builder
 	 */
 	public function set($key, $value = '', $escape = NULL)
@@ -1405,8 +1405,8 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 *
 	 * Compiles a SELECT query string and returns the sql.
 	 *
-	 * @param	string	the table name to select from (optional)
-	 * @param	bool	TRUE: resets QB values; FALSE: leave QB values alone
+	 * @param	string	$table	the table name to select from (optional)
+	 * @param	bool	$reset	TRUE: resets QB values; FALSE: leave QB values alone
 	 * @return	string
 	 */
 	public function get_compiled_select($table = '', $reset = TRUE)
@@ -1435,9 +1435,9 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 * Compiles the select statement based on the other functions called
 	 * and runs the query
 	 *
-	 * @param	string	the table
-	 * @param	string	the limit clause
-	 * @param	string	the offset clause
+	 * @param	string	$table	the table
+	 * @param	string	$limit	the limit clause
+	 * @param	string	$offset	the offset clause
 	 * @return	CI_DB_result
 	 */
 	public function get($table = '', $limit = NULL, $offset = NULL)
@@ -1466,8 +1466,8 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 * Generates a platform-specific query string that counts all records
 	 * returned by an Query Builder query.
 	 *
-	 * @param	string
-	 * @param	bool	the reset clause
+	 * @param	string	$table
+	 * @param	bool	$reset	the reset clause
 	 * @return	int
 	 */
 	public function count_all_results($table = '', $reset = TRUE)
@@ -1620,9 +1620,9 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	/**
 	 * The "set_insert_batch" function.  Allows key/value pairs to be set for batch inserts
 	 *
-	 * @param	mixed
-	 * @param	string
-	 * @param	bool
+	 * @param	mixed	$key
+	 * @param	string	$value
+	 * @param	bool	$escape
 	 * @return	CI_DB_query_builder
 	 */
 	public function set_insert_batch($key, $value = '', $escape = NULL)
@@ -1680,8 +1680,8 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 *
 	 * Compiles an insert query and returns the sql
 	 *
-	 * @param	string	the table to insert into
-	 * @param	bool	TRUE: reset QB values; FALSE: leave QB values alone
+	 * @param	string	$table	the table to insert into
+	 * @param	bool	$reset	TRUE: reset QB values; FALSE: leave QB values alone
 	 * @return	string
 	 */
 	public function get_compiled_insert($table = '', $reset = TRUE)
@@ -1714,8 +1714,8 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 *
 	 * Compiles an insert string and runs the query
 	 *
-	 * @param	string	the table to insert data into
-	 * @param	array	an associative array of insert values
+	 * @param	string	$table	the table to insert data into
+	 * @param	array	$set	an associative array of insert values
 	 * @param	bool	$escape	Whether to escape values and identifiers
 	 * @return	bool	TRUE on success, FALSE on failure
 	 */
@@ -1752,7 +1752,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 * validate that the there data is actually being set and that table
 	 * has been chosen to be inserted into.
 	 *
-	 * @param	string	the table to insert data into
+	 * @param	string	$table	the table to insert data into
 	 * @return	string
 	 */
 	protected function _validate_insert($table = '')
@@ -1781,8 +1781,8 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 *
 	 * Compiles an replace into string and runs the query
 	 *
-	 * @param	string	the table to replace data into
-	 * @param	array	an associative array of insert values
+	 * @param	string	$table	the table to replace data into
+	 * @param	array	$set	an associative array of insert values
 	 * @return	bool	TRUE on success, FALSE on failure
 	 */
 	public function replace($table = '', $set = NULL)
@@ -1820,9 +1820,9 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 *
 	 * Generates a platform-specific replace string from the supplied data
 	 *
-	 * @param	string	the table name
-	 * @param	array	the insert keys
-	 * @param	array	the insert values
+	 * @param	string	$table	the table name
+	 * @param	array	$keys	the insert keys
+	 * @param	array	$values	the insert values
 	 * @return	string
 	 */
 	protected function _replace($table, $keys, $values)
@@ -1854,8 +1854,8 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 *
 	 * Compiles an update query and returns the sql
 	 *
-	 * @param	string	the table to update
-	 * @param	bool	TRUE: reset QB values; FALSE: leave QB values alone
+	 * @param	string	$table	the table to update
+	 * @param	bool	$reset	TRUE: reset QB values; FALSE: leave QB values alone
 	 * @return	string
 	 */
 	public function get_compiled_update($table = '', $reset = TRUE)
@@ -1930,7 +1930,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 * validate that data is actually being set and that a table has been
 	 * chosen to be update.
 	 *
-	 * @param	string	the table to update data on
+	 * @param	string	$table	the table to update data on
 	 * @return	bool
 	 */
 	protected function _validate_update($table)
@@ -1959,9 +1959,10 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 *
 	 * Compiles an update string and runs the query
 	 *
-	 * @param	string	the table to retrieve the results from
-	 * @param	array	an associative array of update values
-	 * @param	string	the where key
+	 * @param	string	$table	the table to retrieve the results from
+	 * @param	array	$set	an associative array of update values
+	 * @param	string	$index	the where key
+	 * @param	int	$batch_size
 	 * @return	int	number of rows affected or FALSE on failure
 	 */
 	public function update_batch($table, $set = NULL, $index = NULL, $batch_size = 100)
@@ -2063,9 +2064,9 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	/**
 	 * The "set_update_batch" function.  Allows key/value pairs to be set for batch updating
 	 *
-	 * @param	array
-	 * @param	string
-	 * @param	bool
+	 * @param	array	$key
+	 * @param	string	$index
+	 * @param	bool	$escape
 	 * @return	CI_DB_query_builder
 	 */
 	public function set_update_batch($key, $index = '', $escape = NULL)
@@ -2114,7 +2115,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 *
 	 * Compiles a delete string and runs "DELETE FROM table"
 	 *
-	 * @param	string	the table to empty
+	 * @param	string	$table	the table to empty
 	 * @return	bool	TRUE on success, FALSE on failure
 	 */
 	public function empty_table($table = '')
@@ -2147,7 +2148,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 * If the database does not support the truncate() command
 	 * This function maps to "DELETE FROM table"
 	 *
-	 * @param	string	the table to truncate
+	 * @param	string	$table	the table to truncate
 	 * @return	bool	TRUE on success, FALSE on failure
 	 */
 	public function truncate($table = '')
@@ -2181,7 +2182,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 * If the database does not support the truncate() command,
 	 * then this method maps to 'DELETE FROM table'
 	 *
-	 * @param	string	the table name
+	 * @param	string	$table	the table name
 	 * @return	string
 	 */
 	protected function _truncate($table)
@@ -2196,8 +2197,8 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 *
 	 * Compiles a delete query string and returns the sql
 	 *
-	 * @param	string	the table to delete from
-	 * @param	bool	TRUE: reset QB values; FALSE: leave QB values alone
+	 * @param	string	$table	the table to delete from
+	 * @param	bool	$reset	TRUE: reset QB values; FALSE: leave QB values alone
 	 * @return	string
 	 */
 	public function get_compiled_delete($table = '', $reset = TRUE)
@@ -2215,10 +2216,10 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 *
 	 * Compiles a delete string and runs the query
 	 *
-	 * @param	mixed	the table(s) to delete from. String or array
-	 * @param	mixed	the where clause
-	 * @param	mixed	the limit clause
-	 * @param	bool
+	 * @param	mixed	$table	the table(s) to delete from. String or array
+	 * @param	mixed	$where	the where clause
+	 * @param	mixed	$limit	the limit clause
+	 * @param	bool	$reset_data
 	 * @return	mixed
 	 */
 	public function delete($table = '', $where = '', $limit = NULL, $reset_data = TRUE)
@@ -2282,7 +2283,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 *
 	 * Generates a platform-specific delete string from the supplied data
 	 *
-	 * @param	string	the table name
+	 * @param	string	$table	the table name
 	 * @return	string
 	 */
 	protected function _delete($table)
@@ -2298,7 +2299,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 *
 	 * Prepends a database prefix if one exists in configuration
 	 *
-	 * @param	string	the table
+	 * @param	string	$table	the table
 	 * @return	string
 	 */
 	public function dbprefix($table = '')
@@ -2318,7 +2319,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 *
 	 * Set's the DB Prefix to something new without needing to reconnect
 	 *
-	 * @param	string	the prefix
+	 * @param	string	$prefix	the prefix
 	 * @return	string
 	 */
 	public function set_dbprefix($prefix = '')
@@ -2333,7 +2334,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 *
 	 * Used to track SQL statements written with aliased tables.
 	 *
-	 * @param	string	The table to inspect
+	 * @param	string	$table	The table to inspect
 	 * @return	string
 	 */
 	protected function _track_aliases($table)
@@ -2603,7 +2604,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 *
 	 * Takes an object as input and converts the class variables to array key/vals
 	 *
-	 * @param	object
+	 * @param	object	$object
 	 * @return	array
 	 */
 	protected function _object_to_array($object)
@@ -2633,7 +2634,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	 *
 	 * Takes an object as input and converts the class variables to array key/vals
 	 *
-	 * @param	object
+	 * @param	object	$object
 	 * @return	array
 	 */
 	protected function _object_to_array_batch($object)
@@ -2819,7 +2820,7 @@ abstract class CI_DB_query_builder extends CI_DB_driver {
 	/**
 	 * Resets the query builder values.  Called by the get() function
 	 *
-	 * @param	array	An array of fields to reset
+	 * @param	array	$qb_reset_items	An array of fields to reset
 	 * @return	void
 	 */
 	protected function _reset_run($qb_reset_items)

--- a/system/database/DB_utility.php
+++ b/system/database/DB_utility.php
@@ -230,7 +230,7 @@ abstract class CI_DB_utility {
 	/**
 	 * Generate CSV from a query result object
 	 *
-	 * @param	object	$query		Query result object
+	 * @param	CI_DB_result	$query		Query result object
 	 * @param	string	$delim		Delimiter (default: ,)
 	 * @param	string	$newline	Newline character (default: \n)
 	 * @param	string	$enclosure	Enclosure (default: ")
@@ -266,7 +266,7 @@ abstract class CI_DB_utility {
 	/**
 	 * Generate XML data from a query result object
 	 *
-	 * @param	object	$query	Query result object
+	 * @param	CI_DB_result	$query	Query result object
 	 * @param	array	$params	Any preferences
 	 * @return	string
 	 */

--- a/system/database/drivers/cubrid/cubrid_driver.php
+++ b/system/database/drivers/cubrid/cubrid_driver.php
@@ -253,7 +253,7 @@ class CI_DB_cubrid_driver extends CI_DB {
 	/**
 	 * Platform-dependent string escape
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	string
 	 */
 	protected function _escape_str($str)

--- a/system/database/drivers/cubrid/cubrid_utility.php
+++ b/system/database/drivers/cubrid/cubrid_utility.php
@@ -67,7 +67,7 @@ class CI_DB_cubrid_utility extends CI_DB_utility {
 	/**
 	 * CUBRID Export
 	 *
-	 * @param	array	Preferences
+	 * @param	array	$params	Preferences
 	 * @return	mixed
 	 */
 	protected function _backup($params = array())

--- a/system/database/drivers/mysql/mysql_driver.php
+++ b/system/database/drivers/mysql/mysql_driver.php
@@ -154,7 +154,7 @@ class CI_DB_mysql_driver extends CI_DB {
 			{
 				log_message('error', "Database: Unable to set the configured connection charset ('{$this->char_set}').");
 				$this->close();
-				return ($this->db->debug) ? $this->display_error('db_unable_to_set_charset', $this->char_set) : FALSE;
+				return ($this->db_debug) ? $this->display_error('db_unable_to_set_charset', $this->char_set) : FALSE;
 			}
 
 			if (isset($this->stricton))

--- a/system/database/drivers/mysql/mysql_driver.php
+++ b/system/database/drivers/mysql/mysql_driver.php
@@ -339,7 +339,7 @@ class CI_DB_mysql_driver extends CI_DB {
 	/**
 	 * Platform-dependent string escape
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	string
 	 */
 	protected function _escape_str($str)

--- a/system/database/drivers/mysqli/mysqli_driver.php
+++ b/system/database/drivers/mysqli/mysqli_driver.php
@@ -387,7 +387,7 @@ class CI_DB_mysqli_driver extends CI_DB {
 	/**
 	 * Platform-dependent string escape
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	string
 	 */
 	protected function _escape_str($str)

--- a/system/database/drivers/mysqli/mysqli_driver.php
+++ b/system/database/drivers/mysqli/mysqli_driver.php
@@ -227,7 +227,7 @@ class CI_DB_mysqli_driver extends CI_DB {
 			{
 				log_message('error', "Database: Unable to set the configured connection charset ('{$this->char_set}').");
 				$this->_mysqli->close();
-				return ($this->db->db_debug) ? $this->display_error('db_unable_to_set_charset', $this->char_set) : FALSE;
+				return ($this->db_debug) ? $this->display_error('db_unable_to_set_charset', $this->char_set) : FALSE;
 			}
 
 			return $this->_mysqli;

--- a/system/database/drivers/odbc/odbc_driver.php
+++ b/system/database/drivers/odbc/odbc_driver.php
@@ -294,7 +294,7 @@ class CI_DB_odbc_driver extends CI_DB_driver {
 	/**
 	 * Determines if a query is a "write" type.
 	 *
-	 * @param	string	An SQL query string
+	 * @param	string	$sql	An SQL query string
 	 * @return	bool
 	 */
 	public function is_write_type($sql)
@@ -312,7 +312,7 @@ class CI_DB_odbc_driver extends CI_DB_driver {
 	/**
 	 * Platform-dependent string escape
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	string
 	 */
 	protected function _escape_str($str)

--- a/system/database/drivers/pdo/pdo_driver.php
+++ b/system/database/drivers/pdo/pdo_driver.php
@@ -234,7 +234,7 @@ class CI_DB_pdo_driver extends CI_DB {
 	/**
 	 * Platform-dependent string escape
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	string
 	 */
 	protected function _escape_str($str)

--- a/system/database/drivers/pdo/subdrivers/pdo_odbc_driver.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_odbc_driver.php
@@ -164,7 +164,7 @@ class CI_DB_pdo_odbc_driver extends CI_DB_pdo_driver {
 	/**
 	 * Platform-dependent string escape
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	string
 	 */
 	protected function _escape_str($str)
@@ -177,7 +177,7 @@ class CI_DB_pdo_odbc_driver extends CI_DB_pdo_driver {
 	/**
 	 * Determines if a query is a "write" type.
 	 *
-	 * @param	string	An SQL query string
+	 * @param	string	$sql	An SQL query string
 	 * @return	bool
 	 */
 	public function is_write_type($sql)

--- a/system/database/drivers/pdo/subdrivers/pdo_pgsql_driver.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_pgsql_driver.php
@@ -150,7 +150,7 @@ class CI_DB_pdo_pgsql_driver extends CI_DB_pdo_driver {
 	/**
 	 * Determines if a query is a "write" type.
 	 *
-	 * @param	string	An SQL query string
+	 * @param	string	$sql	An SQL query string
 	 * @return	bool
 	 */
 	public function is_write_type($sql)

--- a/system/database/drivers/postgre/postgre_driver.php
+++ b/system/database/drivers/postgre/postgre_driver.php
@@ -269,7 +269,7 @@ class CI_DB_postgre_driver extends CI_DB {
 	/**
 	 * Determines if a query is a "write" type.
 	 *
-	 * @param	string	An SQL query string
+	 * @param	string	$sql	An SQL query string
 	 * @return	bool
 	 */
 	public function is_write_type($sql)
@@ -287,7 +287,7 @@ class CI_DB_postgre_driver extends CI_DB {
 	/**
 	 * Platform-dependent string escape
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	string
 	 */
 	protected function _escape_str($str)

--- a/system/database/drivers/sqlite3/sqlite3_driver.php
+++ b/system/database/drivers/sqlite3/sqlite3_driver.php
@@ -171,7 +171,7 @@ class CI_DB_sqlite3_driver extends CI_DB {
 	/**
 	 * Platform-dependent string escape
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	string
 	 */
 	protected function _escape_str($str)

--- a/system/database/drivers/sqlsrv/sqlsrv_driver.php
+++ b/system/database/drivers/sqlsrv/sqlsrv_driver.php
@@ -285,8 +285,8 @@ class CI_DB_sqlsrv_driver extends CI_DB {
 	 *
 	 * Generates a platform-specific query string so that the table names can be fetched
 	 *
-	 * @param	bool
-	 * @return	string	$prefix_limit
+	 * @param	bool	$prefix_limit
+	 * @return	string
 	 */
 	protected function _list_tables($prefix_limit = FALSE)
 	{

--- a/system/helpers/array_helper.php
+++ b/system/helpers/array_helper.php
@@ -58,9 +58,9 @@ if ( ! function_exists('element'))
 	 * Lets you determine whether an array index is set and whether it has a value.
 	 * If the element is empty it returns NULL (or whatever you specify as the default value.)
 	 *
-	 * @param	string
-	 * @param	array
-	 * @param	mixed
+	 * @param	string	$item
+	 * @param	array	$array
+	 * @param	mixed	$default
 	 * @return	mixed	depends on what the array contains
 	 */
 	function element($item, array $array, $default = NULL)
@@ -76,7 +76,7 @@ if ( ! function_exists('random_element'))
 	/**
 	 * Random Element - Takes an array as input and returns a random element
 	 *
-	 * @param	array
+	 * @param	array	$array
 	 * @return	mixed	depends on what the array contains
 	 */
 	function random_element($array)
@@ -95,9 +95,9 @@ if ( ! function_exists('elements'))
 	 * Returns only the array items specified. Will return a default value if
 	 * it is not set.
 	 *
-	 * @param	array
-	 * @param	array
-	 * @param	mixed
+	 * @param	array	$items
+	 * @param	array	$array
+	 * @param	mixed	$default
 	 * @return	mixed	depends on what the array contains
 	 */
 	function elements($items, array $array, $default = NULL)

--- a/system/helpers/cookie_helper.php
+++ b/system/helpers/cookie_helper.php
@@ -58,14 +58,14 @@ if ( ! function_exists('set_cookie'))
 	 * Accepts seven parameters, or you can submit an associative
 	 * array in the first parameter containing all the values.
 	 *
-	 * @param	mixed
-	 * @param	string	the value of the cookie
-	 * @param	int	the number of seconds until expiration
-	 * @param	string	the cookie domain.  Usually:  .yourdomain.com
-	 * @param	string	the cookie path
-	 * @param	string	the cookie prefix
-	 * @param	bool	true makes the cookie secure
-	 * @param	bool	true makes the cookie accessible via http(s) only (no javascript)
+	 * @param	mixed	$name
+	 * @param	string	$value	the value of the cookie
+	 * @param	int	$expire	the number of seconds until expiration
+	 * @param	string	$domain	the cookie domain.  Usually:  .yourdomain.com
+	 * @param	string	$path	the cookie path
+	 * @param	string	$prefix	the cookie prefix
+	 * @param	bool	$secure	true makes the cookie secure
+	 * @param	bool	$httponly	true makes the cookie accessible via http(s) only (no javascript)
 	 * @return	void
 	 */
 	function set_cookie($name, $value = '', $expire = 0, $domain = '', $path = '/', $prefix = '', $secure = NULL, $httponly = NULL, $samesite = NULL)
@@ -82,8 +82,8 @@ if ( ! function_exists('get_cookie'))
 	/**
 	 * Fetch an item from the COOKIE array
 	 *
-	 * @param	string
-	 * @param	bool
+	 * @param	string	$index
+	 * @param	bool	$xss_clean
 	 * @return	mixed
 	 */
 	function get_cookie($index, $xss_clean = FALSE)
@@ -100,10 +100,10 @@ if ( ! function_exists('delete_cookie'))
 	/**
 	 * Delete a COOKIE
 	 *
-	 * @param	mixed
-	 * @param	string	the cookie domain. Usually: .yourdomain.com
-	 * @param	string	the cookie path
-	 * @param	string	the cookie prefix
+	 * @param	mixed	$name
+	 * @param	string	$domain	the cookie domain. Usually: .yourdomain.com
+	 * @param	string	$path	the cookie path
+	 * @param	string	$prefix	the cookie prefix
 	 * @return	void
 	 */
 	function delete_cookie($name, $domain = '', $path = '/', $prefix = '')

--- a/system/helpers/date_helper.php
+++ b/system/helpers/date_helper.php
@@ -58,7 +58,7 @@ if ( ! function_exists('now'))
 	 * Returns time() based on the timezone parameter or on the
 	 * "time_reference" setting
 	 *
-	 * @param	string
+	 * @param	string	$timezone
 	 * @return	int
 	 */
 	function now($timezone = NULL)
@@ -96,8 +96,8 @@ if ( ! function_exists('mdate'))
 	 * have to worry about escaping your text letters that
 	 * match the date codes.
 	 *
-	 * @param	string
-	 * @param	int
+	 * @param	string	$datestr
+	 * @param	int	$time
 	 * @return	int
 	 */
 	function mdate($datestr = '', $time = '')
@@ -131,9 +131,9 @@ if ( ! function_exists('timespan'))
 	 * Returns a span of seconds in this format:
 	 *	10 days 14 hours 36 minutes 47 seconds
 	 *
-	 * @param	int	a number of seconds
-	 * @param	int	Unix timestamp
-	 * @param	int	a number of display units
+	 * @param	int	$seconds	a number of seconds
+	 * @param	int	$time	Unix timestamp
+	 * @param	int	$units	a number of display units
 	 * @return	string
 	 */
 	function timespan($seconds = 1, $time = '', $units = 7)
@@ -235,8 +235,8 @@ if ( ! function_exists('days_in_month'))
 	 * Takes a month/year as input and returns the number of days
 	 * for the given month/year. Takes leap years into consideration.
 	 *
-	 * @param	int	a numeric month
-	 * @param	int	a numeric year
+	 * @param	int	$month	a numeric month
+	 * @param	int	$year	a numeric year
 	 * @return	int
 	 */
 	function days_in_month($month = 0, $year = '')
@@ -280,7 +280,7 @@ if ( ! function_exists('local_to_gmt'))
 	/**
 	 * Converts a local Unix timestamp to GMT
 	 *
-	 * @param	int	Unix timestamp
+	 * @param	int	$time	Unix timestamp
 	 * @return	int
 	 */
 	function local_to_gmt($time = '')
@@ -312,9 +312,9 @@ if ( ! function_exists('gmt_to_local'))
 	 * at the local value based on the timezone and DST setting
 	 * submitted
 	 *
-	 * @param	int	Unix timestamp
-	 * @param	string	timezone
-	 * @param	bool	whether DST is active
+	 * @param	int	$time	Unix timestamp
+	 * @param	string	$timezone	timezone
+	 * @param	bool	$dst	whether DST is active
 	 * @return	int
 	 */
 	function gmt_to_local($time = '', $timezone = 'UTC', $dst = FALSE)
@@ -337,7 +337,7 @@ if ( ! function_exists('mysql_to_unix'))
 	/**
 	 * Converts a MySQL Timestamp to Unix
 	 *
-	 * @param	int	MySQL timestamp YYYY-MM-DD HH:MM:SS
+	 * @param	int	$time	MySQL timestamp YYYY-MM-DD HH:MM:SS
 	 * @return	int	Unix timstamp
 	 */
 	function mysql_to_unix($time = '')
@@ -369,9 +369,9 @@ if ( ! function_exists('unix_to_human'))
 	 *
 	 * Formats Unix timestamp to the following prototype: 2006-08-21 11:35 PM
 	 *
-	 * @param	int	Unix timestamp
-	 * @param	bool	whether to show seconds
-	 * @param	string	format: us or euro
+	 * @param	int	$time	Unix timestamp
+	 * @param	bool	$seconds	whether to show seconds
+	 * @param	string	$fmt	format: us or euro
 	 * @return	string
 	 */
 	function unix_to_human($time = '', $seconds = FALSE, $fmt = 'us')
@@ -410,7 +410,7 @@ if ( ! function_exists('human_to_unix'))
 	 *
 	 * Reverses the above process
 	 *
-	 * @param	string	format: us or euro
+	 * @param	string	$datestr	format: us or euro
 	 * @return	int
 	 */
 	function human_to_unix($datestr = '')
@@ -458,10 +458,10 @@ if ( ! function_exists('timezone_menu'))
 	 *
 	 * Generates a drop-down menu of timezones.
 	 *
-	 * @param	string	timezone
-	 * @param	string	classname
-	 * @param	string	menu name
-	 * @param	mixed	attributes
+	 * @param	string	$default	timezone
+	 * @param	string	$class	classname
+	 * @param	string	$name	menu name
+	 * @param	mixed	$attributes	attributes
 	 * @return	string
 	 */
 	function timezone_menu($default = 'UTC', $class = '', $name = 'timezones', $attributes = '')
@@ -500,7 +500,7 @@ if ( ! function_exists('timezones'))
 	 * Returns an array of timezones. This is a helper function
 	 * for various other ones in this library
 	 *
-	 * @param	string	timezone
+	 * @param	string	$tz	timezone
 	 * @return	string
 	 */
 	function timezones($tz = '')
@@ -569,14 +569,14 @@ if ( ! function_exists('date_range'))
 	 *
 	 * Returns a list of dates within a specified period.
 	 *
-	 * @param	int	unix_start	UNIX timestamp of period start date
-	 * @param	int	unix_end|days	UNIX timestamp of period end date
+	 * @param	int	$unix_start	UNIX timestamp of period start date
+	 * @param	int	$mixed	UNIX timestamp of period end date
 	 *					or interval in days.
-	 * @param	mixed	is_unix		Specifies whether the second parameter
+	 * @param	mixed	$is_unix		Specifies whether the second parameter
 	 *					is a UNIX timestamp or a day interval
 	 *					 - TRUE or 'unix' for a timestamp
 	 *					 - FALSE or 'days' for an interval
-	 * @param	string  date_format	Output date format, same as in date()
+	 * @param	string  $format	Output date format, same as in date()
 	 * @return	array
 	 */
 	function date_range($unix_start = '', $mixed = '', $is_unix = TRUE, $format = 'Y-m-d')

--- a/system/helpers/download_helper.php
+++ b/system/helpers/download_helper.php
@@ -57,9 +57,9 @@ if ( ! function_exists('force_download'))
 	 *
 	 * Generates headers that force a download to happen
 	 *
-	 * @param	mixed	filename (or an array of local file path => destination filename)
-	 * @param	mixed	the data to be downloaded
-	 * @param	bool	whether to try and send the actual file MIME type
+	 * @param	mixed	$filename	filename (or an array of local file path => destination filename)
+	 * @param	mixed	$data	the data to be downloaded
+	 * @param	bool	$set_mime	whether to try and send the actual file MIME type
 	 * @return	void
 	 */
 	function force_download($filename = '', $data = '', $set_mime = FALSE)

--- a/system/helpers/file_helper.php
+++ b/system/helpers/file_helper.php
@@ -150,9 +150,9 @@ if ( ! function_exists('get_filenames'))
 	 * Reads the specified directory and builds an array containing the filenames.
 	 * Any sub-folders contained within the specified path are read as well.
 	 *
-	 * @param	string	path to source
-	 * @param	bool	whether to include the path as part of the filename
-	 * @param	bool	internal variable to determine recursion status - do not use in calls
+	 * @param	string	$source_dir	path to source
+	 * @param	bool	$include_path	whether to include the path as part of the filename
+	 * @param	bool	$_recursion	internal variable to determine recursion status - do not use in calls
 	 * @return	array
 	 */
 	function get_filenames($source_dir, $include_path = FALSE, $_recursion = FALSE)
@@ -200,9 +200,9 @@ if ( ! function_exists('get_dir_file_info'))
 	 *
 	 * Any sub-folders contained within the specified path are read as well.
 	 *
-	 * @param	string	path to source
-	 * @param	bool	Look only at the top level directory specified?
-	 * @param	bool	internal variable to determine recursion status - do not use in calls
+	 * @param	string	$source_dir	path to source
+	 * @param	bool	$top_level_only	Look only at the top level directory specified?
+	 * @param	bool	$_recursion	internal variable to determine recursion status - do not use in calls
 	 * @return	array
 	 */
 	function get_dir_file_info($source_dir, $top_level_only = TRUE, $_recursion = FALSE)
@@ -254,8 +254,8 @@ if ( ! function_exists('get_file_info'))
 	 * Options are: name, server_path, size, date, readable, writable, executable, fileperms
 	 * Returns FALSE if the file cannot be found.
 	 *
-	 * @param	string	path to file
-	 * @param	mixed	array or comma separated string of information returned
+	 * @param	string	$file	path to file
+	 * @param	mixed	$returned_values	array or comma separated string of information returned
 	 * @return	array
 	 */
 	function get_file_info($file, $returned_values = array('name', 'server_path', 'size', 'date'))

--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -57,9 +57,9 @@ if ( ! function_exists('form_open'))
 	 *
 	 * Creates the opening portion of the form.
 	 *
-	 * @param	string	the URI segments of the form destination
-	 * @param	array	a key/value pair of attributes
-	 * @param	array	a key/value pair hidden data
+	 * @param	string	$action	the URI segments of the form destination
+	 * @param	array	$attributes	a key/value pair of attributes
+	 * @param	array	$hidden	a key/value pair hidden data
 	 * @return	string
 	 */
 	function form_open($action = '', $attributes = array(), $hidden = array())
@@ -147,9 +147,9 @@ if ( ! function_exists('form_open_multipart'))
 	 *
 	 * Creates the opening portion of the form, but with "multipart/form-data".
 	 *
-	 * @param	string	the URI segments of the form destination
-	 * @param	array	a key/value pair of attributes
-	 * @param	array	a key/value pair hidden data
+	 * @param	string	$action	the URI segments of the form destination
+	 * @param	array	$attributes	a key/value pair of attributes
+	 * @param	array	$hidden	a key/value pair hidden data
 	 * @return	string
 	 */
 	function form_open_multipart($action = '', $attributes = array(), $hidden = array())
@@ -225,9 +225,9 @@ if ( ! function_exists('form_input'))
 	/**
 	 * Text Input Field
 	 *
-	 * @param	mixed
-	 * @param	string
-	 * @param	mixed
+	 * @param	mixed	$data
+	 * @param	string	$value
+	 * @param	mixed	$extra
 	 * @return	string
 	 */
 	function form_input($data = '', $value = '', $extra = '')
@@ -251,9 +251,9 @@ if ( ! function_exists('form_password'))
 	 *
 	 * Identical to the input function but adds the "password" type
 	 *
-	 * @param	mixed
-	 * @param	string
-	 * @param	mixed
+	 * @param	mixed	$data
+	 * @param	string	$value
+	 * @param	mixed	$extra
 	 * @return	string
 	 */
 	function form_password($data = '', $value = '', $extra = '')
@@ -273,8 +273,8 @@ if ( ! function_exists('form_upload'))
 	 *
 	 * Identical to the input function but adds the "file" type
 	 *
-	 * @param	mixed
-	 * @param	mixed
+	 * @param	mixed	$data
+	 * @param	mixed	$extra
 	 * @return	string
 	 */
 	function form_upload($data = '', $extra = '')
@@ -330,10 +330,10 @@ if ( ! function_exists('form_multiselect'))
 	/**
 	 * Multi-select menu
 	 *
-	 * @param	string
-	 * @param	array
-	 * @param	mixed
-	 * @param	mixed
+	 * @param	string	$name
+	 * @param	array	$options
+	 * @param	mixed	$selected
+	 * @param	mixed	$extra
 	 * @return	string
 	 */
 	function form_multiselect($name = '', $options = array(), $selected = array(), $extra = '')
@@ -450,10 +450,10 @@ if ( ! function_exists('form_checkbox'))
 	/**
 	 * Checkbox Field
 	 *
-	 * @param	mixed
-	 * @param	string
-	 * @param	bool
-	 * @param	mixed
+	 * @param	mixed	$data
+	 * @param	string	$value
+	 * @param	bool	$checked
+	 * @param	mixed	$extra
 	 * @return	string
 	 */
 	function form_checkbox($data = '', $value = '', $checked = FALSE, $extra = '')
@@ -494,10 +494,10 @@ if ( ! function_exists('form_radio'))
 	/**
 	 * Radio Button
 	 *
-	 * @param	mixed
-	 * @param	string
-	 * @param	bool
-	 * @param	mixed
+	 * @param	mixed	$data
+	 * @param	string	$value
+	 * @param	bool	$checked
+	 * @param	mixed	$extra
 	 * @return	string
 	 */
 	function form_radio($data = '', $value = '', $checked = FALSE, $extra = '')
@@ -516,9 +516,9 @@ if ( ! function_exists('form_submit'))
 	/**
 	 * Submit Button
 	 *
-	 * @param	mixed
-	 * @param	string
-	 * @param	mixed
+	 * @param	mixed	$data
+	 * @param	string	$value
+	 * @param	mixed	$extra
 	 * @return	string
 	 */
 	function form_submit($data = '', $value = '', $extra = '')
@@ -540,9 +540,9 @@ if ( ! function_exists('form_reset'))
 	/**
 	 * Reset Button
 	 *
-	 * @param	mixed
-	 * @param	string
-	 * @param	mixed
+	 * @param	mixed	$data
+	 * @param	string	$value
+	 * @param	mixed	$extra
 	 * @return	string
 	 */
 	function form_reset($data = '', $value = '', $extra = '')
@@ -564,9 +564,9 @@ if ( ! function_exists('form_button'))
 	/**
 	 * Form Button
 	 *
-	 * @param	mixed
-	 * @param	string
-	 * @param	mixed
+	 * @param	mixed	$data
+	 * @param	string	$content
+	 * @param	mixed	$extra
 	 * @return	string
 	 */
 	function form_button($data = '', $content = '', $extra = '')
@@ -595,9 +595,9 @@ if ( ! function_exists('form_label'))
 	/**
 	 * Form Label Tag
 	 *
-	 * @param	string	The text to appear onscreen
-	 * @param	string	The id the label applies to
-	 * @param	mixed	Additional attributes
+	 * @param	string	$label_text	The text to appear onscreen
+	 * @param	string	$id	The id the label applies to
+	 * @param	mixed	$attributes	Additional attributes
 	 * @return	string
 	 */
 	function form_label($label_text = '', $id = '', $attributes = array())
@@ -626,8 +626,8 @@ if ( ! function_exists('form_fieldset'))
 	 * Used to produce <fieldset><legend>text</legend>.  To close fieldset
 	 * use form_fieldset_close()
 	 *
-	 * @param	string	The legend text
-	 * @param	array	Additional attributes
+	 * @param	string	$legend_text	The legend text
+	 * @param	array	$attributes	Additional attributes
 	 * @return	string
 	 */
 	function form_fieldset($legend_text = '', $attributes = array())
@@ -649,7 +649,7 @@ if ( ! function_exists('form_fieldset_close'))
 	/**
 	 * Fieldset Close Tag
 	 *
-	 * @param	string
+	 * @param	string	$extra
 	 * @return	string
 	 */
 	function form_fieldset_close($extra = '')
@@ -665,7 +665,7 @@ if ( ! function_exists('form_close'))
 	/**
 	 * Form Close Tag
 	 *
-	 * @param	string
+	 * @param	string	$extra
 	 * @return	string
 	 */
 	function form_close($extra = '')
@@ -713,9 +713,9 @@ if ( ! function_exists('set_select'))
 	 * Let's you set the selected value of a <select> menu via data in the POST array.
 	 * If Form Validation is active it retrieves the info from the validation class
 	 *
-	 * @param	string
-	 * @param	string
-	 * @param	bool
+	 * @param	string	$field
+	 * @param	string	$value
+	 * @param	bool	$default
 	 * @return	string
 	 */
 	function set_select($field, $value = '', $default = FALSE)
@@ -760,9 +760,9 @@ if ( ! function_exists('set_checkbox'))
 	 * Let's you set the selected value of a checkbox via the value in the POST array.
 	 * If Form Validation is active it retrieves the info from the validation class
 	 *
-	 * @param	string
-	 * @param	string
-	 * @param	bool
+	 * @param	string	$field
+	 * @param	string	$value
+	 * @param	bool	$default
 	 * @return	string
 	 */
 	function set_checkbox($field, $value = '', $default = FALSE)
@@ -864,9 +864,9 @@ if ( ! function_exists('form_error'))
 	 * Returns the error for a specific form field. This is a helper for the
 	 * form validation class.
 	 *
-	 * @param	string
-	 * @param	string
-	 * @param	string
+	 * @param	string	$field
+	 * @param	string	$prefix
+	 * @param	string	$suffix
 	 * @return	string
 	 */
 	function form_error($field = '', $prefix = '', $suffix = '')
@@ -890,8 +890,8 @@ if ( ! function_exists('validation_errors'))
 	 * Returns all the errors associated with a form submission. This is a helper
 	 * function for the form validation class.
 	 *
-	 * @param	string
-	 * @param	string
+	 * @param	string	$prefix
+	 * @param	string	$suffix
 	 * @return	string
 	 */
 	function validation_errors($prefix = '', $suffix = '')
@@ -966,7 +966,7 @@ if ( ! function_exists('_attributes_to_string'))
 	 *
 	 * Helper function used by some of the form helpers
 	 *
-	 * @param	mixed
+	 * @param	mixed	$attributes
 	 * @return	string
 	 */
 	function _attributes_to_string($attributes)

--- a/system/helpers/html_helper.php
+++ b/system/helpers/html_helper.php
@@ -57,9 +57,9 @@ if ( ! function_exists('heading'))
 	 *
 	 * Generates an HTML heading tag.
 	 *
-	 * @param	string	content
-	 * @param	int	heading level
-	 * @param	string
+	 * @param	string	$data	content
+	 * @param	int	$h	heading level
+	 * @param	string	$attributes
 	 * @return	string
 	 */
 	function heading($data = '', $h = '1', $attributes = '')
@@ -77,8 +77,8 @@ if ( ! function_exists('ul'))
 	 *
 	 * Generates an HTML unordered list from an single or multi-dimensional array.
 	 *
-	 * @param	array
-	 * @param	mixed
+	 * @param	array	$list
+	 * @param	mixed	$attributes
 	 * @return	string
 	 */
 	function ul($list, $attributes = '')
@@ -96,8 +96,8 @@ if ( ! function_exists('ol'))
 	 *
 	 * Generates an HTML ordered list from an single or multi-dimensional array.
 	 *
-	 * @param	array
-	 * @param	mixed
+	 * @param	array	$list
+	 * @param	mixed	$attributes
 	 * @return	string
 	 */
 	function ol($list, $attributes = '')
@@ -115,10 +115,10 @@ if ( ! function_exists('_list'))
 	 *
 	 * Generates an HTML ordered list from an single or multi-dimensional array.
 	 *
-	 * @param	string
-	 * @param	mixed
-	 * @param	mixed
-	 * @param	int
+	 * @param	string	$type
+	 * @param	mixed	$list
+	 * @param	mixed	$attributes
+	 * @param	int	$depth
 	 * @return	string
 	 */
 	function _list($type = 'ul', $list = array(), $attributes = '', $depth = 0)
@@ -170,9 +170,9 @@ if ( ! function_exists('img'))
 	 *
 	 * Generates an <img /> element
 	 *
-	 * @param	mixed
-	 * @param	bool
-	 * @param	mixed
+	 * @param	mixed	$src
+	 * @param	bool	$index_page
+	 * @param	mixed	$attributes
 	 * @return	string
 	 */
 	function img($src = '', $index_page = FALSE, $attributes = '')
@@ -226,7 +226,7 @@ if ( ! function_exists('doctype'))
 	 * xhtml-frame, html4-strict, html4-trans, and html4-frame.
 	 * All values are saved in the doctypes config file.
 	 *
-	 * @param	string	type	The doctype to be generated
+	 * @param	string	$type	The doctype to be generated
 	 * @return	string
 	 */
 	function doctype($type = 'html5')
@@ -267,12 +267,12 @@ if ( ! function_exists('link_tag'))
 	 *
 	 * Generates link to a CSS file
 	 *
-	 * @param	mixed	stylesheet hrefs or an array
-	 * @param	string	rel
-	 * @param	string	type
-	 * @param	string	title
-	 * @param	string	media
-	 * @param	bool	should index_page be added to the css path
+	 * @param	mixed	$href	stylesheet hrefs or an array
+	 * @param	string	$rel
+	 * @param	string	$type
+	 * @param	string	$title
+	 * @param	string	$media
+	 * @param	bool	$index_page should index_page be added to the css path
 	 * @return	string
 	 */
 	function link_tag($href = '', $rel = 'stylesheet', $type = 'text/css', $title = '', $media = '', $index_page = FALSE)
@@ -340,10 +340,10 @@ if ( ! function_exists('meta'))
 	/**
 	 * Generates meta tags from an array of key/values
 	 *
-	 * @param	array
-	 * @param	string
-	 * @param	string
-	 * @param	string
+	 * @param	array	$name
+	 * @param	string	$content
+	 * @param	string	$type
+	 * @param	string	$newline
 	 * @return	string
 	 */
 	function meta($name = '', $content = '', $type = 'name', $newline = "\n")

--- a/system/helpers/number_helper.php
+++ b/system/helpers/number_helper.php
@@ -55,8 +55,8 @@ if ( ! function_exists('byte_format'))
 	/**
 	 * Formats a numbers as bytes, based on size, and adds the appropriate suffix
 	 *
-	 * @param	mixed	will be cast as int
-	 * @param	int
+	 * @param	mixed	$num	will be cast as int
+	 * @param	int	$precision
 	 * @return	string
 	 */
 	function byte_format($num, $precision = 1)

--- a/system/helpers/path_helper.php
+++ b/system/helpers/path_helper.php
@@ -55,8 +55,8 @@ if ( ! function_exists('set_realpath'))
 	/**
 	 * Set Realpath
 	 *
-	 * @param	string
-	 * @param	bool	checks to see if the path exists
+	 * @param	string	$path
+	 * @param	bool	$check_existance	checks to see if the path exists
 	 * @return	string
 	 */
 	function set_realpath($path, $check_existance = FALSE)

--- a/system/helpers/security_helper.php
+++ b/system/helpers/security_helper.php
@@ -55,8 +55,8 @@ if ( ! function_exists('xss_clean'))
 	/**
 	 * XSS Filtering
 	 *
-	 * @param	string
-	 * @param	bool	whether or not the content is an image file
+	 * @param	string	$str
+	 * @param	bool	$is_image	whether or not the content is an image file
 	 * @return	string
 	 */
 	function xss_clean($str, $is_image = FALSE)
@@ -72,7 +72,7 @@ if ( ! function_exists('sanitize_filename'))
 	/**
 	 * Sanitize Filename
 	 *
-	 * @param	string
+	 * @param	string	$filename
 	 * @return	string
 	 */
 	function sanitize_filename($filename)
@@ -88,7 +88,7 @@ if ( ! function_exists('strip_image_tags'))
 	/**
 	 * Strip Image Tags
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	string
 	 */
 	function strip_image_tags($str)
@@ -104,7 +104,7 @@ if ( ! function_exists('encode_php_tags'))
 	/**
 	 * Convert PHP tags to entities
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	string
 	 */
 	function encode_php_tags($str)

--- a/system/helpers/string_helper.php
+++ b/system/helpers/string_helper.php
@@ -57,7 +57,7 @@ if ( ! function_exists('strip_slashes'))
 	 *
 	 * Removes slashes contained in a string or in an array
 	 *
-	 * @param	mixed	string or array
+	 * @param	mixed	$str	string or array
 	 * @return	mixed	string or array
 	 */
 	function strip_slashes($str)
@@ -85,7 +85,7 @@ if ( ! function_exists('strip_quotes'))
 	 *
 	 * Removes single and double quotes from a string
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	string
 	 */
 	function strip_quotes($str)
@@ -103,7 +103,7 @@ if ( ! function_exists('quotes_to_entities'))
 	 *
 	 * Converts single and double quotes to entities
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	string
 	 */
 	function quotes_to_entities($str)
@@ -128,7 +128,7 @@ if ( ! function_exists('reduce_double_slashes'))
 	 *
 	 * http://www.some-site.com/index.php
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	string
 	 */
 	function reduce_double_slashes($str)
@@ -152,9 +152,9 @@ if ( ! function_exists('reduce_multiples'))
 	 *
 	 * Fred, Bill, Joe, Jimmy
 	 *
-	 * @param	string
-	 * @param	string	the character you wish to reduce
-	 * @param	bool	TRUE/FALSE - whether to trim the character from the beginning/end
+	 * @param	string	$str
+	 * @param	string	$character	the character you wish to reduce
+	 * @param	bool	$trim	TRUE/FALSE - whether to trim the character from the beginning/end
 	 * @return	string
 	 */
 	function reduce_multiples($str, $character = ',', $trim = FALSE)
@@ -171,8 +171,8 @@ if ( ! function_exists('random_string'))
 	/**
 	 * Create a "Random" String
 	 *
-	 * @param	string	type of random string.  basic, alpha, alnum, numeric, nozero, md5 and sha1
-	 * @param	int	number of characters
+	 * @param	string	$type	type of random string.  basic, alpha, alnum, numeric, nozero, md5 and sha1
+	 * @param	int	$len	number of characters
 	 * @return	string
 	 */
 	function random_string($type = 'alnum', $len = 8)
@@ -216,9 +216,9 @@ if ( ! function_exists('increment_string'))
 	/**
 	 * Add's _1 to a string or increment the ending number to allow _2, _3, etc
 	 *
-	 * @param	string	required
-	 * @param	string	What should the duplicate number be appended with
-	 * @param	string	Which number should be used for the first dupe increment
+	 * @param	string	$str	required
+	 * @param	string	$separator	What should the duplicate number be appended with
+	 * @param	string	$first	Which number should be used for the first dupe increment
 	 * @return	string
 	 */
 	function increment_string($str, $separator = '_', $first = 1)
@@ -237,7 +237,7 @@ if ( ! function_exists('alternator'))
 	 *
 	 * Allows strings to be alternated. See docs...
 	 *
-	 * @param	string (as many parameters as needed)
+	 * @param	string ... (as many parameters as needed)
 	 * @return	string
 	 */
 	function alternator()

--- a/system/helpers/text_helper.php
+++ b/system/helpers/text_helper.php
@@ -57,9 +57,9 @@ if ( ! function_exists('word_limiter'))
 	 *
 	 * Limits a string to X number of words.
 	 *
-	 * @param	string
-	 * @param	int
-	 * @param	string	the end character. Usually an ellipsis
+	 * @param	string	$str
+	 * @param	int	$limit
+	 * @param	string	$end_char	the end character. Usually an ellipsis
 	 * @return	string
 	 */
 	function word_limiter($str, $limit = 100, $end_char = '&#8230;')
@@ -90,9 +90,9 @@ if ( ! function_exists('character_limiter'))
 	 * Limits the string based on the character count.  Preserves complete words
 	 * so the character count may not be exactly as specified.
 	 *
-	 * @param	string
-	 * @param	int
-	 * @param	string	the end character. Usually an ellipsis
+	 * @param	string	$str
+	 * @param	int	$n
+	 * @param	string	$end_char	the end character. Usually an ellipsis
 	 * @return	string
 	 */
 	function character_limiter($str, $n = 500, $end_char = '&#8230;')
@@ -200,8 +200,8 @@ if ( ! function_exists('entities_to_ascii'))
 	 *
 	 * Converts character entities back to ASCII
 	 *
-	 * @param	string
-	 * @param	bool
+	 * @param	string	$str
+	 * @param	bool	$all
 	 * @return	string
 	 */
 	function entities_to_ascii($str, $all = TRUE)
@@ -257,9 +257,9 @@ if ( ! function_exists('word_censor'))
 	 * matched words will be converted to #### or to the replacement
 	 * word you've submitted.
 	 *
-	 * @param	string	the text string
-	 * @param	string	the array of censored words
-	 * @param	string	the optional replacement value
+	 * @param	string	$str	the text string
+	 * @param	string	$censored	the array of censored words
+	 * @param	string	$replacement	the optional replacement value
 	 * @return	string
 	 */
 	function word_censor($str, $censored, $replacement = '')
@@ -317,7 +317,7 @@ if ( ! function_exists('highlight_code'))
 	 *
 	 * Colorizes code strings
 	 *
-	 * @param	string	the text string
+	 * @param	string	$str	the text string
 	 * @return	string
 	 */
 	function highlight_code($str)
@@ -534,10 +534,10 @@ if ( ! function_exists('ellipsize'))
 	 *
 	 * This function will strip tags from a string, split it at its max_length and ellipsize
 	 *
-	 * @param	string	string to ellipsize
-	 * @param	int	max length of string
-	 * @param	mixed	int (1|0) or float, .5, .2, etc for position to split
-	 * @param	string	ellipsis ; Default '...'
+	 * @param	string	$str	string to ellipsize
+	 * @param	int	$max_length	max length of string
+	 * @param	mixed	$position	int (1|0) or float, .5, .2, etc for position to split
+	 * @param	string	$ellipsis	ellipsis ; Default '...'
 	 * @return	string	ellipsized string
 	 */
 	function ellipsize($str, $max_length, $position = 1, $ellipsis = '&hellip;')

--- a/system/helpers/typography_helper.php
+++ b/system/helpers/typography_helper.php
@@ -55,7 +55,7 @@ if ( ! function_exists('nl2br_except_pre'))
 	/**
 	 * Convert newlines to HTML line breaks except within PRE tags
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	string
 	 */
 	function nl2br_except_pre($str)
@@ -94,8 +94,8 @@ if ( ! function_exists('entity_decode'))
 	 *
 	 * This function is a replacement for html_entity_decode()
 	 *
-	 * @param	string
-	 * @param	string
+	 * @param	string	$str
+	 * @param	string	$charset
 	 * @return	string
 	 */
 	function entity_decode($str, $charset = NULL)

--- a/system/helpers/url_helper.php
+++ b/system/helpers/url_helper.php
@@ -151,9 +151,9 @@ if ( ! function_exists('anchor'))
 	 *
 	 * Creates an anchor based on the local URL.
 	 *
-	 * @param	string	the URL
-	 * @param	string	the link title
-	 * @param	mixed	any attributes
+	 * @param	string	$uri	the URL
+	 * @param	string	$title	the link title
+	 * @param	mixed	$attributes	any attributes
 	 * @return	string
 	 */
 	function anchor($uri = '', $title = '', $attributes = '')
@@ -188,9 +188,9 @@ if ( ! function_exists('anchor_popup'))
 	 * Creates an anchor based on the local URL. The link
 	 * opens a new window based on the attributes specified.
 	 *
-	 * @param	string	the URL
-	 * @param	string	the link title
-	 * @param	mixed	any attributes
+	 * @param	string	$uri	the URL
+	 * @param	string	$title	the link title
+	 * @param	mixed	$attributes	any attributes
 	 * @return	string
 	 */
 	function anchor_popup($uri = '', $title = '', $attributes = FALSE)
@@ -246,9 +246,9 @@ if ( ! function_exists('mailto'))
 	/**
 	 * Mailto Link
 	 *
-	 * @param	string	the email address
-	 * @param	string	the link title
-	 * @param	mixed	any attributes
+	 * @param	string	$email	the email address
+	 * @param	string	$title	the link title
+	 * @param	mixed	$attributes	any attributes
 	 * @return	string
 	 */
 	function mailto($email, $title = '', $attributes = '')
@@ -273,9 +273,9 @@ if ( ! function_exists('safe_mailto'))
 	 *
 	 * Create a spam-protected mailto link written in Javascript
 	 *
-	 * @param	string	the email address
-	 * @param	string	the link title
-	 * @param	mixed	any attributes
+	 * @param	string	$email	the email address
+	 * @param	string	$title	the link title
+	 * @param	mixed	$attributes	any attributes
 	 * @return	string
 	 */
 	function safe_mailto($email, $title = '', $attributes = '')
@@ -386,9 +386,9 @@ if ( ! function_exists('auto_link'))
 	 * URLs or emails that end in a period. We'll strip these
 	 * off and add them after the link.
 	 *
-	 * @param	string	the string
-	 * @param	string	the type: email, url, or both
-	 * @param	bool	whether to create pop-up links
+	 * @param	string	$str	the string
+	 * @param	string	$type	the type: email, url, or both
+	 * @param	bool	$popup	whether to create pop-up links
 	 * @return	string
 	 */
 	function auto_link($str, $type = 'both', $popup = FALSE)
@@ -439,7 +439,7 @@ if ( ! function_exists('prep_url'))
 	 *
 	 * Simply adds the http:// part if no scheme is included
 	 *
-	 * @param	string	the URL
+	 * @param	string	$str	the URL
 	 * @return	string
 	 */
 	function prep_url($str = '')

--- a/system/helpers/xml_helper.php
+++ b/system/helpers/xml_helper.php
@@ -55,8 +55,8 @@ if ( ! function_exists('xml_convert'))
 	/**
 	 * Convert Reserved XML characters to Entities
 	 *
-	 * @param	string
-	 * @param	bool
+	 * @param	string	$str
+	 * @param	bool	$protect_all
 	 * @return	string
 	 */
 	function xml_convert($str, $protect_all = FALSE)

--- a/system/libraries/Cache/drivers/Cache_apc.php
+++ b/system/libraries/Cache/drivers/Cache_apc.php
@@ -73,7 +73,7 @@ class CI_Cache_apc extends CI_Driver {
 	 * Look for a value in the cache. If it exists, return the data
 	 * if not, return FALSE
 	 *
-	 * @param	string
+	 * @param	string	$id
 	 * @return	mixed	value that is stored/FALSE on failure
 	 */
 	public function get($id)
@@ -105,7 +105,7 @@ class CI_Cache_apc extends CI_Driver {
 	/**
 	 * Delete from Cache
 	 *
-	 * @param	mixed	unique identifier of the item in the cache
+	 * @param	mixed	$id	unique identifier of the item in the cache
 	 * @return	bool	true on success/false on failure
 	 */
 	public function delete($id)
@@ -158,7 +158,7 @@ class CI_Cache_apc extends CI_Driver {
 	/**
 	 * Cache Info
 	 *
-	 * @param	string	user/filehits
+	 * @param	string	$type	user/filehits
 	 * @return	mixed	array on success, false on failure
 	 */
 	public function cache_info($type = NULL)
@@ -171,7 +171,7 @@ class CI_Cache_apc extends CI_Driver {
 	/**
 	 * Get Cache Metadata
 	 *
-	 * @param	mixed	key to get cache metadata on
+	 * @param	mixed	$id	key to get cache metadata on
 	 * @return	mixed	array on success/false on failure
 	 */
 	public function get_metadata($id)

--- a/system/libraries/Cache/drivers/Cache_apcu.php
+++ b/system/libraries/Cache/drivers/Cache_apcu.php
@@ -71,7 +71,7 @@ class CI_Cache_apcu extends CI_Driver {
 	 * Look for a value in the cache. If it exists, return the data
 	 * if not, return FALSE
 	 *
-	 * @param	string
+	 * @param	string	$id
 	 * @return	mixed	value that is stored/FALSE on failure
 	 */
 	public function get($id)
@@ -116,7 +116,7 @@ class CI_Cache_apcu extends CI_Driver {
 	/**
 	 * Delete from Cache
 	 *
-	 * @param	mixed	unique identifier of the item in the cache
+	 * @param	mixed	$id	unique identifier of the item in the cache
 	 * @return	bool	true on success/false on failure
 	 */
 	public function delete($id)
@@ -181,7 +181,7 @@ class CI_Cache_apcu extends CI_Driver {
 	/**
 	 * Get Cache Metadata
 	 *
-	 * @param	mixed	key to get cache metadata on
+	 * @param	mixed	$id	key to get cache metadata on
 	 * @return	mixed	array on success/false on failure
 	 */
 	public function get_metadata($id)

--- a/system/libraries/Cache/drivers/Cache_dummy.php
+++ b/system/libraries/Cache/drivers/Cache_dummy.php
@@ -54,7 +54,7 @@ class CI_Cache_dummy extends CI_Driver {
 	 *
 	 * Since this is the dummy class, it's always going to return FALSE.
 	 *
-	 * @param	string
+	 * @param	string	$id
 	 * @return	bool	FALSE
 	 */
 	public function get($id)
@@ -67,10 +67,10 @@ class CI_Cache_dummy extends CI_Driver {
 	/**
 	 * Cache Save
 	 *
-	 * @param	string	Unique Key
-	 * @param	mixed	Data to store
-	 * @param	int	Length of time (in seconds) to cache the data
-	 * @param	bool	Whether to store the raw value
+	 * @param	string	$id	Unique Key
+	 * @param	mixed	$data	Data to store
+	 * @param	int	$ttl	Length of time (in seconds) to cache the data
+	 * @param	bool	$raw	Whether to store the raw value
 	 * @return	bool	TRUE, Simulating success
 	 */
 	public function save($id, $data, $ttl = 60, $raw = FALSE)
@@ -83,7 +83,7 @@ class CI_Cache_dummy extends CI_Driver {
 	/**
 	 * Delete from Cache
 	 *
-	 * @param	mixed	unique identifier of the item in the cache
+	 * @param	mixed	$id	unique identifier of the item in the cache
 	 * @return	bool	TRUE, simulating success
 	 */
 	public function delete($id)
@@ -136,7 +136,7 @@ class CI_Cache_dummy extends CI_Driver {
 	/**
 	 * Cache Info
 	 *
-	 * @param	string	user/filehits
+	 * @param	string	$type	user/filehits
 	 * @return	bool	FALSE
 	 */
 	public function cache_info($type = NULL)
@@ -149,7 +149,7 @@ class CI_Cache_dummy extends CI_Driver {
 	/**
 	 * Get Cache Metadata
 	 *
-	 * @param	mixed	key to get cache metadata on
+	 * @param	mixed	$id	key to get cache metadata on
 	 * @return	bool	FALSE
 	 */
 	public function get_metadata($id)

--- a/system/libraries/Cache/drivers/Cache_file.php
+++ b/system/libraries/Cache/drivers/Cache_file.php
@@ -116,7 +116,7 @@ class CI_Cache_file extends CI_Driver {
 	/**
 	 * Delete from Cache
 	 *
-	 * @param	mixed	unique identifier of item in cache
+	 * @param	mixed	$id	unique identifier of item in cache
 	 * @return	bool	true on success/false on failure
 	 */
 	public function delete($id)
@@ -199,7 +199,7 @@ class CI_Cache_file extends CI_Driver {
 	 *
 	 * Not supported by file-based caching
 	 *
-	 * @param	string	user/filehits
+	 * @param	string	$type	user/filehits
 	 * @return	mixed	FALSE
 	 */
 	public function cache_info($type = NULL)
@@ -212,7 +212,7 @@ class CI_Cache_file extends CI_Driver {
 	/**
 	 * Get Cache Metadata
 	 *
-	 * @param	mixed	key to get cache metadata on
+	 * @param	mixed	$id	key to get cache metadata on
 	 * @return	mixed	FALSE on failure, array on success.
 	 */
 	public function get_metadata($id)

--- a/system/libraries/Cache/drivers/Cache_wincache.php
+++ b/system/libraries/Cache/drivers/Cache_wincache.php
@@ -109,7 +109,7 @@ class CI_Cache_wincache extends CI_Driver {
 	/**
 	 * Delete from Cache
 	 *
-	 * @param	mixed	unique identifier of the item in the cache
+	 * @param	mixed	$id	unique identifier of the item in the cache
 	 * @return	bool	true on success/false on failure
 	 */
 	public function delete($id)
@@ -180,7 +180,7 @@ class CI_Cache_wincache extends CI_Driver {
 	/**
 	 * Get Cache Metadata
 	 *
-	 * @param	mixed	key to get cache metadata on
+	 * @param	mixed	$id	key to get cache metadata on
 	 * @return	mixed	array on success/false on failure
 	 */
 	public function get_metadata($id)

--- a/system/libraries/Calendar.php
+++ b/system/libraries/Calendar.php
@@ -145,7 +145,7 @@ class CI_Calendar {
 	 *
 	 * Accepts an associative array as input, containing display preferences
 	 *
-	 * @param	array	config preferences
+	 * @param	array	$config config preferences
 	 * @return	CI_Calendar
 	 */
 	public function initialize($config = array())
@@ -172,9 +172,9 @@ class CI_Calendar {
 	/**
 	 * Generate the calendar
 	 *
-	 * @param	int	the year
-	 * @param	int	the month
-	 * @param	array	the data to be shown in the calendar cells
+	 * @param	int	$year	the year
+	 * @param	int	$month	the month
+	 * @param	array	$data	the data to be shown in the calendar cells
 	 * @return	string
 	 */
 	public function generate($year = '', $month = '', $data = array())
@@ -348,7 +348,7 @@ class CI_Calendar {
 	 * Generates a textual month name based on the numeric
 	 * month provided.
 	 *
-	 * @param	int	the month
+	 * @param	int	$month	the month
 	 * @return	string
 	 */
 	public function get_month_name($month)
@@ -375,7 +375,7 @@ class CI_Calendar {
 	 * Returns an array of day names (Sunday, Monday, etc.) based
 	 * on the type. Options: long, short, abr
 	 *
-	 * @param	string
+	 * @param	string	$day_type
 	 * @return	array
 	 */
 	public function get_day_names($day_type = '')
@@ -416,8 +416,8 @@ class CI_Calendar {
 	 * For example, if you submit 13 as the month, the year will
 	 * increment and the month will become January.
 	 *
-	 * @param	int	the month
-	 * @param	int	the year
+	 * @param	int	$month	the month
+	 * @param	int	$year	the year
 	 * @return	array
 	 */
 	public function adjust_date($month, $year)
@@ -452,8 +452,8 @@ class CI_Calendar {
 	/**
 	 * Total days in a given month
 	 *
-	 * @param	int	the month
-	 * @param	int	the year
+	 * @param	int	$month	the month
+	 * @param	int	$year	the year
 	 * @return	int
 	 */
 	public function get_total_days($month, $year)

--- a/system/libraries/Driver.php
+++ b/system/libraries/Driver.php
@@ -50,6 +50,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  * @author		EllisLab Dev Team
  * @link
  */
+#[AllowDynamicProperties]
 class CI_Driver_Library {
 
 	/**

--- a/system/libraries/Driver.php
+++ b/system/libraries/Driver.php
@@ -73,7 +73,7 @@ class CI_Driver_Library {
 	 * The first time a child is used it won't exist, so we instantiate it
 	 * subsequents calls will go straight to the proper child.
 	 *
-	 * @param	string	Child class name
+	 * @param	string	$child	Child class name
 	 * @return	object	Child class
 	 */
 	public function __get($child)
@@ -87,7 +87,7 @@ class CI_Driver_Library {
 	 *
 	 * Separate load_driver call to support explicit driver load by library or user
 	 *
-	 * @param	string	Driver name (w/o parent prefix)
+	 * @param	string	$child	Driver name (w/o parent prefix)
 	 * @return	object	Child class
 	 */
 	public function load_driver($child)
@@ -243,7 +243,7 @@ class CI_Driver {
 	 *
 	 * Decorates the child with the parent driver lib's methods and properties
 	 *
-	 * @param	object
+	 * @param	object	$parent
 	 * @return	void
 	 */
 	public function decorate($parent)
@@ -290,8 +290,8 @@ class CI_Driver {
 	 *
 	 * Handles access to the parent driver library's methods
 	 *
-	 * @param	string
-	 * @param	array
+	 * @param	string	$method
+	 * @param	array	$args
 	 * @return	mixed
 	 */
 	public function __call($method, $args = array())
@@ -311,7 +311,7 @@ class CI_Driver {
 	 *
 	 * Handles reading of the parent driver library's properties
 	 *
-	 * @param	string
+	 * @param	string	$var
 	 * @return	mixed
 	 */
 	public function __get($var)
@@ -329,8 +329,8 @@ class CI_Driver {
 	 *
 	 * Handles writing to the parent driver library's properties
 	 *
-	 * @param	string
-	 * @param	array
+	 * @param	string	$var
+	 * @param	array	$val
 	 * @return	mixed
 	 */
 	public function __set($var, $val)

--- a/system/libraries/Email.php
+++ b/system/libraries/Email.php
@@ -435,7 +435,7 @@ class CI_Email {
 	/**
 	 * Initialize the Email Data
 	 *
-	 * @param	bool
+	 * @param	bool	$clear_attachments
 	 * @return	CI_Email
 	 */
 	public function clear($clear_attachments = FALSE)
@@ -515,8 +515,8 @@ class CI_Email {
 	/**
 	 * Set Reply-to
 	 *
-	 * @param	string
-	 * @param	string
+	 * @param	string	$replyto
+	 * @param	string	$name
 	 * @return	CI_Email
 	 */
 	public function reply_to($replyto, $name = '')
@@ -556,7 +556,7 @@ class CI_Email {
 	/**
 	 * Set Recipients
 	 *
-	 * @param	string
+	 * @param	string	$to
 	 * @return	CI_Email
 	 */
 	public function to($to)
@@ -584,7 +584,7 @@ class CI_Email {
 	/**
 	 * Set CC
 	 *
-	 * @param	string
+	 * @param	string	$cc
 	 * @return	CI_Email
 	 */
 	public function cc($cc)
@@ -611,8 +611,8 @@ class CI_Email {
 	/**
 	 * Set BCC
 	 *
-	 * @param	string
-	 * @param	string
+	 * @param	string	$bcc
+	 * @param	string	$limit
 	 * @return	CI_Email
 	 */
 	public function bcc($bcc, $limit = '')
@@ -647,7 +647,7 @@ class CI_Email {
 	/**
 	 * Set Email Subject
 	 *
-	 * @param	string
+	 * @param	string	$subject
 	 * @return	CI_Email
 	 */
 	public function subject($subject)
@@ -662,7 +662,7 @@ class CI_Email {
 	/**
 	 * Set Body
 	 *
-	 * @param	string
+	 * @param	string	$body
 	 * @return	CI_Email
 	 */
 	public function message($body)
@@ -748,8 +748,8 @@ class CI_Email {
 	/**
 	 * Add a Header Item
 	 *
-	 * @param	string
-	 * @param	string
+	 * @param	string	$header
+	 * @param	string	$value
 	 * @return	CI_Email
 	 */
 	public function set_header($header, $value)
@@ -763,7 +763,7 @@ class CI_Email {
 	/**
 	 * Convert a String to an Array
 	 *
-	 * @param	string
+	 * @param	string	$email
 	 * @return	array
 	 */
 	protected function _str_to_array($email)
@@ -783,7 +783,7 @@ class CI_Email {
 	/**
 	 * Set Multipart Value
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	CI_Email
 	 */
 	public function set_alt_message($str)
@@ -797,7 +797,7 @@ class CI_Email {
 	/**
 	 * Set Mailtype
 	 *
-	 * @param	string
+	 * @param	string	$type
 	 * @return	CI_Email
 	 */
 	public function set_mailtype($type = 'text')
@@ -811,7 +811,7 @@ class CI_Email {
 	/**
 	 * Set Wordwrap
 	 *
-	 * @param	bool
+	 * @param	bool	$wordwrap
 	 * @return	CI_Email
 	 */
 	public function set_wordwrap($wordwrap = TRUE)
@@ -825,7 +825,7 @@ class CI_Email {
 	/**
 	 * Set Protocol
 	 *
-	 * @param	string
+	 * @param	string	$protocol
 	 * @return	CI_Email
 	 */
 	public function set_protocol($protocol = 'mail')
@@ -839,7 +839,7 @@ class CI_Email {
 	/**
 	 * Set Priority
 	 *
-	 * @param	int
+	 * @param	int	$n
 	 * @return	CI_Email
 	 */
 	public function set_priority($n = 3)
@@ -853,7 +853,7 @@ class CI_Email {
 	/**
 	 * Set Newline Character
 	 *
-	 * @param	string
+	 * @param	string	$newline
 	 * @return	CI_Email
 	 */
 	public function set_newline($newline = "\n")
@@ -867,7 +867,7 @@ class CI_Email {
 	/**
 	 * Set CRLF
 	 *
-	 * @param	string
+	 * @param	string	$crlf
 	 * @return	CI_Email
 	 */
 	public function set_crlf($crlf = "\n")
@@ -980,7 +980,7 @@ class CI_Email {
 	/**
 	 * Validate Email Address
 	 *
-	 * @param	string
+	 * @param	string	$email
 	 * @return	bool
 	 */
 	public function validate_email($email)
@@ -1008,7 +1008,7 @@ class CI_Email {
 	/**
 	 * Email Validation
 	 *
-	 * @param	string
+	 * @param	string	$email
 	 * @return	bool
 	 */
 	public function valid_email($email)
@@ -1033,7 +1033,7 @@ class CI_Email {
 	/**
 	 * Clean Extended Email Address: Joe Smith <joe@smith.com>
 	 *
-	 * @param	string
+	 * @param	string	$email
 	 * @return	string
 	 */
 	public function clean_email($email)
@@ -1095,8 +1095,8 @@ class CI_Email {
 	/**
 	 * Word Wrap
 	 *
-	 * @param	string
-	 * @param	int	line-length limit
+	 * @param	string	$str
+	 * @param	int	$charlim	line-length limit
 	 * @return	string
 	 */
 	public function word_wrap($str, $charlim = NULL)
@@ -1470,7 +1470,7 @@ class CI_Email {
 	 * Prepares string for Quoted-Printable Content-Transfer-Encoding
 	 * Refer to RFC 2045 https://www.ietf.org/rfc/rfc2045.txt
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	string
 	 */
 	protected function _prep_quoted_printable($str)
@@ -1578,7 +1578,7 @@ class CI_Email {
 	 * It's related but not identical to quoted-printable, so it has its
 	 * own method.
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	string
 	 */
 	protected function _prep_q_encoding($str)
@@ -2072,8 +2072,8 @@ class CI_Email {
 	/**
 	 * Send SMTP command
 	 *
-	 * @param	string
-	 * @param	string
+	 * @param	string	$cmd
+	 * @param	string	$data
 	 * @return	bool
 	 */
 	protected function _send_command($cmd, $data = '')
@@ -2348,7 +2348,7 @@ class CI_Email {
 	/**
 	 * Mime Types
 	 *
-	 * @param	string
+	 * @param	string	$ext
 	 * @return	string
 	 */
 	protected function _mime_types($ext = '')

--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -280,8 +280,8 @@ class CI_Form_validation {
 	 * Lets users set their own error messages on the fly. Note:
 	 * The key name has to match the function name that it corresponds to.
 	 *
-	 * @param	array
-	 * @param	string
+	 * @param	array	$lang
+	 * @param	string	$val
 	 * @return	CI_Form_validation
 	 */
 	public function set_message($lang, $val = '')
@@ -302,8 +302,8 @@ class CI_Form_validation {
 	 *
 	 * Permits a prefix/suffix to be added to each error message
 	 *
-	 * @param	string
-	 * @param	string
+	 * @param	string	$prefix
+	 * @param	string	$suffix
 	 * @return	CI_Form_validation
 	 */
 	public function set_error_delimiters($prefix = '<p>', $suffix = '</p>')
@@ -366,8 +366,8 @@ class CI_Form_validation {
 	 *
 	 * Returns the error messages as a string, wrapped in the error delimiters
 	 *
-	 * @param	string
-	 * @param	string
+	 * @param	string	$prefix
+	 * @param	string	$suffix
 	 * @return	string
 	 */
 	public function error_string($prefix = '', $suffix = '')
@@ -557,9 +557,9 @@ class CI_Form_validation {
 	/**
 	 * Traverse a multidimensional $_POST array index until the data is found
 	 *
-	 * @param	array
-	 * @param	array
-	 * @param	int
+	 * @param	array	$array
+	 * @param	array	$keys
+	 * @param	int	$i
 	 * @return	mixed
 	 */
 	protected function _reduce_array($array, $keys, $i = 0)
@@ -618,10 +618,10 @@ class CI_Form_validation {
 	/**
 	 * Executes the Validation routines
 	 *
-	 * @param	array
-	 * @param	array
-	 * @param	mixed
-	 * @param	int
+	 * @param	array	$row
+	 * @param	array	$rules
+	 * @param	mixed	$postdata
+	 * @param	int	$cycles
 	 * @return	mixed
 	 */
 	protected function _execute($row, $rules, $postdata = NULL, $cycles = 0)
@@ -861,7 +861,7 @@ class CI_Form_validation {
 	/**
 	 * Translate a field name
 	 *
-	 * @param	string	the field name
+	 * @param	string	$fieldname	the field name
 	 * @return	string
 	 */
 	protected function _translate_fieldname($fieldname)
@@ -881,9 +881,9 @@ class CI_Form_validation {
 	/**
 	 * Build an error message using the field and param.
 	 *
-	 * @param	string	The error message line
-	 * @param	string	A field's human name
-	 * @param	mixed	A rule's optional parameter
+	 * @param	string	$line	The error message line
+	 * @param	string	$field	A field's human name
+	 * @param	mixed	$param	A rule's optional parameter
 	 * @return	string
 	 */
 	protected function _build_error_msg($line, $field = '', $param = '')
@@ -904,7 +904,7 @@ class CI_Form_validation {
 	 *
 	 * Permits you to check if a rule is present within the validator
 	 *
-	 * @param	string	the field name
+	 * @param	string	$field	the field name
 	 * @return	bool
 	 */
 	public function has_rule($field)
@@ -920,8 +920,8 @@ class CI_Form_validation {
 	 * Permits you to repopulate a form field with the value it was submitted
 	 * with, or, if that value doesn't exist, with the default
 	 *
-	 * @param	string	the field name
-	 * @param	string
+	 * @param	string	$field	the field name
+	 * @param	string	$default
 	 * @return	string
 	 */
 	public function set_value($field = '', $default = '')
@@ -949,9 +949,9 @@ class CI_Form_validation {
 	 * Enables pull-down lists to be set to the value the user
 	 * selected in the event of an error
 	 *
-	 * @param	string
-	 * @param	string
-	 * @param	bool
+	 * @param	string	$field
+	 * @param	string	$value
+	 * @param	bool	$default
 	 * @return	string
 	 */
 	public function set_select($field = '', $value = '', $default = FALSE)
@@ -992,9 +992,9 @@ class CI_Form_validation {
 	 * Enables radio buttons to be set to the value the user
 	 * selected in the event of an error
 	 *
-	 * @param	string
-	 * @param	string
-	 * @param	bool
+	 * @param	string	$field
+	 * @param	string	$value
+	 * @param	bool	$default
 	 * @return	string
 	 */
 	public function set_radio($field = '', $value = '', $default = FALSE)
@@ -1035,9 +1035,9 @@ class CI_Form_validation {
 	 * Enables checkboxes to be set to the value the user
 	 * selected in the event of an error
 	 *
-	 * @param	string
-	 * @param	string
-	 * @param	bool
+	 * @param	string	$field
+	 * @param	string	$value
+	 * @param	bool	$default
 	 * @return	string
 	 */
 	public function set_checkbox($field = '', $value = '', $default = FALSE)
@@ -1051,7 +1051,7 @@ class CI_Form_validation {
 	/**
 	 * Required
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	bool
 	 */
 	public function required($str)
@@ -1066,8 +1066,8 @@ class CI_Form_validation {
 	/**
 	 * Performs a Regular Expression match test.
 	 *
-	 * @param	string
-	 * @param	string	regex
+	 * @param	string	$str
+	 * @param	string	$regex
 	 * @return	bool
 	 */
 	public function regex_match($str, $regex)
@@ -1096,8 +1096,8 @@ class CI_Form_validation {
 	/**
 	 * Differs from another field
 	 *
-	 * @param	string
-	 * @param	string	field
+	 * @param	string	$str
+	 * @param	string	$field
 	 * @return	bool
 	 */
 	public function differs($str, $field)
@@ -1130,8 +1130,8 @@ class CI_Form_validation {
 	/**
 	 * Minimum Length
 	 *
-	 * @param	string
-	 * @param	string
+	 * @param	string	$str
+	 * @param	string	$val
 	 * @return	bool
 	 */
 	public function min_length($str, $val)
@@ -1149,8 +1149,8 @@ class CI_Form_validation {
 	/**
 	 * Max Length
 	 *
-	 * @param	string
-	 * @param	string
+	 * @param	string	$str
+	 * @param	string	$val
 	 * @return	bool
 	 */
 	public function max_length($str, $val)
@@ -1168,8 +1168,8 @@ class CI_Form_validation {
 	/**
 	 * Exact Length
 	 *
-	 * @param	string
-	 * @param	string
+	 * @param	string	$str
+	 * @param	string	$val
 	 * @return	bool
 	 */
 	public function exact_length($str, $val)
@@ -1233,7 +1233,7 @@ class CI_Form_validation {
 	/**
 	 * Valid Email
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	bool
 	 */
 	public function valid_email($str)
@@ -1258,7 +1258,7 @@ class CI_Form_validation {
 	/**
 	 * Valid Emails
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	bool
 	 */
 	public function valid_emails($str)
@@ -1284,8 +1284,8 @@ class CI_Form_validation {
 	/**
 	 * Validate IP Address
 	 *
-	 * @param	string
-	 * @param	string	'ipv4' or 'ipv6' to validate a specific IP format
+	 * @param	string	$ip
+	 * @param	string	$which	'ipv4' or 'ipv6' to validate a specific IP format
 	 * @return	bool
 	 */
 	public function valid_ip($ip, $which = '')
@@ -1323,7 +1323,7 @@ class CI_Form_validation {
 	/**
 	 * Alpha
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	bool
 	 */
 	public function alpha($str)
@@ -1336,7 +1336,7 @@ class CI_Form_validation {
 	/**
 	 * Alpha-numeric
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	bool
 	 */
 	public function alpha_numeric($str)
@@ -1349,7 +1349,7 @@ class CI_Form_validation {
 	/**
 	 * Alpha-numeric w/ spaces
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	bool
 	 */
 	public function alpha_numeric_spaces($str)
@@ -1362,7 +1362,7 @@ class CI_Form_validation {
 	/**
 	 * Alpha-numeric with underscores and dashes
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	bool
 	 */
 	public function alpha_dash($str)
@@ -1375,7 +1375,7 @@ class CI_Form_validation {
 	/**
 	 * Numeric
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	bool
 	 */
 	public function numeric($str)
@@ -1389,7 +1389,7 @@ class CI_Form_validation {
 	/**
 	 * Integer
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	bool
 	 */
 	public function integer($str)
@@ -1402,7 +1402,7 @@ class CI_Form_validation {
 	/**
 	 * Decimal number
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	bool
 	 */
 	public function decimal($str)
@@ -1415,8 +1415,8 @@ class CI_Form_validation {
 	/**
 	 * Greater than
 	 *
-	 * @param	string
-	 * @param	int
+	 * @param	string	$str
+	 * @param	int	$min
 	 * @return	bool
 	 */
 	public function greater_than($str, $min)
@@ -1429,8 +1429,8 @@ class CI_Form_validation {
 	/**
 	 * Equal to or Greater than
 	 *
-	 * @param	string
-	 * @param	int
+	 * @param	string	$str
+	 * @param	int	$min
 	 * @return	bool
 	 */
 	public function greater_than_equal_to($str, $min)
@@ -1443,8 +1443,8 @@ class CI_Form_validation {
 	/**
 	 * Less than
 	 *
-	 * @param	string
-	 * @param	int
+	 * @param	string	$str
+	 * @param	int	$max
 	 * @return	bool
 	 */
 	public function less_than($str, $max)
@@ -1457,8 +1457,8 @@ class CI_Form_validation {
 	/**
 	 * Equal to or Less than
 	 *
-	 * @param	string
-	 * @param	int
+	 * @param	string	$str
+	 * @param	int	$max
 	 * @return	bool
 	 */
 	public function less_than_equal_to($str, $max)
@@ -1471,8 +1471,8 @@ class CI_Form_validation {
 	/**
 	 * Value should be within an array of values
 	 *
-	 * @param	string
-	 * @param	string
+	 * @param	string	$value
+	 * @param	string	$list
 	 * @return	bool
 	 */
 	public function in_list($value, $list)
@@ -1485,7 +1485,7 @@ class CI_Form_validation {
 	/**
 	 * Is a Natural number  (0,1,2,3, etc.)
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	bool
 	 */
 	public function is_natural($str)
@@ -1498,7 +1498,7 @@ class CI_Form_validation {
 	/**
 	 * Is a Natural number, but not a zero  (1,2,3, etc.)
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	bool
 	 */
 	public function is_natural_no_zero($str)
@@ -1514,7 +1514,7 @@ class CI_Form_validation {
 	 * Tests a string for characters outside of the Base64 alphabet
 	 * as defined by RFC 2045 http://www.faqs.org/rfcs/rfc2045
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	bool
 	 */
 	public function valid_base64($str)
@@ -1527,7 +1527,7 @@ class CI_Form_validation {
 	/**
 	 * Prep URL
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	string
 	 */
 	public function prep_url($str = '')
@@ -1545,7 +1545,7 @@ class CI_Form_validation {
 	/**
 	 * Strip Image Tags
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	string
 	 */
 	public function strip_image_tags($str)
@@ -1558,7 +1558,7 @@ class CI_Form_validation {
 	/**
 	 * Convert PHP tags to entities
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	string
 	 */
 	public function encode_php_tags($str)

--- a/system/libraries/Image_lib.php
+++ b/system/libraries/Image_lib.php
@@ -79,6 +79,13 @@ class CI_Image_lib {
 	public $source_image		= '';
 
 	/**
+	 * Path to destination image
+	 *
+	 * @var string
+	 */
+	public $dest_image		= '';
+
+	/**
 	 * Path to the modified image
 	 *
 	 * @var string

--- a/system/libraries/Image_lib.php
+++ b/system/libraries/Image_lib.php
@@ -462,7 +462,7 @@ class CI_Image_lib {
 	/**
 	 * initialize image preferences
 	 *
-	 * @param	array
+	 * @param	array	$props
 	 * @return	bool
 	 */
 	public function initialize($props = array())
@@ -754,7 +754,7 @@ class CI_Image_lib {
 	 *
 	 * This function will resize or crop
 	 *
-	 * @param	string
+	 * @param	string	$action
 	 * @return	bool
 	 */
 	public function image_process_gd($action = 'resize')
@@ -858,7 +858,7 @@ class CI_Image_lib {
 	 *
 	 * This function will resize, crop or rotate
 	 *
-	 * @param	string
+	 * @param	string	$action
 	 * @return	bool
 	 */
 	public function image_process_imagemagick($action = 'resize')
@@ -928,7 +928,7 @@ class CI_Image_lib {
 	 *
 	 * This function will resize, crop or rotate
 	 *
-	 * @param	string
+	 * @param	string	$action
 	 * @return	bool
 	 */
 	public function image_process_netpbm($action = 'resize')
@@ -1442,8 +1442,8 @@ class CI_Image_lib {
 	 * This simply creates an image resource handle
 	 * based on the type of image being processed
 	 *
-	 * @param	string
-	 * @param	string
+	 * @param	string	$path
+	 * @param	string	$image_type
 	 * @return	resource
 	 */
 	public function image_create_gd($path = '', $image_type = '')
@@ -1506,7 +1506,7 @@ class CI_Image_lib {
 	 * Takes an image resource as input and writes the file
 	 * to the specified destination
 	 *
-	 * @param	resource
+	 * @param	resource	$resource
 	 * @return	bool
 	 */
 	public function image_save_gd($resource)
@@ -1579,7 +1579,7 @@ class CI_Image_lib {
 	/**
 	 * Dynamically outputs an image
 	 *
-	 * @param	resource
+	 * @param	resource	$resource
 	 * @return	void
 	 */
 	public function image_display_gd($resource)
@@ -1675,8 +1675,8 @@ class CI_Image_lib {
 	 *
 	 * A helper function that gets info about the file
 	 *
-	 * @param	string
-	 * @param	bool
+	 * @param	string	$path
+	 * @param	bool	$return
 	 * @return	mixed
 	 */
 	public function get_image_properties($path = '', $return = FALSE)
@@ -1741,7 +1741,7 @@ class CI_Image_lib {
 	 *			'new_height'	=> ''
 	 *		);
 	 *
-	 * @param	array
+	 * @param	array	$vals
 	 * @return	array
 	 */
 	public function size_calculator($vals)
@@ -1790,7 +1790,7 @@ class CI_Image_lib {
 	 * $array['ext']  = '.jpg';
 	 * $array['name'] = 'my.cool';
 	 *
-	 * @param	array
+	 * @param	string	$source_image
 	 * @return	array
 	 */
 	public function explode_name($source_image)
@@ -1844,7 +1844,7 @@ class CI_Image_lib {
 	/**
 	 * Set error message
 	 *
-	 * @param	string
+	 * @param	string	$msg
 	 * @return	void
 	 */
 	public function set_error($msg)
@@ -1874,8 +1874,8 @@ class CI_Image_lib {
 	/**
 	 * Show error messages
 	 *
-	 * @param	string
-	 * @param	string
+	 * @param	string	$open
+	 * @param	string	$close
 	 * @return	string
 	 */
 	public function display_errors($open = '<p>', $close = '</p>')

--- a/system/libraries/Parser.php
+++ b/system/libraries/Parser.php
@@ -91,9 +91,9 @@ class CI_Parser {
 	 * Parses pseudo-variables contained in the specified template view,
 	 * replacing them with the data in the second param
 	 *
-	 * @param	string
-	 * @param	array
-	 * @param	bool
+	 * @param	string	$template
+	 * @param	array	$data
+	 * @param	bool	$return
 	 * @return	string
 	 */
 	public function parse($template, $data, $return = FALSE)
@@ -111,9 +111,9 @@ class CI_Parser {
 	 * Parses pseudo-variables contained in the specified string,
 	 * replacing them with the data in the second param
 	 *
-	 * @param	string
-	 * @param	array
-	 * @param	bool
+	 * @param	string	$template
+	 * @param	array	$data
+	 * @param	bool	$return
 	 * @return	string
 	 */
 	public function parse_string($template, $data, $return = FALSE)
@@ -129,9 +129,9 @@ class CI_Parser {
 	 * Parses pseudo-variables contained in the specified template,
 	 * replacing them with the data in the second param
 	 *
-	 * @param	string
-	 * @param	array
-	 * @param	bool
+	 * @param	string	$template
+	 * @param	array	$data
+	 * @param	bool	$return
 	 * @return	string
 	 */
 	protected function _parse($template, $data, $return = FALSE)
@@ -168,8 +168,8 @@ class CI_Parser {
 	/**
 	 * Set the left/right variable delimiters
 	 *
-	 * @param	string
-	 * @param	string
+	 * @param	string	$l
+	 * @param	string	$r
 	 * @return	void
 	 */
 	public function set_delimiters($l = '{', $r = '}')
@@ -183,9 +183,9 @@ class CI_Parser {
 	/**
 	 * Parse a single key/value
 	 *
-	 * @param	string
-	 * @param	string
-	 * @param	string
+	 * @param	string	$key
+	 * @param	string	$val
+	 * @param	string	$string
 	 * @return	string
 	 */
 	protected function _parse_single($key, $val, $string)
@@ -200,9 +200,9 @@ class CI_Parser {
 	 *
 	 * Parses tag pairs: {some_tag} string... {/some_tag}
 	 *
-	 * @param	string
-	 * @param	array
-	 * @param	string
+	 * @param	string	$variable
+	 * @param	array	$data
+	 * @param	string	$string
 	 * @return	string
 	 */
 	protected function _parse_pair($variable, $data, $string)

--- a/system/libraries/Session/Session.php
+++ b/system/libraries/Session/Session.php
@@ -1019,7 +1019,7 @@ class CI_Session {
 	 *
 	 * Legacy CI_Session compatibility method
 	 *
-	 * @param	mixed	$data	Session data key(s)
+	 * @param	mixed	$key	Session data key(s)
 	 * @return	void
 	 */
 	public function unset_tempdata($key)

--- a/system/libraries/Session/drivers/Session_database_driver.php
+++ b/system/libraries/Session/drivers/Session_database_driver.php
@@ -350,7 +350,7 @@ class CI_Session_database_driver extends CI_Session_driver implements CI_Session
 	 * Update session timestamp without modifying data
 	 *
 	 * @param	string	$id	Session ID
-	 * @param	string	$data	Unknown & unused
+	 * @param	string	$unknown	Unknown & unused
 	 * @return	bool
 	 */
 	public function updateTimestamp($id, $unknown)

--- a/system/libraries/Session/drivers/Session_files_driver.php
+++ b/system/libraries/Session/drivers/Session_files_driver.php
@@ -406,7 +406,7 @@ class CI_Session_files_driver extends CI_Session_driver implements CI_Session_dr
 	 * Update session timestamp without modifying data
 	 *
 	 * @param	string	$id	Session ID
-	 * @param	string	$data	Unknown & unused
+	 * @param	string	$unknown	Unknown & unused
 	 * @return	bool
 	 */
 	public function updateTimestamp($id, $unknown)

--- a/system/libraries/Session/drivers/Session_memcached_driver.php
+++ b/system/libraries/Session/drivers/Session_memcached_driver.php
@@ -301,7 +301,7 @@ class CI_Session_memcached_driver extends CI_Session_driver implements CI_Sessio
 	 * Update session timestamp without modifying data
 	 *
 	 * @param	string	$id	Session ID
-	 * @param	string	$data	Unknown & unused
+	 * @param	string	$unknown	Unknown & unused
 	 * @return	bool
 	 */
 	public function updateTimestamp($id, $unknown)

--- a/system/libraries/Session/drivers/Session_redis_driver.php
+++ b/system/libraries/Session/drivers/Session_redis_driver.php
@@ -387,7 +387,7 @@ class CI_Session_redis_driver extends CI_Session_driver implements CI_Session_dr
 	 * Update session timestamp without modifying data
 	 *
 	 * @param	string	$id	Session ID
-	 * @param	string	$data	Unknown & unused
+	 * @param	string	$unknown	Unknown & unused
 	 * @return	bool
 	 */
 	public function updateTimestamp($id, $unknown)

--- a/system/libraries/Table.php
+++ b/system/libraries/Table.php
@@ -150,7 +150,7 @@ class CI_Table {
 	 *
 	 * Can be passed as an array or discreet params
 	 *
-	 * @param	mixed
+	 * @param	mixed	$args
 	 * @return	CI_Table
 	 */
 	public function set_heading($args = array())
@@ -230,7 +230,7 @@ class CI_Table {
 	 *
 	 * Can be passed as an array or discreet params
 	 *
-	 * @param	mixed
+	 * @param	mixed	$args
 	 * @return	CI_Table
 	 */
 	public function add_row($args = array())
@@ -246,7 +246,7 @@ class CI_Table {
 	 *
 	 * Ensures a standard associative array format for all cell data
 	 *
-	 * @param	array
+	 * @param	array	$args
 	 * @return	array
 	 */
 	protected function _prep_args($args)

--- a/system/libraries/Table.php
+++ b/system/libraries/Table.php
@@ -490,12 +490,12 @@ class CI_Table {
 			return;
 		}
 
-		$this->temp = $this->_default_template();
+		$temp = $this->_default_template();
 		foreach (array('table_open', 'thead_open', 'thead_close', 'heading_row_start', 'heading_row_end', 'heading_cell_start', 'heading_cell_end', 'tbody_open', 'tbody_close', 'row_start', 'row_end', 'cell_start', 'cell_end', 'row_alt_start', 'row_alt_end', 'cell_alt_start', 'cell_alt_end', 'table_close') as $val)
 		{
 			if ( ! isset($this->template[$val]))
 			{
-				$this->template[$val] = $this->temp[$val];
+				$this->template[$val] = $temp[$val];
 			}
 		}
 	}

--- a/system/libraries/Trackback.php
+++ b/system/libraries/Trackback.php
@@ -112,7 +112,7 @@ class CI_Trackback {
 	/**
 	 * Send Trackback
 	 *
-	 * @param	array
+	 * @param	array	$tb_data
 	 * @return	bool
 	 */
 	public function send($tb_data)
@@ -235,7 +235,7 @@ class CI_Trackback {
 	 * sends the "incomplete information" error, as that's
 	 * the most common one.
 	 *
-	 * @param	string
+	 * @param	string	$message
 	 * @return	void
 	 */
 	public function send_error($message = 'Incomplete Information')
@@ -263,7 +263,7 @@ class CI_Trackback {
 	/**
 	 * Fetch a particular item
 	 *
-	 * @param	string
+	 * @param	string	$item
 	 * @return	string
 	 */
 	public function data($item)
@@ -279,8 +279,8 @@ class CI_Trackback {
 	 * Opens a socket connection and passes the data to
 	 * the server. Returns TRUE on success, FALSE on failure
 	 *
-	 * @param	string
-	 * @param	string
+	 * @param	string	$url
+	 * @param	string	$data
 	 * @return	bool
 	 */
 	public function process($url, $data)
@@ -342,7 +342,7 @@ class CI_Trackback {
 	 * It takes a string of URLs (separated by comma or
 	 * space) and puts each URL into an array
 	 *
-	 * @param	string
+	 * @param	string	$urls
 	 * @return	string
 	 */
 	public function extract_urls($urls)
@@ -364,7 +364,7 @@ class CI_Trackback {
 	 *
 	 * Simply adds "http://" if missing
 	 *
-	 * @param	string
+	 * @param	string	$url
 	 * @return	void
 	 */
 	public function validate_url(&$url)
@@ -382,7 +382,7 @@ class CI_Trackback {
 	/**
 	 * Find the Trackback URL's ID
 	 *
-	 * @param	string
+	 * @param	string	$url
 	 * @return	string
 	 */
 	public function get_id($url)
@@ -423,7 +423,7 @@ class CI_Trackback {
 	/**
 	 * Convert Reserved XML characters to Entities
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	string
 	 */
 	public function convert_xml($str)
@@ -446,9 +446,9 @@ class CI_Trackback {
 	 *
 	 * Limits the string based on the character count. Will preserve complete words.
 	 *
-	 * @param	string
-	 * @param	int
-	 * @param	string
+	 * @param	string	$str
+	 * @param	int	$n
+	 * @param	string	$end_char
 	 * @return	string
 	 */
 	public function limit_characters($str, $n = 500, $end_char = '&#8230;')
@@ -484,7 +484,7 @@ class CI_Trackback {
 	 * Converts Hight ascii text and MS Word special chars
 	 * to character entities
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	string
 	 */
 	public function convert_ascii($str)
@@ -531,7 +531,7 @@ class CI_Trackback {
 	/**
 	 * Set error message
 	 *
-	 * @param	string
+	 * @param	string	$msg
 	 * @return	void
 	 */
 	public function set_error($msg)
@@ -545,8 +545,8 @@ class CI_Trackback {
 	/**
 	 * Show error messages
 	 *
-	 * @param	string
-	 * @param	string
+	 * @param	string	$open
+	 * @param	string	$close
 	 * @return	string
 	 */
 	public function display_errors($open = '<p>', $close = '</p>')

--- a/system/libraries/Typography.php
+++ b/system/libraries/Typography.php
@@ -102,8 +102,8 @@ class CI_Typography {
 	 *	- Converts double dashes into em-dashes.
 	 *  - Converts two spaces into entities
 	 *
-	 * @param	string
-	 * @param	bool	whether to reduce more then two consecutive newlines to two
+	 * @param	string	$str
+	 * @param	bool	$reduce_linebreaks	whether to reduce more then two consecutive newlines to two
 	 * @return	string
 	 */
 	public function auto_typography($str, $reduce_linebreaks = FALSE)
@@ -288,7 +288,7 @@ class CI_Typography {
 	 * to curly entities, but it also converts em-dashes,
 	 * double spaces, and ampersands
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	string
 	 */
 	public function format_characters($str)
@@ -351,7 +351,7 @@ class CI_Typography {
 	 *
 	 * Converts newline characters into either <p> tags or <br />
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	string
 	 */
 	protected function _format_newlines($str)
@@ -391,7 +391,7 @@ class CI_Typography {
 	 * and we don't want double dashes converted to emdash entities, so they are marked with {@DD}
 	 * likewise double spaces are converted to {@NBS} to prevent entity conversion
 	 *
-	 * @param	array
+	 * @param	array	$match
 	 * @return	string
 	 */
 	protected function _protect_characters($match)
@@ -404,7 +404,7 @@ class CI_Typography {
 	/**
 	 * Convert newlines to HTML line breaks except within PRE tags
 	 *
-	 * @param	string
+	 * @param	string	$str
 	 * @return	string
 	 */
 	public function nl2br_except_pre($str)

--- a/system/libraries/Unit_test.php
+++ b/system/libraries/Unit_test.php
@@ -253,7 +253,7 @@ class CI_Unit_test {
 	 *
 	 * Enables/disables unit testing
 	 *
-	 * @param	bool
+	 * @param	bool	$state
 	 * @return	void
 	 */
 	public function active($state = TRUE)
@@ -315,7 +315,7 @@ class CI_Unit_test {
 	 *
 	 * This lets us set the template to be used to display results
 	 *
-	 * @param	string
+	 * @param	string	$template
 	 * @return	void
 	 */
 	public function set_template($template)

--- a/system/libraries/Xmlrpc.php
+++ b/system/libraries/Xmlrpc.php
@@ -964,7 +964,7 @@ class XML_RPC_Response
 	/**
 	 * XML-RPC Object to PHP Types
 	 *
-	 * @param	object
+	 * @param	object	$xmlrpc_val
 	 * @return	array
 	 */
 	public function xmlrpc_decoder($xmlrpc_val)
@@ -1006,8 +1006,8 @@ class XML_RPC_Response
 	/**
 	 * ISO-8601 time to server or UTC time
 	 *
-	 * @param	string
-	 * @param	bool
+	 * @param	string	$time
+	 * @param	bool	$utc
 	 * @return	int	unix timestamp
 	 */
 	public function iso8601_decode($time, $utc = FALSE)
@@ -1114,7 +1114,7 @@ class XML_RPC_Message extends CI_Xmlrpc
 	/**
 	 * Parse External XML-RPC Server's Response
 	 *
-	 * @param	resource
+	 * @param	resource	$fp
 	 * @return	object
 	 */
 	public function parseResponse($fp)
@@ -1273,8 +1273,8 @@ class XML_RPC_Message extends CI_Xmlrpc
 	/**
 	 * Start Element Handler
 	 *
-	 * @param	string
-	 * @param	string
+	 * @param	string	$the_parser
+	 * @param	string	$name
 	 * @return	void
 	 */
 	public function open_tag($the_parser, $name)
@@ -1374,8 +1374,8 @@ class XML_RPC_Message extends CI_Xmlrpc
 	/**
 	 * End Element Handler
 	 *
-	 * @param	string
-	 * @param	string
+	 * @param	string	$the_parser
+	 * @param	string	$name
 	 * @return	void
 	 */
 	public function closing_tag($the_parser, $name)
@@ -1508,8 +1508,8 @@ class XML_RPC_Message extends CI_Xmlrpc
 	/**
 	 * Parse character data
 	 *
-	 * @param	string
-	 * @param	string
+	 * @param	string	$the_parser
+	 * @param	string	$data
 	 * @return	void
 	 */
 	public function character_data($the_parser, $data)
@@ -1540,7 +1540,7 @@ class XML_RPC_Message extends CI_Xmlrpc
 	/**
 	 * Add parameter
 	 *
-	 * @param	mixed
+	 * @param	mixed	$par
 	 * @return	void
 	 */
 	public function addParam($par)
@@ -1603,7 +1603,7 @@ class XML_RPC_Message extends CI_Xmlrpc
 	/**
 	 * Decode message
 	 *
-	 * @param	object
+	 * @param	object	$param
 	 * @return	mixed
 	 */
 	public function decode_message($param)
@@ -1703,8 +1703,8 @@ class XML_RPC_Values extends CI_Xmlrpc
 	/**
 	 * Add scalar value
 	 *
-	 * @param	scalar
-	 * @param	string
+	 * @param	scalar	$val
+	 * @param	string	$type
 	 * @return	int
 	 */
 	public function addScalar($val, $type = 'string')
@@ -1750,7 +1750,7 @@ class XML_RPC_Values extends CI_Xmlrpc
 	/**
 	 * Add array value
 	 *
-	 * @param	array
+	 * @param	array	$vals
 	 * @return	int
 	 */
 	public function addArray($vals)
@@ -1771,7 +1771,7 @@ class XML_RPC_Values extends CI_Xmlrpc
 	/**
 	 * Add struct value
 	 *
-	 * @param	object
+	 * @param	object	$vals
 	 * @return	int
 	 */
 	public function addStruct($vals)
@@ -1809,8 +1809,8 @@ class XML_RPC_Values extends CI_Xmlrpc
 	/**
 	 * Serialize data
 	 *
-	 * @param	string
-	 * @param	mixed
+	 * @param	string	$typ
+	 * @param	mixed	$val
 	 * @return	string
 	 */
 	public function serializedata($typ, $val)
@@ -1879,7 +1879,7 @@ class XML_RPC_Values extends CI_Xmlrpc
 	/**
 	 * Serialize value
 	 *
-	 * @param	object
+	 * @param	object	$o
 	 * @return	string
 	 */
 	public function serializeval($o)
@@ -1907,8 +1907,8 @@ class XML_RPC_Values extends CI_Xmlrpc
 	 * Encode time in ISO-8601 form.
 	 * Useful for sending time in XML-RPC
 	 *
-	 * @param	int	unix timestamp
-	 * @param	bool
+	 * @param	int	$time	unix timestamp
+	 * @param	bool	$utc
 	 * @return	string
 	 */
 	public function iso8601_encode($time, $utc = FALSE)

--- a/system/libraries/Xmlrpcs.php
+++ b/system/libraries/Xmlrpcs.php
@@ -113,7 +113,7 @@ class CI_Xmlrpcs extends CI_Xmlrpc {
 	/**
 	 * Initialize Prefs and Serve
 	 *
-	 * @param	mixed
+	 * @param	mixed	$config
 	 * @return	void
 	 */
 	public function initialize($config = array())
@@ -190,10 +190,10 @@ class CI_Xmlrpcs extends CI_Xmlrpc {
 	/**
 	 * Add Method to Class
 	 *
-	 * @param	string	method name
-	 * @param	string	function
-	 * @param	string	signature
-	 * @param	string	docstring
+	 * @param	string	$methodname	method name
+	 * @param	string	$function	function
+	 * @param	string	$sig	signature
+	 * @param	string	$doc	docstring
 	 * @return	void
 	 */
 	public function add_to_map($methodname, $function, $sig, $doc)
@@ -210,7 +210,7 @@ class CI_Xmlrpcs extends CI_Xmlrpc {
 	/**
 	 * Parse Server Request
 	 *
-	 * @param	string	data
+	 * @param	string	$data	data
 	 * @return	object	xmlrpc response
 	 */
 	public function parseRequest($data = '')
@@ -311,7 +311,7 @@ class CI_Xmlrpcs extends CI_Xmlrpc {
 	/**
 	 * Executes the Method
 	 *
-	 * @param	object
+	 * @param	object	$m
 	 * @return	mixed
 	 */
 	protected function _execute($m)
@@ -415,7 +415,7 @@ class CI_Xmlrpcs extends CI_Xmlrpc {
 	/**
 	 * Server Function: List Methods
 	 *
-	 * @param	mixed
+	 * @param	mixed	$m
 	 * @return	object
 	 */
 	public function listMethods($m)
@@ -442,7 +442,7 @@ class CI_Xmlrpcs extends CI_Xmlrpc {
 	/**
 	 * Server Function: Return Signature for Method
 	 *
-	 * @param	mixed
+	 * @param	mixed	$m
 	 * @return	object
 	 */
 	public function methodSignature($m)
@@ -482,7 +482,7 @@ class CI_Xmlrpcs extends CI_Xmlrpc {
 	/**
 	 * Server Function: Doc String for Method
 	 *
-	 * @param	mixed
+	 * @param	mixed	$m
 	 * @return	object
 	 */
 	public function methodHelp($m)
@@ -505,7 +505,7 @@ class CI_Xmlrpcs extends CI_Xmlrpc {
 	/**
 	 * Server Function: Multi-call
 	 *
-	 * @param	mixed
+	 * @param	mixed	$m
 	 * @return	object
 	 */
 	public function multicall($m)
@@ -546,7 +546,7 @@ class CI_Xmlrpcs extends CI_Xmlrpc {
 	/**
 	 * Multi-call Function: Error Handling
 	 *
-	 * @param	mixed
+	 * @param	mixed	$err
 	 * @return	object
 	 */
 	public function multicall_error($err)
@@ -565,7 +565,7 @@ class CI_Xmlrpcs extends CI_Xmlrpc {
 	/**
 	 * Multi-call Function: Processes method
 	 *
-	 * @param	mixed
+	 * @param	mixed	$call
 	 * @return	object
 	 */
 	public function do_multicall($call)

--- a/tests/codeigniter/core/Loader_test.php
+++ b/tests/codeigniter/core/Loader_test.php
@@ -125,7 +125,7 @@ class Loader_test extends CI_TestCase {
 		// Create library in VFS
 		$lib = 'unit_test_config_lib';
 		$class = 'CI_'.ucfirst($lib);
-		$content = '<?php class '.$class.' { public function __construct($params) { $this->config = $params; } }';
+		$content = "<?php \n#[AllowDynamicProperties]\nclass ".$class.' { public function __construct($params) { $this->config = $params; } }';
 		$this->ci_vfs_create(ucfirst($lib), $content, $this->ci_base_root, 'libraries');
 
 		// Create config file

--- a/tests/codeigniter/libraries/Upload_test.php
+++ b/tests/codeigniter/libraries/Upload_test.php
@@ -59,9 +59,6 @@ class Upload_test extends CI_TestCase {
 		$data = array(
 				'file_name'		=> 'hello.txt',
 				'file_type'		=> 'text/plain',
-				'file_path'		=> '/tmp/',
-				'full_path'		=> '/tmp/hello.txt',
-				'raw_name'		=> 'hello',
 				'orig_name'		=> 'hello.txt',
 				'client_name'		=> '',
 				'file_ext'		=> '.txt',
@@ -79,6 +76,10 @@ class Upload_test extends CI_TestCase {
 		{
 			$this->upload->{$k}	= $v;
 		}
+
+		$data['file_path'] = '/tmp/';
+		$data['full_path'] = '/tmp/hello.txt';
+		$data['raw_name'] = 'hello';
 
 		$this->assertEquals('hello.txt', $this->upload->data('file_name'));
 		$this->assertEquals($data, $this->upload->data());

--- a/tests/mocks/ci_testcase.php
+++ b/tests/mocks/ci_testcase.php
@@ -1,5 +1,6 @@
 <?php
 
+#[AllowDynamicProperties]
 class CI_TestCase extends \PHPUnit\Framework\TestCase {
 
 	public $ci_vfs_root;


### PR DESCRIPTION
This pull request includes all of the changes in pull request [Adding PHP 8.2 support](https://github.com/bcit-ci/CodeIgniter/pull/6173) by @gxgpet, but applied to the latest develop branch of CI3 as of this writing, [a6faab](https://github.com/bcit-ci/CodeIgniter/commit/a6faab2ebf082eefff9c2422fce016e49da548bf). I think one of gxgpet's commits has my name attached to it because git was complaining about commits with a private email address.

I have also made changes to reduce the number of complaints by PHPStan from about 1830 to about 560. Anyone who wants to check the PHPStan scan of this PR can do so by running this from the command line on a machine with PHP 8.2.3. It works for me on both Ubuntu and MacOS. NOTE that this phpstan config excludes the `tests` and `user_guide_src` from analysis.

```bash
# make a dir
mkdir ci3-pr
cd ci3-pr
# fetch sneakyimp PR source
curl -o ci.zip https://codeload.github.com/sneakyimp/CodeIgniter/zip/refs/heads/develop
unzip ci.zip
mv CodeIgniter-develop codeigniter
rm ci.zip
# install composer
php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
php -r "if (hash_file('sha384', 'composer-setup.php') === '55ce33d7678c5a611085589f1f3ddf8b3c52d662cd01d4ba75c0ee0459970c2200a51f492d557530c71c15d8dba01eae') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
php composer-setup.php
php -r "unlink('composer-setup.php');"
# user composer to install phpstan
./composer.phar require --dev phpstan/phpstan
# create a ci.neon config file for phpstan
echo -e "parameters:" >> ci.neon
echo -e "\tlevel: 2" >> ci.neon
echo -e "\tpaths:" >> ci.neon
echo -e "\t\t- codeigniter" >> ci.neon
echo -e "\texcludePaths:" >> ci.neon
echo -e "\t\tanalyse:" >> ci.neon
echo -e "\t\t\t- codeigniter/tests" >> ci.neon
echo -e "\t\t\t- codeigniter/user_guide_src" >> ci.neon
# clear the phpstan cache, if any
vendor/bin/phpstan clear-result-cache -c ci.neon
# run the phpstan analysis
vendor/bin/phpstan analyse -c ci.neon > phpstan.txt
```
This downloads my fork into a subdir, **ci3-pr**, and runs phpstan on it via composer. You can inspect the file ci3-pr/phpstan.txt for the results:
```bash
tail ci3-pr/phpstan.txt
```

The most significant source code hange is worth describing specifically. CI3 has [awkwardly declared the CI_DB class inside a conditional](https://github.com/bcit-ci/CodeIgniter/blob/3378180483140fa9251e50843bda15a508e85e89/system/database/DB.php#L151) that is inside the function `DB()` defined in `system/database/DB.php`:
```php
	require_once(BASEPATH.'database/DB_driver.php');
	require_once(BASEPATH.'database/DB_query_builder.php');
	if ( ! class_exists('CI_DB', FALSE))
	{
		/**
		 * CI_DB
		 *
		 * Acts as an alias for both CI_DB_driver and CI_DB_query_builder.
		 *
		 * @see	CI_DB_query_builder
		 * @see	CI_DB_driver
		 */
		class CI_DB extends CI_DB_query_builder {}
	}
```
I can see no reason for this class to be declared in this strange way. Examining the code base, the file system/database/DB.php will only ever be included/required once in `system/core/Loader.php` or `tests/mocks/database/db.php` so it's entirely safe to put those require_once statements and the CI_DB class declaration at the beginning of the file. It will not be included/required twice, and the DB() function will be more efficient without that conditional being evaluated every time. This also eliminates a vast number of phpstan complaints as described above.

Aside from this possibly significant change, **the vast majority of changes I have made are simply to fix bad phpdoc parameter declarations.** I have also changed a couple of phpdoc `@var` declarations. There are one or two changes to actual variables described below.

To further the goal of PHP 8.2 compatibility, I ran phpstan on my code and looked for all the ‘undefined property’ errors. I think they have all been addressed. See below for explanations as to why I think we have handled the various remaining errors.

`system/core/Input.php`
  281    Access to an undefined property CI_Input::$raw_input_stream.
This class defines a protected $_raw_input_stream and also a __get method. The intent seems to be to set this value at the last possible moment or something. I don’t think it’ll cause a problem but not sure how to get rid of the phpstan error.

`system/core/Loader.php`
  403    Access to an undefined property CI_Controller::$db.
  438    Access to an undefined property CI_Controller::$dbutil
  465    Access to an undefined property object::$dbdriver.
  465    Access to an undefined property object::$dbdriver.
  469    Access to an undefined property object::$dbdriver.
  482    Access to an undefined property CI_Controller::$dbforge.
  694    Access to an undefined property CI_Controller::$lang.
  713    Access to an undefined property CI_Controller::$config.
  1016   Access to an undefined property CI_Controller::$output.
The CI_Controller class declaration is preceded by the #[AllowDynamicProperties] attribute so these should be fine. NOTE that most of these complaints could probably be eliminated by simply declaring public $db in CI_Controller as a suitable CI_DB type.


`system/core/Output.php`
  523    Access to an undefined property CI_Controller::$profiler.
  528    Access to an undefined property CI_Controller::$profiler.
  561    Access to an undefined property CI_Controller::$config.
  570    Access to an undefined property CI_Controller::$config.
  571    Access to an undefined property CI_Controller::$config.
  572    Access to an undefined property CI_Controller::$uri.
  574    Access to an undefined property CI_Controller::$config.
  740    Access to an undefined property CI_Controller::$config.
  754    Access to an undefined property CI_Controller::$uri.
  756    Access to an undefined property CI_Controller::$config.
  769    Access to an undefined property CI_Controller::$config.
  769    Access to an undefined property CI_Controller::$config.
The CI_Controller class declaration is preceded by the #[AllowDynamicProperties] attribute so these should be fine. We could probably eliminate *a lot more* phpstan errors if we simply added $config & $lang properties to the CI_Controller class.

`system/database/DB_driver.php`
  1480   Access to an undefined property CI_DB_driver::$qb_limit.
The abstract class CI_DB_driver is preceded by the #[AllowDynamicProperties] attribute so this should be fine

`system/database/DB_forge.php`
  474    Access to an undefined property object::$dbprefix.
  545    Access to an undefined property object::$dbprefix.
  548    Access to an undefined property object::$dbprefix.
OK these complaints are weird because other lines, including line 464 in the same function, also refers to $this->db->dbprefix without complaint. The DB object should probably have a dbprefix so perhaps we don’t need to worry about this. 🤷

`system/database/DB_utility.php`
  400    Access to an undefined property CI_Controller::$zip.
  401    Access to an undefined property CI_Controller::$zip.
The CI_Controller class declaration is preceded by the #[AllowDynamicProperties] attribute so these should be fine.
**NOTE: I see some type hinting parameter declarations in the functions csv_from_result and xml_from_result — this might be incompatible with PHP 5? I suggest we remove these.**

`system/database/drivers/ibase/ibase_forge.php`
  102    Access to an undefined property CI_DB_ibase_forge::$hostname.
  117    Access to an undefined property CI_DB_ibase_forge::$conn_id.
  123    Access to an undefined property object::$database.
I don’t know what to do about these. Other forge objects don’t seem to refer to hostname or conn_id. The $database is referenced on $this->db->database. I punt this to someone who know what ibase is.

`system/database/drivers/mysql/mysql_driver.php`
  157    Access to an undefined property CI_DB_mysql_driver::$db.
This looks like it was actually a bug, referring to $this->db->debug when it should have referred to $this->db_debug.

`system/database/drivers/mysqli/mysqli_driver.php`
  230    Access to an undefined property CI_DB_mysqli_driver::$db.
Another bug, referring to $this->db->db_debug when it should have just referred to $this->db_debug.

`system/database/drivers/pdo/pdo_result.php`
  146    Access to an undefined property CI_DB_pdo_result::$db.
  148    Access to an undefined property CI_DB_pdo_result::$db.
**These are actually bugs. This class has no db object nor any db_debug object. This still needs top be fixed.** Should we simply echo the stuff? Or not echo it? Throw an exception?

`system/database/drivers/pdo/subdrivers/pdo_firebird_forge.php`
  88     Access to an undefined property CI_DB_pdo_firebird_forge::$hostname.
  103    Access to an undefined property CI_DB_pdo_firebird_forge::$conn_id.
  109    Access to an undefined property object::$database.
As with the ibase_forge above, this reference to hostname or conn_id or database is not typical of CI3 forge classes. I don’t want to break this so I’ll avoid touching it.

`system/database/drivers/pdo/subdrivers/pdo_pgsql_forge.php`
  102    Access to an undefined property CI_DB_pdo_pgsql_forge::$create_table_if.
**This looks like a bug, a mistaken reference to $create_table_if instead of $_create_table_if. I have not touched it.**

`system/database/drivers/pdo/subdrivers/pdo_sqlite_forge.php`
  133    Access to an undefined property object::$database.
This class ultimately inherits $this->db from the class CI_DB_forge, which has $db declared as just an object. We might change this to CI_DB or perhaps CI_DB_query_builder or CI_DB_driver? 
```php
        /**
         * Database object
         *
         * @var object
         */
        protected $db;
```

`system/database/drivers/postgre/postgre_driver.php`
  162    Access to an undefined property CI_DB_postgre_driver::$db.
**This class CI_DB_postgre_driver extends CI_DB which extends CI_DB_query_builder which extends CI_DB_driver which has a db_debug property and none of these classes has a $db property, so I believe this is a mistake/bug. I have not fixed it because I am not currently able to test postgre, but I believe we should switch $this->db->db_debug to $this->db_debug**

`system/database/drivers/postgre/postgre_forge.php`
  90     Access to an undefined property CI_DB_postgre_forge::$create_table_if.
I believe this is a bug/mistaken and instead of $this->create_table_if, it should refer to this->_create_table_if

`system/database/drivers/sqlite3/sqlite3_forge.php`
  119    Access to an undefined property object::$database.
I believe this is safe, but we could probably eliminate this error by declaring a more specific type for the $db property of the CI_DB_forge class. Perhaps CI_DB?

`system/database/drivers/sqlsrv/sqlsrv_driver.php`
  300    Access to an undefined property CI_DB_sqlsrv_driver::$_escape_like_chr.
  300    Access to an undefined property CI_DB_sqlsrv_driver::$_escape_like_str.
**This looks like a bug/mistake. This is the only place in any CI file that refers to _escape_like_chr or _escape_like_str. I have not fixed this. I don’t know what the intent is here.**

`system/helpers/captcha_helper.php`
  197    Access to an undefined property CI_Controller::$security.
The CI_Controller class declaration is preceded by the #[AllowDynamicProperties] attribute so this should be fine.

`system/helpers/cookie_helper.php`
  74     Access to an undefined property CI_Controller::$input.
  92     Access to an undefined property CI_Controller::$input.
The CI_Controller class declaration is preceded by the #[AllowDynamicProperties] attribute so these should be fine.

`system/helpers/date_helper.php`
`system/helpers/download_helper.php`
`system/helpers/form_helper.php`
`system/helpers/html_helper.php`
`system/helpers/language_helper.php`
etc etc etc...tons of CI_Controller references should be fine because the CI_Controller class declaration is preceded by the #[AllowDynamicProperties] attribute so these should be fine. Again, we might want to add a $config and $lang property to CI_Controller class to eliminate a lot of these errors.

`system/libraries/Image_lib.php`
  558    Access to an undefined property CI_Image_lib::$dest_image.
  563    Access to an undefined property CI_Image_lib::$dest_image.
  571    Access to an undefined property CI_Image_lib::$dest_image.
  577    Access to an undefined property CI_Image_lib::$dest_image.
I added a $dest_image property in there to get rid of this error.

`system/libraries/Migration.php`
  145    Access to an undefined property CI_Migration::$lang.
  148    Access to an undefined property CI_Migration::$load.
  168    Access to an undefined property CI_Migration::$db.
  170    Access to an undefined property CI_Migration::$dbforge.
  174    Access to an undefined property CI_Migration::$dbforge.
  176    Access to an undefined property CI_Migration::$db.
  215    Access to an undefined property CI_Migration::$lang.
  276    Access to an undefined property CI_Migration::$lang.
  289    Access to an undefined property CI_Migration::$lang.
  294    Access to an undefined property CI_Migration::$lang.
  337    Access to an undefined property CI_Migration::$lang.
  396    Access to an undefined property CI_Migration::$lang.
  446    Access to an undefined property CI_Migration::$db.
  460    Access to an undefined property CI_Migration::$db.
This CI_Migration class has a magic __get method which looks in a CI_Controller for the requested value. This __get method could be improved to throw an exception if the value is not found, but think it’s OK.

`system/libraries/Profiler.php`
  521    Access to an undefined property object::$lang.
  521    Access to an undefined property object::$lang.
  521    Access to an undefined property object::$lang.
  521    Access to an undefined property object::$lang.
  521    Access to an undefined property object::$lang.
This all refer to the $CI controller singleton, which is dynamic, so should be OK? We could get rid of a LOT of these phpstan errors if we declared a $lang property on the CI_Controller class.

I look foward to any feedback and I truly hope my PR can be adopted promptly. I need to get some CI3 sites working with PHP 8.2.