### PR TITLE
Fixes GitHub actions not starting anymore

### DIFF
--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     env:
       PHP_INI_VALUES: assert.exception=1, zend.assertions=1

--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     env:
       PHP_INI_VALUES: assert.exception=1, zend.assertions=1

--- a/tests/codeigniter/libraries/Encryption_test.php
+++ b/tests/codeigniter/libraries/Encryption_test.php
@@ -208,7 +208,7 @@ class Encryption_test extends CI_TestCase {
 		$this->assertEquals($message, $this->encryption->decrypt($this->encryption->encrypt($message)));
 
 		// Try DES in ECB mode, just for the sake of changing stuff
-		$this->encryption->initialize(array('cipher' => 'des', 'mode' => 'ecb', 'key' => substr($key, 0, 8)));
+		$this->encryption->initialize(array('cipher' => 'tripledes', 'mode' => 'ofb', 'key' => substr($key, 0, 8)));
 		$this->assertEquals($message, $this->encryption->decrypt($this->encryption->encrypt($message)));
 	}
 

--- a/tests/codeigniter/libraries/Encryption_test.php
+++ b/tests/codeigniter/libraries/Encryption_test.php
@@ -212,7 +212,7 @@ class Encryption_test extends CI_TestCase {
 
 		$this->assertEquals($message, $this->encryption->decrypt($this->encryption->encrypt($message)));
 
-		// Try DES in ECB mode, just for the sake of changing stuff
+		// Try DES3 in OFB mode, just for the sake of changing stuff
 		$this->encryption->initialize(array('cipher' => 'tripledes', 'mode' => 'ofb', 'key' => substr($key, 0, 8)));
 		$this->assertEquals($message, $this->encryption->decrypt($this->encryption->encrypt($message)));
 	}

--- a/tests/codeigniter/libraries/Encryption_test.php
+++ b/tests/codeigniter/libraries/Encryption_test.php
@@ -5,6 +5,11 @@ class Encryption_test extends CI_TestCase {
 	public function set_up()
 	{
 		$this->encryption = new Mock_Libraries_Encryption();
+
+		if (version_compare(PHP_VERSION, '7.1', '<'))
+		{
+			$this->markTestSkipped('Ubuntu-latest OpenSSL is not working correct in some older PHP versions.');
+		}
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
This switches to `ubuntu-22.04` (instead of `ubuntu-18.04`) as base OS ver.

Some tests from Encrypt_test have unexpected behavior on older PHP versions, combined with using the latest Ubuntu version. Marking the test as skipped on PHP < 7.1.