### PR TITLE
Undefined variable in cache redis

### DIFF
--- a/system/libraries/Cache/drivers/Cache_redis.php
+++ b/system/libraries/Cache/drivers/Cache_redis.php
@@ -163,7 +163,7 @@ class CI_Cache_redis extends CI_Driver
 	{
 		$data = $this->_redis->hMGet($key, array('__ci_type', '__ci_value'));
 
-		if ($value !== FALSE && $this->_redis->sIsMember('_ci_redis_serialized', $key))
+		if ($data['__ci_value'] !== FALSE && $this->_redis->sIsMember('_ci_redis_serialized', $key))
 		{
 			return FALSE;
 		}


### PR DESCRIPTION
Variable $value is undefined in cache redis.


Maybe you still need to check it like this
```
if  (! isset($data['__ci_type'], $data['__ci_value']) || ($data['__ci_value'] === FALSE && $this->_redis->sIsMember('_ci_redis_serialized', $key))  )
{
            return null;
}
````