### PR TITLE
Fix PHP 8.1 E_DEPRECATED issue when the page has no output.

### DIFF
--- a/system/core/Output.php
+++ b/system/core/Output.php
@@ -456,7 +456,7 @@ class CI_Output {
 
 		$elapsed = $BM->elapsed_time('total_execution_time_start', 'total_execution_time_end');
 
-		if ($this->parse_exec_vars === TRUE)
+		if ($this->parse_exec_vars === TRUE && !empty($output))
 		{
 			$memory	= round(memory_get_usage() / 1024 / 1024, 2).'MB';
 			$output = str_replace(array('{elapsed_time}', '{memory_usage}'), array($elapsed, $memory), $output);


### PR DESCRIPTION
At the moment, if a page doesn't use CI for output (e.g. sending a file's contents), an E_DEPRECATED will be triggered because $output is null:

```
str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated [path]/system/core/Output.php 462
```

This is a quick fix for that.

Note: The code seems to override the original $output with $this->final_output, which initially is a string, but isn't when it actually gets to that point. I didn't investigate that further, as there was no need, but it was surprising.

```
// Set the output data
if ($output === NULL)
{
    $output =& $this->final_output;
}
```