### PR TITLE
Fix ctype_digit() Argument Type Error in Postgre Driver

### DIFF
--- a/system/database/drivers/postgre/postgre_driver.php
+++ b/system/database/drivers/postgre/postgre_driver.php
@@ -95,7 +95,7 @@ class CI_DB_postgre_driver extends CI_DB {
 
 		$this->hostname === '' OR $this->dsn = 'host='.$this->hostname.' ';
 
-		if ( ! empty($this->port) && ctype_digit($this->port))
+		if ( ! empty($this->port) && ctype_digit((string) $this->port))
 		{
 			$this->dsn .= 'port='.$this->port.' ';
 		}


### PR DESCRIPTION
### Summary

This Pull Request addresses the deprecation warning for `ctype_digit()` when the argument is of type `int`. The warning message is as follows:

```
A PHP Error was encountered
Severity: 8192

Message: ctype_digit(): Argument of type int will be interpreted as string in the future

Filename: postgre/postgre_driver.php

Line Number: 98
```


### Changes Made

- Cast the `$this->port` to a string before passing it to `ctype_digit()` in the `_build_dsn()` method of the `postgre_driver.php` file.

### Before

```php
if ( ! empty($this->port) && ctype_digit($this->port))
{
    $this->dsn .= 'port='.$this->port.' ';
}

if ( ! empty($this->port) && ctype_digit((string) $this->port))
{
    $this->dsn .= 'port='.$this->port.' ';
}
