### PR TITLE
Fix tests with phpunit10

### DIFF
--- a/tests/codeigniter/core/Loader_test.php
+++ b/tests/codeigniter/core/Loader_test.php
@@ -36,7 +36,7 @@ class Loader_test extends CI_TestCase {
 		// Test loading as an array.
 		$this->assertInstanceOf('CI_Loader', $this->load->library(array($lib)));
 		$this->assertTrue(class_exists($class), $class.' does not exist');
-		$this->assertObjectHasAttribute($lib, $this->ci_obj);
+		$this->assertObjectHasProperty($lib, $this->ci_obj);
 		$this->assertInstanceOf($class, $this->ci_obj->$lib);
 
 		// Create library in VFS
@@ -88,21 +88,21 @@ class Loader_test extends CI_TestCase {
 		$this->assertInstanceOf('CI_Loader', $this->load->library($lib));
 		$this->assertTrue(class_exists($class), $class.' does not exist');
 		$this->assertTrue(class_exists($ext), $ext.' does not exist');
-		$this->assertObjectHasAttribute($name, $this->ci_obj);
+		$this->assertObjectHasProperty($name, $this->ci_obj);
 		$this->assertInstanceOf($class, $this->ci_obj->$name);
 		$this->assertInstanceOf($ext, $this->ci_obj->$name);
 
 		// Test reloading with object name
 		$obj = 'exttest';
 		$this->assertInstanceOf('CI_Loader', $this->load->library($lib, NULL, $obj));
-		$this->assertObjectHasAttribute($obj, $this->ci_obj);
+		$this->assertObjectHasProperty($obj, $this->ci_obj);
 		$this->assertInstanceOf($class, $this->ci_obj->$obj);
 		$this->assertInstanceOf($ext, $this->ci_obj->$obj);
 
 		// Test reloading
 		unset($this->ci_obj->$name);
 		$this->assertInstanceOf('CI_Loader', $this->load->library($lib));
-		$this->assertObjectHasAttribute($name, $this->ci_obj);
+		$this->assertObjectHasProperty($name, $this->ci_obj);
 
 		// Create baseless library
 		$name = 'ext_baseless_lib';
@@ -140,7 +140,7 @@ class Loader_test extends CI_TestCase {
 		$obj = 'testy';
 		$this->assertInstanceOf('CI_Loader', $this->load->library($lib, NULL, $obj));
 		$this->assertTrue(class_exists($class), $class.' does not exist');
-		$this->assertObjectHasAttribute($obj, $this->ci_obj);
+		$this->assertObjectHasProperty($obj, $this->ci_obj);
 		$this->assertInstanceOf($class, $this->ci_obj->$obj);
 		$this->assertEquals($cfg, $this->ci_obj->$obj->config);
 
@@ -172,7 +172,7 @@ class Loader_test extends CI_TestCase {
 
 		// Was the model class instantiated.
 		$this->assertTrue(class_exists($class), $class.' does not exist');
-		$this->assertObjectHasAttribute($lib, $this->ci_obj);
+		$this->assertObjectHasProperty($lib, $this->ci_obj);
 		$this->assertInstanceOf($class, $this->ci_obj->$lib);
 	}
 
@@ -193,13 +193,13 @@ class Loader_test extends CI_TestCase {
 		// Test loading as an array.
 		$this->assertInstanceOf('CI_Loader', $this->load->driver(array($driver)));
 		$this->assertTrue(class_exists($class), $class.' does not exist');
-		$this->assertObjectHasAttribute($driver, $this->ci_obj);
+		$this->assertObjectHasProperty($driver, $this->ci_obj);
 		$this->assertInstanceOf($class, $this->ci_obj->$driver);
 
 		// Test loading as a library with a name
 		$obj = 'testdrive';
 		$this->assertInstanceOf('CI_Loader', $this->load->library($driver, NULL, $obj));
-		$this->assertObjectHasAttribute($obj, $this->ci_obj);
+		$this->assertObjectHasProperty($obj, $this->ci_obj);
 		$this->assertInstanceOf($class, $this->ci_obj->$obj);
 
 		// Test a string given to params
@@ -222,7 +222,7 @@ class Loader_test extends CI_TestCase {
 
 		// Was the model class instantiated.
 		$this->assertTrue(class_exists($model));
-		$this->assertObjectHasAttribute($model, $this->ci_obj);
+		$this->assertObjectHasProperty($model, $this->ci_obj);
 
 		// Test no model given
 		$this->assertInstanceOf('CI_Loader', $this->load->model(''));
@@ -248,8 +248,8 @@ class Loader_test extends CI_TestCase {
 
 		// Was the model class instantiated?
 		$this->assertTrue(class_exists($model));
-		$this->assertObjectHasAttribute($name, $this->ci_obj);
-		$this->assertObjectHasAttribute($name, $this->ci_obj);
+		$this->assertObjectHasProperty($name, $this->ci_obj);
+		$this->assertObjectHasProperty($name, $this->ci_obj);
 		$this->assertInstanceOf($base, $this->ci_obj->$name);
 		$this->assertInstanceOf($model, $this->ci_obj->$name);
 
@@ -607,17 +607,17 @@ class Loader_test extends CI_TestCase {
 
 		// Verify library
 		$this->assertTrue(class_exists($lib_class), $lib_class.' does not exist');
-		$this->assertObjectHasAttribute($lib, $this->ci_obj);
+		$this->assertObjectHasProperty($lib, $this->ci_obj);
 		$this->assertInstanceOf($lib_class, $this->ci_obj->$lib);
 
 		// Verify driver
 		$this->assertTrue(class_exists($drv_class), $drv_class.' does not exist');
-		$this->assertObjectHasAttribute($drv, $this->ci_obj);
+		$this->assertObjectHasProperty($drv, $this->ci_obj);
 		$this->assertInstanceOf($drv_class, $this->ci_obj->$drv);
 
 		// Verify model
 		$this->assertTrue(class_exists($model), $model.' does not exist');
-		$this->assertObjectHasAttribute($model, $this->ci_obj);
+		$this->assertObjectHasProperty($model, $this->ci_obj);
 		$this->assertInstanceOf($model, $this->ci_obj->$model);
 
 		// Verify config calls

--- a/tests/codeigniter/core/Loader_test.php
+++ b/tests/codeigniter/core/Loader_test.php
@@ -322,7 +322,7 @@ class Loader_test extends CI_TestCase {
 		$this->assertEquals($content.'undefined', $out);
 
 		// Mock output class
-		$output = $this->getMockBuilder('CI_Output')->setMethods(array('append_output'))->getMock();
+		$output = $this->getMockBuilder('CI_Output')->onlyMethods(array('append_output'))->getMock();
 		$output->expects($this->once())->method('append_output')->with($content.$value);
 		$this->ci_instance_var('output', $output);
 
@@ -483,7 +483,7 @@ class Loader_test extends CI_TestCase {
 	{
 		// Mock lang class and test load call
 		$file = 'test';
-		$lang = $this->getMockBuilder('CI_Lang')->setMethods(array('load'))->getMock();
+		$lang = $this->getMockBuilder('CI_Lang')->onlyMethods(array('load'))->getMock();
 		$lang->expects($this->once())->method('load')->with($file);
 		$this->ci_instance_var('lang', $lang);
 		$this->assertInstanceOf('CI_Loader', $this->load->language($file));

--- a/tests/codeigniter/core/Loader_test.php
+++ b/tests/codeigniter/core/Loader_test.php
@@ -36,7 +36,7 @@ class Loader_test extends CI_TestCase {
 		// Test loading as an array.
 		$this->assertInstanceOf('CI_Loader', $this->load->library(array($lib)));
 		$this->assertTrue(class_exists($class), $class.' does not exist');
-		$this->assertObjectHasProperty($lib, $this->ci_obj);
+		$this->assertObjectHasAttribute($lib, $this->ci_obj);
 		$this->assertInstanceOf($class, $this->ci_obj->$lib);
 
 		// Create library in VFS
@@ -88,21 +88,21 @@ class Loader_test extends CI_TestCase {
 		$this->assertInstanceOf('CI_Loader', $this->load->library($lib));
 		$this->assertTrue(class_exists($class), $class.' does not exist');
 		$this->assertTrue(class_exists($ext), $ext.' does not exist');
-		$this->assertObjectHasProperty($name, $this->ci_obj);
+		$this->assertObjectHasAttribute($name, $this->ci_obj);
 		$this->assertInstanceOf($class, $this->ci_obj->$name);
 		$this->assertInstanceOf($ext, $this->ci_obj->$name);
 
 		// Test reloading with object name
 		$obj = 'exttest';
 		$this->assertInstanceOf('CI_Loader', $this->load->library($lib, NULL, $obj));
-		$this->assertObjectHasProperty($obj, $this->ci_obj);
+		$this->assertObjectHasAttribute($obj, $this->ci_obj);
 		$this->assertInstanceOf($class, $this->ci_obj->$obj);
 		$this->assertInstanceOf($ext, $this->ci_obj->$obj);
 
 		// Test reloading
 		unset($this->ci_obj->$name);
 		$this->assertInstanceOf('CI_Loader', $this->load->library($lib));
-		$this->assertObjectHasProperty($name, $this->ci_obj);
+		$this->assertObjectHasAttribute($name, $this->ci_obj);
 
 		// Create baseless library
 		$name = 'ext_baseless_lib';
@@ -140,7 +140,7 @@ class Loader_test extends CI_TestCase {
 		$obj = 'testy';
 		$this->assertInstanceOf('CI_Loader', $this->load->library($lib, NULL, $obj));
 		$this->assertTrue(class_exists($class), $class.' does not exist');
-		$this->assertObjectHasProperty($obj, $this->ci_obj);
+		$this->assertObjectHasAttribute($obj, $this->ci_obj);
 		$this->assertInstanceOf($class, $this->ci_obj->$obj);
 		$this->assertEquals($cfg, $this->ci_obj->$obj->config);
 
@@ -172,7 +172,7 @@ class Loader_test extends CI_TestCase {
 
 		// Was the model class instantiated.
 		$this->assertTrue(class_exists($class), $class.' does not exist');
-		$this->assertObjectHasProperty($lib, $this->ci_obj);
+		$this->assertObjectHasAttribute($lib, $this->ci_obj);
 		$this->assertInstanceOf($class, $this->ci_obj->$lib);
 	}
 
@@ -193,13 +193,13 @@ class Loader_test extends CI_TestCase {
 		// Test loading as an array.
 		$this->assertInstanceOf('CI_Loader', $this->load->driver(array($driver)));
 		$this->assertTrue(class_exists($class), $class.' does not exist');
-		$this->assertObjectHasProperty($driver, $this->ci_obj);
+		$this->assertObjectHasAttribute($driver, $this->ci_obj);
 		$this->assertInstanceOf($class, $this->ci_obj->$driver);
 
 		// Test loading as a library with a name
 		$obj = 'testdrive';
 		$this->assertInstanceOf('CI_Loader', $this->load->library($driver, NULL, $obj));
-		$this->assertObjectHasProperty($obj, $this->ci_obj);
+		$this->assertObjectHasAttribute($obj, $this->ci_obj);
 		$this->assertInstanceOf($class, $this->ci_obj->$obj);
 
 		// Test a string given to params
@@ -222,7 +222,7 @@ class Loader_test extends CI_TestCase {
 
 		// Was the model class instantiated.
 		$this->assertTrue(class_exists($model));
-		$this->assertObjectHasProperty($model, $this->ci_obj);
+		$this->assertObjectHasAttribute($model, $this->ci_obj);
 
 		// Test no model given
 		$this->assertInstanceOf('CI_Loader', $this->load->model(''));
@@ -248,8 +248,8 @@ class Loader_test extends CI_TestCase {
 
 		// Was the model class instantiated?
 		$this->assertTrue(class_exists($model));
-		$this->assertObjectHasProperty($name, $this->ci_obj);
-		$this->assertObjectHasProperty($name, $this->ci_obj);
+		$this->assertObjectHasAttribute($name, $this->ci_obj);
+		$this->assertObjectHasAttribute($name, $this->ci_obj);
 		$this->assertInstanceOf($base, $this->ci_obj->$name);
 		$this->assertInstanceOf($model, $this->ci_obj->$name);
 
@@ -607,17 +607,17 @@ class Loader_test extends CI_TestCase {
 
 		// Verify library
 		$this->assertTrue(class_exists($lib_class), $lib_class.' does not exist');
-		$this->assertObjectHasProperty($lib, $this->ci_obj);
+		$this->assertObjectHasAttribute($lib, $this->ci_obj);
 		$this->assertInstanceOf($lib_class, $this->ci_obj->$lib);
 
 		// Verify driver
 		$this->assertTrue(class_exists($drv_class), $drv_class.' does not exist');
-		$this->assertObjectHasProperty($drv, $this->ci_obj);
+		$this->assertObjectHasAttribute($drv, $this->ci_obj);
 		$this->assertInstanceOf($drv_class, $this->ci_obj->$drv);
 
 		// Verify model
 		$this->assertTrue(class_exists($model), $model.' does not exist');
-		$this->assertObjectHasProperty($model, $this->ci_obj);
+		$this->assertObjectHasAttribute($model, $this->ci_obj);
 		$this->assertInstanceOf($model, $this->ci_obj->$model);
 
 		// Verify config calls

--- a/tests/codeigniter/core/Loader_test.php
+++ b/tests/codeigniter/core/Loader_test.php
@@ -4,6 +4,8 @@ class Loader_test extends CI_TestCase {
 
 	private $ci_obj;
 
+	private $realAssertObjectHasProperty;
+
 	public function set_up()
 	{
 		// Instantiate a new loader
@@ -16,6 +18,12 @@ class Loader_test extends CI_TestCase {
 		// Set subclass prefix
 		$this->prefix = 'MY_';
 		$this->ci_set_config('subclass_prefix', $this->prefix);
+
+		// assertObjectHasAttribute() is deprecated and will be removed in PHPUnit 10.
+		// It was replaced by assertObjectHasProperty() in phpunit 10.1.0+
+		$this->realAssertObjectHasProperty = method_exists($this, 'assertObjectHasProperty')
+			? 'assertObjectHasProperty'
+			: 'assertObjectHasAttribute';
 	}
 
 	// --------------------------------------------------------------------
@@ -36,7 +44,7 @@ class Loader_test extends CI_TestCase {
 		// Test loading as an array.
 		$this->assertInstanceOf('CI_Loader', $this->load->library(array($lib)));
 		$this->assertTrue(class_exists($class), $class.' does not exist');
-		$this->assertObjectHasAttribute($lib, $this->ci_obj);
+		call_user_func_array(array($this, $this->realAssertObjectHasProperty), array($lib, $this->ci_obj));
 		$this->assertInstanceOf($class, $this->ci_obj->$lib);
 
 		// Create library in VFS
@@ -88,21 +96,21 @@ class Loader_test extends CI_TestCase {
 		$this->assertInstanceOf('CI_Loader', $this->load->library($lib));
 		$this->assertTrue(class_exists($class), $class.' does not exist');
 		$this->assertTrue(class_exists($ext), $ext.' does not exist');
-		$this->assertObjectHasAttribute($name, $this->ci_obj);
+		call_user_func_array(array($this, $this->realAssertObjectHasProperty), array($name, $this->ci_obj));
 		$this->assertInstanceOf($class, $this->ci_obj->$name);
 		$this->assertInstanceOf($ext, $this->ci_obj->$name);
 
 		// Test reloading with object name
 		$obj = 'exttest';
 		$this->assertInstanceOf('CI_Loader', $this->load->library($lib, NULL, $obj));
-		$this->assertObjectHasAttribute($obj, $this->ci_obj);
+		call_user_func_array(array($this, $this->realAssertObjectHasProperty), array($obj, $this->ci_obj));
 		$this->assertInstanceOf($class, $this->ci_obj->$obj);
 		$this->assertInstanceOf($ext, $this->ci_obj->$obj);
 
 		// Test reloading
 		unset($this->ci_obj->$name);
 		$this->assertInstanceOf('CI_Loader', $this->load->library($lib));
-		$this->assertObjectHasAttribute($name, $this->ci_obj);
+		call_user_func_array(array($this, $this->realAssertObjectHasProperty), array($name, $this->ci_obj));
 
 		// Create baseless library
 		$name = 'ext_baseless_lib';
@@ -140,7 +148,7 @@ class Loader_test extends CI_TestCase {
 		$obj = 'testy';
 		$this->assertInstanceOf('CI_Loader', $this->load->library($lib, NULL, $obj));
 		$this->assertTrue(class_exists($class), $class.' does not exist');
-		$this->assertObjectHasAttribute($obj, $this->ci_obj);
+		call_user_func_array(array($this, $this->realAssertObjectHasProperty), array($obj, $this->ci_obj));
 		$this->assertInstanceOf($class, $this->ci_obj->$obj);
 		$this->assertEquals($cfg, $this->ci_obj->$obj->config);
 
@@ -172,7 +180,7 @@ class Loader_test extends CI_TestCase {
 
 		// Was the model class instantiated.
 		$this->assertTrue(class_exists($class), $class.' does not exist');
-		$this->assertObjectHasAttribute($lib, $this->ci_obj);
+		call_user_func_array(array($this, $this->realAssertObjectHasProperty), array($lib, $this->ci_obj));
 		$this->assertInstanceOf($class, $this->ci_obj->$lib);
 	}
 
@@ -193,13 +201,13 @@ class Loader_test extends CI_TestCase {
 		// Test loading as an array.
 		$this->assertInstanceOf('CI_Loader', $this->load->driver(array($driver)));
 		$this->assertTrue(class_exists($class), $class.' does not exist');
-		$this->assertObjectHasAttribute($driver, $this->ci_obj);
+		call_user_func_array(array($this, $this->realAssertObjectHasProperty), array($driver, $this->ci_obj));
 		$this->assertInstanceOf($class, $this->ci_obj->$driver);
 
 		// Test loading as a library with a name
 		$obj = 'testdrive';
 		$this->assertInstanceOf('CI_Loader', $this->load->library($driver, NULL, $obj));
-		$this->assertObjectHasAttribute($obj, $this->ci_obj);
+		call_user_func_array(array($this, $this->realAssertObjectHasProperty), array($obj, $this->ci_obj));
 		$this->assertInstanceOf($class, $this->ci_obj->$obj);
 
 		// Test a string given to params
@@ -222,7 +230,7 @@ class Loader_test extends CI_TestCase {
 
 		// Was the model class instantiated.
 		$this->assertTrue(class_exists($model));
-		$this->assertObjectHasAttribute($model, $this->ci_obj);
+		call_user_func_array(array($this, $this->realAssertObjectHasProperty), array($model, $this->ci_obj));
 
 		// Test no model given
 		$this->assertInstanceOf('CI_Loader', $this->load->model(''));
@@ -248,8 +256,8 @@ class Loader_test extends CI_TestCase {
 
 		// Was the model class instantiated?
 		$this->assertTrue(class_exists($model));
-		$this->assertObjectHasAttribute($name, $this->ci_obj);
-		$this->assertObjectHasAttribute($name, $this->ci_obj);
+		call_user_func_array(array($this, $this->realAssertObjectHasProperty), array($name, $this->ci_obj));
+		call_user_func_array(array($this, $this->realAssertObjectHasProperty), array($name, $this->ci_obj));
 		$this->assertInstanceOf($base, $this->ci_obj->$name);
 		$this->assertInstanceOf($model, $this->ci_obj->$name);
 
@@ -607,17 +615,17 @@ class Loader_test extends CI_TestCase {
 
 		// Verify library
 		$this->assertTrue(class_exists($lib_class), $lib_class.' does not exist');
-		$this->assertObjectHasAttribute($lib, $this->ci_obj);
+		call_user_func_array(array($this, $this->realAssertObjectHasProperty), array($lib, $this->ci_obj));
 		$this->assertInstanceOf($lib_class, $this->ci_obj->$lib);
 
 		// Verify driver
 		$this->assertTrue(class_exists($drv_class), $drv_class.' does not exist');
-		$this->assertObjectHasAttribute($drv, $this->ci_obj);
+		call_user_func_array(array($this, $this->realAssertObjectHasProperty), array($drv, $this->ci_obj));
 		$this->assertInstanceOf($drv_class, $this->ci_obj->$drv);
 
 		// Verify model
 		$this->assertTrue(class_exists($model), $model.' does not exist');
-		$this->assertObjectHasAttribute($model, $this->ci_obj);
+		call_user_func_array(array($this, $this->realAssertObjectHasProperty), array($model, $this->ci_obj));
 		$this->assertInstanceOf($model, $this->ci_obj->$model);
 
 		// Verify config calls

--- a/tests/codeigniter/helpers/language_helper_test.php
+++ b/tests/codeigniter/helpers/language_helper_test.php
@@ -5,7 +5,7 @@ class Language_helper_test extends CI_TestCase {
 	public function test_lang()
 	{
 		$this->helper('language');
-		$lang = $this->getMockBuilder('CI_Lang')->setMethods(array('line'))->getMock();
+		$lang = $this->getMockBuilder('CI_Lang')->onlyMethods(array('line'))->getMock();
 		$lang->expects($this->any())->method('line')->will($this->returnValue(FALSE));
 		$this->ci_instance_var('lang', $lang);
 

--- a/tests/codeigniter/helpers/number_helper_test.php
+++ b/tests/codeigniter/helpers/number_helper_test.php
@@ -11,7 +11,7 @@ class Number_helper_test extends CI_TestCase {
 
 		// Mock away load, too much going on in there,
 		// we'll just check for the expected parameter
-		$lang = $this->getMockBuilder('CI_Lang')->setMethods(array('load'))->getMock();
+		$lang = $this->getMockBuilder('CI_Lang')->onlyMethods(array('load'))->getMock();
 		$lang->expects($this->once())
 			 ->method('load')
 			 ->with($this->equalTo('number'));

--- a/tests/codeigniter/helpers/security_helper_test.php
+++ b/tests/codeigniter/helpers/security_helper_test.php
@@ -1,8 +1,8 @@
 <?php
 
-class Security_helper_tests extends CI_TestCase {
+class Security_helper_test extends CI_TestCase {
 
-	function setUp()
+	function set_up()
 	{
 		$this->helper('security');
 		$obj = new stdClass;

--- a/tests/codeigniter/libraries/Calendar_test.php
+++ b/tests/codeigniter/libraries/Calendar_test.php
@@ -5,9 +5,9 @@ class Calendar_test extends CI_TestCase {
 	public function set_up()
 	{
 		// Required for get_total_days()
-		$this->ci_instance_var('load', $this->getMockBuilder('CI_Loader')->setMethods(array('helper'))->getMock());
+		$this->ci_instance_var('load', $this->getMockBuilder('CI_Loader')->onlyMethods(array('helper'))->getMock());
 
-		$lang = $this->getMockBuilder('CI_Lang')->setMethods(array('load', 'line'))->getMock();
+		$lang = $this->getMockBuilder('CI_Lang')->onlyMethods(array('load', 'line'))->getMock();
 		$lang->expects($this->any())->method('line')->will($this->returnValue(FALSE));
 		$this->ci_instance_var('lang', $lang);
 

--- a/tests/codeigniter/libraries/Driver_test.php
+++ b/tests/codeigniter/libraries/Driver_test.php
@@ -51,12 +51,12 @@ class Driver_test extends CI_TestCase {
 		$this->assertEquals($this->name, $this->lib->get_name());
 
 		// Was driver loaded?
-		$this->assertObjectHasAttribute($driver, $this->lib);
+		$this->assertObjectHasProperty($driver, $this->lib);
 		$this->assertInstanceOf($class, $this->lib->$driver);
 		$this->assertInstanceOf('CI_Driver', $this->lib->$driver);
 
 		// Was decorate called?
-		$this->assertObjectHasAttribute($prop, $this->lib->$driver);
+		$this->assertObjectHasProperty($prop, $this->lib->$driver);
 		$this->assertTrue($this->lib->$driver->$prop);
 
 		// Do we get an error for an invalid driver?
@@ -86,7 +86,7 @@ class Driver_test extends CI_TestCase {
 		$this->assertNotNull($this->lib->load_driver($driver));
 
 		// Was driver loaded?
-		$this->assertObjectHasAttribute($driver, $this->lib);
+		$this->assertObjectHasProperty($driver, $this->lib);
 		$this->assertInstanceOf($class, $this->lib->$driver);
 		$this->assertInstanceOf('CI_Driver', $this->lib->$driver);
 
@@ -120,7 +120,7 @@ class Driver_test extends CI_TestCase {
 		$this->assertNotNull($this->lib->load_driver($driver));
 
 		// Was driver loaded?
-		$this->assertObjectHasAttribute($driver, $this->lib);
+		$this->assertObjectHasProperty($driver, $this->lib);
 		$this->assertInstanceOf($class, $this->lib->$driver);
 		$this->assertInstanceOf($baseclass, $this->lib->$driver);
 		$this->assertInstanceOf('CI_Driver', $this->lib->$driver);

--- a/tests/codeigniter/libraries/Driver_test.php
+++ b/tests/codeigniter/libraries/Driver_test.php
@@ -51,12 +51,12 @@ class Driver_test extends CI_TestCase {
 		$this->assertEquals($this->name, $this->lib->get_name());
 
 		// Was driver loaded?
-		$this->assertObjectHasProperty($driver, $this->lib);
+		$this->assertObjectHasAttribute($driver, $this->lib);
 		$this->assertInstanceOf($class, $this->lib->$driver);
 		$this->assertInstanceOf('CI_Driver', $this->lib->$driver);
 
 		// Was decorate called?
-		$this->assertObjectHasProperty($prop, $this->lib->$driver);
+		$this->assertObjectHasAttribute($prop, $this->lib->$driver);
 		$this->assertTrue($this->lib->$driver->$prop);
 
 		// Do we get an error for an invalid driver?
@@ -86,7 +86,7 @@ class Driver_test extends CI_TestCase {
 		$this->assertNotNull($this->lib->load_driver($driver));
 
 		// Was driver loaded?
-		$this->assertObjectHasProperty($driver, $this->lib);
+		$this->assertObjectHasAttribute($driver, $this->lib);
 		$this->assertInstanceOf($class, $this->lib->$driver);
 		$this->assertInstanceOf('CI_Driver', $this->lib->$driver);
 
@@ -120,7 +120,7 @@ class Driver_test extends CI_TestCase {
 		$this->assertNotNull($this->lib->load_driver($driver));
 
 		// Was driver loaded?
-		$this->assertObjectHasProperty($driver, $this->lib);
+		$this->assertObjectHasAttribute($driver, $this->lib);
 		$this->assertInstanceOf($class, $this->lib->$driver);
 		$this->assertInstanceOf($baseclass, $this->lib->$driver);
 		$this->assertInstanceOf('CI_Driver', $this->lib->$driver);

--- a/tests/codeigniter/libraries/Driver_test.php
+++ b/tests/codeigniter/libraries/Driver_test.php
@@ -18,7 +18,7 @@ class Driver_test extends CI_TestCase {
 
 		// Mock Loader->get_package_paths
 		$paths = 'get_package_paths';
-		$ldr = $this->getMockBuilder('CI_Loader')->setMethods(array($paths))->getMock();
+		$ldr = $this->getMockBuilder('CI_Loader')->onlyMethods(array($paths))->getMock();
 		$ldr->expects($this->any())->method($paths)->will($this->returnValue(array(APPPATH, BASEPATH)));
 		$this->ci_instance_var('load', $ldr);
 

--- a/tests/codeigniter/libraries/Driver_test.php
+++ b/tests/codeigniter/libraries/Driver_test.php
@@ -7,6 +7,8 @@ class Driver_test extends CI_TestCase {
 
 	private $name;
 
+	private $realAssertObjectHasProperty;
+
 	/**
 	 * Set up test framework
 	 */
@@ -25,6 +27,12 @@ class Driver_test extends CI_TestCase {
 		// Create mock driver library
 		$this->name = 'Driver';
 		$this->lib = new Mock_Libraries_Driver();
+
+		// assertObjectHasAttribute() is deprecated and will be removed in PHPUnit 10.
+		// It was replaced by assertObjectHasProperty() in phpunit 10.1.0+
+		$this->realAssertObjectHasProperty = method_exists($this, 'assertObjectHasProperty')
+			? 'assertObjectHasProperty'
+			: 'assertObjectHasAttribute';
 	}
 
 	/**
@@ -51,12 +59,12 @@ class Driver_test extends CI_TestCase {
 		$this->assertEquals($this->name, $this->lib->get_name());
 
 		// Was driver loaded?
-		$this->assertObjectHasAttribute($driver, $this->lib);
+		call_user_func_array(array($this, $this->realAssertObjectHasProperty), array($driver, $this->lib));
 		$this->assertInstanceOf($class, $this->lib->$driver);
 		$this->assertInstanceOf('CI_Driver', $this->lib->$driver);
 
 		// Was decorate called?
-		$this->assertObjectHasAttribute($prop, $this->lib->$driver);
+		call_user_func_array(array($this, $this->realAssertObjectHasProperty), array($prop, $this->lib->$driver));
 		$this->assertTrue($this->lib->$driver->$prop);
 
 		// Do we get an error for an invalid driver?
@@ -86,7 +94,8 @@ class Driver_test extends CI_TestCase {
 		$this->assertNotNull($this->lib->load_driver($driver));
 
 		// Was driver loaded?
-		$this->assertObjectHasAttribute($driver, $this->lib);
+		call_user_func_array(array($this, $this->realAssertObjectHasProperty), array($driver, $this->lib));
+
 		$this->assertInstanceOf($class, $this->lib->$driver);
 		$this->assertInstanceOf('CI_Driver', $this->lib->$driver);
 
@@ -120,7 +129,7 @@ class Driver_test extends CI_TestCase {
 		$this->assertNotNull($this->lib->load_driver($driver));
 
 		// Was driver loaded?
-		$this->assertObjectHasAttribute($driver, $this->lib);
+		call_user_func_array(array($this, $this->realAssertObjectHasProperty), array($driver, $this->lib));
 		$this->assertInstanceOf($class, $this->lib->$driver);
 		$this->assertInstanceOf($baseclass, $this->lib->$driver);
 		$this->assertInstanceOf('CI_Driver', $this->lib->$driver);

--- a/tests/codeigniter/libraries/Form_validation_test.php
+++ b/tests/codeigniter/libraries/Form_validation_test.php
@@ -8,10 +8,10 @@ class Form_validation_test extends CI_TestCase {
 
 		// Create a mock loader since load->helper() looks in the wrong directories for unit tests,
 		// We'll use CI_TestCase->helper() instead
-		$loader = $this->getMockBuilder('CI_Loader')->setMethods(array('helper'))->getMock();
+		$loader = $this->getMockBuilder('CI_Loader')->onlyMethods(array('helper'))->getMock();
 
 		// Same applies for lang
-		$lang = $this->getMockBuilder('CI_Lang')->setMethods(array('load'))->getMock();
+		$lang = $this->getMockBuilder('CI_Lang')->onlyMethods(array('load'))->getMock();
 
 		$security = new Mock_Core_Security('UTF-8');
 		$input = new CI_Input($security);

--- a/tests/codeigniter/libraries/Upload_test.php
+++ b/tests/codeigniter/libraries/Upload_test.php
@@ -7,7 +7,7 @@ class Upload_test extends CI_TestCase {
 		$ci = $this->ci_instance();
 		$ci->upload = new CI_Upload();
 		$ci->security = new Mock_Core_Security('UTF-8');
-		$ci->lang = $this->getMockBuilder('CI_Lang')->setMethods(array('load', 'line'))->getMock();
+		$ci->lang = $this->getMockBuilder('CI_Lang')->onlyMethods(array('load', 'line'))->getMock();
 		$ci->lang->expects($this->any())->method('line')->will($this->returnValue(FALSE));
 		$this->upload = $ci->upload;
 	}

--- a/tests/mocks/ci_testcase.php
+++ b/tests/mocks/ci_testcase.php
@@ -35,6 +35,7 @@ class CI_TestCase extends \PHPUnit\Framework\TestCase {
 
 	public function setUp()
 	{
+		self::$ci_test_instance = $this;
 		// Setup VFS with base directories
 		$this->ci_vfs_root = vfsStream::setup('');
 		$this->ci_app_root = vfsStream::newDirectory('application')->at($this->ci_vfs_root);
@@ -347,11 +348,11 @@ class CI_TestCase extends \PHPUnit\Framework\TestCase {
 	 * happen in setUp, but someone is bound to forget to
 	 * call the parent method and debugging this is no fun.
 	 */
-	public function runBare()
+	/*public function runBare()
 	{
 		self::$ci_test_instance = $this;
 		parent::runBare();
-	}
+	}*/
 
 	// --------------------------------------------------------------------
 

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./Bootstrap.php" colors="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" stopOnError="false" stopOnFailure="false" stopOnIncomplete="false" stopOnSkipped="false" beStrictAboutTestsThatDoNotTestAnything="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage>
-    <include>
-      <directory suffix=".php">../system/</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./Bootstrap.php" colors="true" stopOnError="false" stopOnFailure="false" stopOnIncomplete="false" stopOnSkipped="false" beStrictAboutTestsThatDoNotTestAnything="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd" cacheDirectory=".phpunit.cache">
+  <coverage/>
   <testsuites>
     <testsuite name="CodeIgniter Core Test Suite">
       <directory suffix="test.php">./codeigniter/core</directory>
@@ -12,4 +8,9 @@
       <directory suffix="test.php">./codeigniter/libraries</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">../system/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,25 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit
-	bootstrap="./Bootstrap.php"
-	colors="true"
-	convertNoticesToExceptions="true"
-	convertWarningsToExceptions="true"
-	stopOnError="false"
-	stopOnFailure="false"
-	stopOnIncomplete="false"
-	stopOnSkipped="false"
-	beStrictAboutTestsThatDoNotTestAnything="false">
-	<testsuites>
-		<testsuite name="CodeIgniter Core Test Suite">
-			<directory suffix="test.php">./codeigniter/core</directory>
-			<directory suffix="test.php">./codeigniter/helpers</directory>
-			<directory suffix="test.php">./codeigniter/libraries</directory>
-		</testsuite>
-	</testsuites>
-	<filter>
-		<whitelist>
-			<directory suffix=".php">../system/</directory>
-		</whitelist>
-	</filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./Bootstrap.php" colors="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" stopOnError="false" stopOnFailure="false" stopOnIncomplete="false" stopOnSkipped="false" beStrictAboutTestsThatDoNotTestAnything="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">../system/</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="CodeIgniter Core Test Suite">
+      <directory suffix="test.php">./codeigniter/core</directory>
+      <directory suffix="test.php">./codeigniter/helpers</directory>
+      <directory suffix="test.php">./codeigniter/libraries</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>


### PR DESCRIPTION
This will fix the errors, warning & deprecations when testing with phpunit10
Pick whatever you may find relevant and a correct fix.

It is assumed this is run with phpunit 10.2 & php 8.2 (and that the php8.2 fixes of #6173  are already applied.

Might close #6219 