### PR TITLE
PHP 8.3: Deprecation Warning for Dynamic Property Creation in Class

### DIFF
--- a/system/core/Controller.php
+++ b/system/core/Controller.php
@@ -67,6 +67,84 @@ class CI_Controller {
 	public $load;
 
 	/**
+	 * CI_Benchmark
+	 *
+	 * @var	CI_Benchmark
+	 */
+	public $benchmark;
+
+	/**
+	 * CI_Config
+	 *
+	 * @var	CI_Config
+	 */
+	public $config;
+
+	/**
+	 * CI_Log
+	 *
+	 * @var	CI_Log
+	 */
+	public $log;
+
+	/**
+	 * CI_Hooks
+	 *
+	 * @var	CI_Hooks
+	 */
+	public $hooks;
+
+	/**
+	 * CI_Lang
+	 *
+	 * @var	CI_Lang
+	 */
+	public $lang;
+
+	/**
+	 * CI_Utf8
+	 *
+	 * @var	CI_Utf8
+	 */
+	public $utf8;
+
+	/**
+	 * CI_Uri
+	 *
+	 * @var	CI_Uri
+	 */
+	public $uri;
+
+	/**
+	 * CI_Router
+	 *
+	 * @var	CI_Router
+	 */
+
+	public $router;
+
+	/**
+	 * CI_Output
+	 *
+	 * @var	CI_Output
+	 */
+	public $output;
+
+	/**
+	 * CI_Security
+	 *
+	 * @var	CI_Security
+	 */
+	public $security;
+
+	/**
+	 * CI_Input 
+	 *
+	 * @var	CI_Input
+	 */
+	public $input;
+
+	/**
 	 * Class constructor
 	 *
 	 * @return	void

--- a/system/core/Loader.php
+++ b/system/core/Loader.php
@@ -123,6 +123,80 @@ class CI_Loader {
 	protected $_ci_helpers =	array();
 
 	/**
+	 * List of loaded libraries
+	 *
+	 * @var	array
+	 */
+	protected $load;
+
+	/**
+	 *
+	 * @var CI_Benchmark
+	 */
+	protected $benchmark;
+
+	/**
+	 *
+	 * @var CI_Config
+	 */
+	protected $config;
+
+	/**
+	 *
+	 * @var CI_Log
+	 */
+	protected $log;
+
+	/**
+	 *
+	 * @var CI_Hooks
+	 */
+	protected $hooks;
+
+	/**
+	 *
+	 * @var CI_Lang
+	 */
+	protected $lang;
+
+	/**
+	 *
+	 * @var CI_Utf8
+	 */
+	protected $utf8;
+
+	/**
+	 *
+	 * @var CI_Uri
+	 */
+	protected $uri;
+
+	/**
+	 *
+	 * @var CI_Router
+	 */
+	protected $router;
+
+	/**
+	 *
+	 * @var CI_output
+	 */
+	protected $output;
+
+	/**
+	 *
+	 * @var CI_security
+	 */
+	protected $security;
+
+	/**
+	 *
+	 * @var CI_Input
+	 */
+	protected $input;
+
+
+	/**
 	 * List of class name mappings
 	 *
 	 * @var	array

--- a/system/core/Router.php
+++ b/system/core/Router.php
@@ -112,6 +112,14 @@ class CI_Router {
 	 */
 	public $enable_query_strings = FALSE;
 
+	/**
+	 * CI_URI class object
+	 *
+	 * @var	object
+	 */
+	public $uri;
+
+
 	// --------------------------------------------------------------------
 
 	/**

--- a/system/core/URI.php
+++ b/system/core/URI.php
@@ -84,7 +84,7 @@ class CI_URI {
 	public $rsegments = array();
 
 	/**
-	 * Associative array of URI data
+	 * Associative array of URI config
 	 *
 	 * @var	array
 	 */

--- a/system/core/URI.php
+++ b/system/core/URI.php
@@ -84,6 +84,13 @@ class CI_URI {
 	public $rsegments = array();
 
 	/**
+	 * Associative array of URI data
+	 *
+	 * @var	array
+	 */
+	public $config;
+
+	/**
 	 * Permitted URI chars
 	 *
 	 * PCRE character group allowed in URI segments


### PR DESCRIPTION
This pull request addresses the deprecation warning introduced in PHP 8.3 regarding dynamic property creation in core classes.