### PR TITLE
docs: explicitly state that this is for CI3

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -10,6 +10,17 @@ interface and logical structure to access these libraries. CodeIgniter lets
 you creatively focus on your project by minimizing the amount of code needed
 for a given task.
 
+*************
+CodeIgniter 3
+*************
+
+This repository is for the legacy version, CodeIgniter 3.
+`CodeIgniter 4 <https://github.com/codeigniter4/CodeIgniter4>`_ is the latest
+version of the framework.
+
+CodeIgniter 3 is the legacy version of the framework, intended for use with PHP
+5.6+. This version is in maintenance, receiving mostly just security updates.
+
 *******************
 Release Information
 *******************

--- a/user_guide_src/source/index.rst
+++ b/user_guide_src/source/index.rst
@@ -1,6 +1,6 @@
-######################
-CodeIgniter User Guide
-######################
+########################
+CodeIgniter 3 User Guide
+########################
 
 - :doc:`License Agreement <license>`
 - :doc:`Change Log <changelog>`
@@ -8,6 +8,16 @@ CodeIgniter User Guide
 .. contents::
    :local:
    :depth: 2
+
+*************
+CodeIgniter 3
+*************
+
+CodeIgniter 3 is the legacy version of the framework, intended for use with PHP
+5.6+. This version is in maintenance, receiving mostly just security updates.
+
+`CodeIgniter 4 <https://codeigniter.com/user_guide/>`_ is the latest version of
+the framework.
 
 *******
 Welcome


### PR DESCRIPTION
It is not noted here that this repository is version 3 and that the latest version is 4.
The latest version is not known to those who come to this repository by search. See https://github.com/bcit-ci/CodeIgniter/issues/6241#issuecomment-1937548732

This PR makes it clear.
