### PR TITLE
Fix setting/destroying multiple cookies PHP < 7.3

### DIFF
--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -378,7 +378,7 @@ class CI_Input {
 			$cookie_header .= ($expire === 0 ? '' : '; Expires='.gmdate('D, d-M-Y H:i:s T', $expire)).'; Max-Age='.$maxage;
 			$cookie_header .= '; Path='.$path.($domain !== '' ? '; Domain='.$domain : '');
 			$cookie_header .= ($secure ? '; Secure' : '').($httponly ? '; HttpOnly' : '').'; SameSite='.$samesite;
-			header($cookie_header);
+			header($cookie_header, FALSE);
 			return;
 		}
 

--- a/system/core/Security.php
+++ b/system/core/Security.php
@@ -299,7 +299,8 @@ class CI_Security {
 					.($domain === '' ? '' : '; Domain='.$domain)
 					.($secure_cookie ? '; Secure' : '')
 					.(config_item('cookie_httponly') ? '; HttpOnly' : '')
-					.'; SameSite=Strict'
+					.'; SameSite=Strict',
+					FALSE
 			);
 		}
 

--- a/system/libraries/Session/Session.php
+++ b/system/libraries/Session/Session.php
@@ -177,7 +177,7 @@ class CI_Session {
 				$header .= '; Path='.$this->_config['cookie_path'];
 				$header .= ($this->_config['cookie_domain'] !== '' ? '; Domain='.$this->_config['cookie_domain'] : '');
 				$header .= ($this->_config['cookie_secure'] ? '; Secure' : '').'; HttpOnly; SameSite='.$this->_config['cookie_samesite'];
-				header($header);
+				header($header, FALSE);
 			}
 
 			if ( ! $this->_config['cookie_secure'] && $this->_config['cookie_samesite'] === 'None')

--- a/system/libraries/Session/Session_driver.php
+++ b/system/libraries/Session/Session_driver.php
@@ -147,7 +147,7 @@ abstract class CI_Session_driver {
 			$header .= '; Path='.$this->_config['cookie_path'];
 			$header .= ($this->_config['cookie_domain'] !== '' ? '; Domain='.$this->_config['cookie_domain'] : '');
 			$header .= ($this->_config['cookie_secure'] ? '; Secure' : '').'; HttpOnly; SameSite='.$this->_config['cookie_samesite'];
-			header($header);
+			header($header, FALSE);
 			return;
 		}
 


### PR DESCRIPTION
CI3 is using header instead of setcookie when PHP < 7.3. But each call to header('Set-Cookie: ...') is replacing the previews one, meaning only the last cookie setting/destroying command is sent.

Using header('Set-Cookie: ...', FALSE) to prevent replacing.