### PR TITLE
fix: cgi-fcgi status code

### DIFF
--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -564,7 +564,7 @@ if ( ! function_exists('set_status_header'))
 			}
 		}
 
-		if (strpos(PHP_SAPI, 'cgi') === 0)
+		if (PHP_SAPI === "cgi")
 		{
 			header('Status: '.$code.' '.$text, TRUE);
 			return;


### PR DESCRIPTION
Hi :wave:

I work at Datadog, and while doing some tests with CodeIgniter 3, I stumbled upon what I found to be strange behavior when using the `cgi-fcgi` sapi. I want to understand whether this is a bug or a feature, or if there is an existing workaround. I mostly want to foster discussion and understand :)

Consider this controller:
```php
<?php

class Foo extends CI_Controller {
    function index() {
        throw new \Exception('an exception message');
    }
}
```

When accessing the `/foo` endpoint, I expect a `500` status code: This is indeed the case in the _response header_ of a curl request, for instance.

However, this is not the case after the exception handler has been called. For instance, if you add the following to `error_exception.php`, a `200` status code will be displayed:
```php
<p>Status Code: <?php echo http_response_code(); ?></p>
```

Forcing the status code during the call to `header` effectively solves this issue, if this is one.

You may ask _why do we care_? Basically, currently, it would appear that when using CGI SAPIs, requests that should be marked as 500s are marked as 200s on Datadog's UI :(

Thank you for your help! 😃 